### PR TITLE
Allow comments before StartObject

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -292,6 +292,10 @@ namespace Newtonsoft.Json.Linq
           throw JsonReaderException.Create(reader, "Error reading JObject from JsonReader.");
       }
 
+      while (reader.TokenType == JsonToken.Comment)
+        reader.Read();
+      
+
       if (reader.TokenType != JsonToken.StartObject)
       {
         throw JsonReaderException.Create(reader, "Error reading JObject from JsonReader. Current JsonReader item is not an object: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));


### PR DESCRIPTION
I found out, when you have a file with a "header comment" like this

[START]
/*This is a comment, what this file is about */
{
valid JSON
}
[END]
it won't work, because he searches for a start token.
Now he reads as long as he found a commentObject before searching for a StartObject.
