### PR TITLE
ExpandoObjectConverter supports emitting an Array type

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/ExpandoObjectConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/ExpandoObjectConverterTests.cs
@@ -171,6 +171,62 @@ namespace Newtonsoft.Json.Tests.Converters
     }
 
     [Test]
+    public void DeserializeExpandoObjectUsingArrays()
+    {
+        string json = @"{
+  ""Before"": ""Before!"",
+  ""Expando"": {
+    ""String"": ""String!"",
+    ""Integer"": 234,
+    ""Float"": 1.23,
+    ""List"": [
+      ""First"",
+      ""Second"",
+      ""Third""
+    ],
+    ""Object"": {
+      ""First"": 1
+    }
+  },
+  ""After"": ""After!""
+}";
+
+        ExpandoContainer o = JsonConvert.DeserializeObject<ExpandoContainer>(json, new ExpandoObjectConverter { UseArrayTypeForCollections = true });
+
+      Assert.AreEqual(o.Before, "Before!");
+      Assert.AreEqual(o.After, "After!");
+      Assert.IsNotNull(o.Expando);
+
+      dynamic d = o.Expando;
+      CustomAssert.IsInstanceOfType(typeof(ExpandoObject), d);
+
+      Assert.AreEqual("String!", d.String);
+      CustomAssert.IsInstanceOfType(typeof(string), d.String);
+
+      Assert.AreEqual(234, d.Integer);
+      CustomAssert.IsInstanceOfType(typeof(long), d.Integer);
+
+      Assert.AreEqual(1.23, d.Float);
+      CustomAssert.IsInstanceOfType(typeof(double), d.Float);
+
+      Assert.IsNotNull(d.List);
+      Assert.AreEqual(3, d.List.Length);
+      CustomAssert.IsInstanceOfType(typeof(Array), d.List);
+
+      Assert.AreEqual("First", d.List[0]);
+      CustomAssert.IsInstanceOfType(typeof(string), d.List[0]);
+
+      Assert.AreEqual("Second", d.List[1]);
+      Assert.AreEqual("Third", d.List[2]);
+
+      Assert.IsNotNull(d.Object);
+      CustomAssert.IsInstanceOfType(typeof(ExpandoObject), d.Object);
+
+      Assert.AreEqual(1, d.Object.First);
+      CustomAssert.IsInstanceOfType(typeof(long), d.Object.First);
+    }
+
+    [Test]
     public void DeserializeNullExpandoObject()
     {
       string json = @"{

--- a/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
@@ -41,6 +41,12 @@ namespace Newtonsoft.Json.Converters
   public class ExpandoObjectConverter : JsonConverter
   {
     /// <summary>
+    /// Gets or sets a value indicating whether to emit Arrays instead of IList&lt;object&gt; types
+    /// when a JSON array is encountered during parsing.
+    /// </summary>
+    public bool UseArrayTypeForCollections { get; set; }
+
+    /// <summary>
     /// Writes the JSON representation of the object.
     /// </summary>
     /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
@@ -102,7 +108,7 @@ namespace Newtonsoft.Json.Converters
             list.Add(v);
             break;
           case JsonToken.EndArray:
-            return list;
+            return UseArrayTypeForCollections ? list.ToArray() : list;
         }
       }
 


### PR DESCRIPTION
Modify ExpandoObjectConverter.cs to support emitting an Array type instead of an IList<object> type when processing a JSON array and the UseArrayTypeForCollections property is true.

Added test to validate that the ExpandoObjectConverter is generating an Array instead of an IList<object> when the UseArrayTypeForCollections property is true.

Refers to this issue on json.CodePlex.com: http://json.codeplex.com/workitem/22878
