### PR TITLE
Add support for custom dynamic object types

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -66,6 +67,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="nunit.framework, Version=2.4.3.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NUnit\DotNet\nunit.framework.dll</HintPath>
@@ -155,6 +157,7 @@
     <Compile Include="TestObjects\Container.cs" />
     <Compile Include="TestObjects\ContentBaseClass.cs" />
     <Compile Include="TestObjects\ContentSubClass.cs" />
+    <Compile Include="TestObjects\CustomDynamicObject.cs" />
     <Compile Include="TestObjects\Foo.cs" />
     <Compile Include="TestObjects\HolderClass.cs" />
     <Compile Include="TestObjects\IPrivateImplementationA.cs" />

--- a/Src/Newtonsoft.Json.Tests/TestObjects/CustomDynamicObject.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/CustomDynamicObject.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Dynamic;
+
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    /// <summary>
+    /// A singleton to represent an undefined value from a JSON object.
+    /// </summary>
+
+    public class Undefined
+    {
+        static Undefined()
+        {
+            Value = new Undefined();
+        }
+        public static readonly Undefined Value;
+    };
+
+    /// <summary>
+    /// A custom dynamic object implementation that returns a special value for undefined properties
+    /// instead of throwing an exception.
+    /// </summary>
+
+    public class CustomDynamicObject: DynamicObject, IDictionary<string,object>
+    {
+
+
+        public CustomDynamicObject()
+        {
+            AllowReadingUndefinedMembers = true;
+        }
+
+        static CustomDynamicObject() {
+           
+        }
+        public  static Undefined Undefined 
+        {
+            get {
+                return Undefined.Value;
+                }
+        }
+
+       
+
+        private IDictionary<string, object> InnerDictionary = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether we allow reading of undefined members.
+        /// </summary>
+
+        public bool AllowReadingUndefinedMembers
+        {
+            get;
+            set;
+        }
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return TryGetMember(binder.Name, out result);
+        }
+        private bool TryGetMember(string name, out object result)
+        {
+            if (InnerDictionary.TryGetValue(name, out result))
+            {
+                return true;
+            }
+            else
+            {
+                result = Undefined;
+                return AllowReadingUndefinedMembers;
+            }
+        }
+        public override bool TrySetMember(SetMemberBinder binder, object value)
+        {
+            return TrySetMember(binder.Name, value);
+        }
+        protected bool TrySetMember(string name, object value)
+        {
+            try
+            {
+                if (String.IsNullOrEmpty(name))
+                {
+                    return false;
+                }
+
+                if (value is IDictionary<string, object> && !(value is CustomDynamicObject))
+                {
+                    InnerDictionary[name] = Wrap((IDictionary<string, object>)value);
+                }
+                else
+                {
+                    InnerDictionary[name] = value;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+            return true;
+        }
+
+        protected CustomDynamicObject Wrap(IDictionary<string, object> value)
+        {
+            var obj = new CustomDynamicObject();
+            IDictionary<string, object> dict = obj;
+            foreach (KeyValuePair<string, object> kvp in value)
+            {
+                dict[kvp.Key] = kvp.Value;
+            }
+            return obj;
+        }
+
+        #region interface members
+
+        public object this[string name]
+        {
+            get
+            {
+                object result;
+                TryGetMember(name,out result);
+                return result;
+            }
+            set
+            {
+                TrySetMember(name, value);
+            }
+        }
+
+        void IDictionary<string, object>.Add(string key, object value)
+        {
+            TrySetMember(key, value);
+        }
+
+        bool IDictionary<string, object>.ContainsKey(string key)
+        {
+            return InnerDictionary.ContainsKey(key);
+        }
+
+        ICollection<string> IDictionary<string, object>.Keys
+        {
+            get { return InnerDictionary.Keys; }
+        }
+
+        bool IDictionary<string, object>.Remove(string key)
+        {
+            return InnerDictionary.Remove(key);
+        }
+
+        bool IDictionary<string, object>.TryGetValue(string key, out object value)
+        {
+            if (InnerDictionary.ContainsKey(key))
+            {
+                return TryGetMember(key, out value);
+            }
+            else
+            {
+                value = null;
+                return false;
+            }
+        }
+
+        ICollection<object> IDictionary<string, object>.Values
+        {
+            get { return InnerDictionary.Values; }
+        }
+
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+        {
+            TrySetMember(item.Key, item.Value);
+        }
+
+        void ICollection<KeyValuePair<string, object>>.Clear()
+        {
+            InnerDictionary.Clear();
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+        {
+            return InnerDictionary.Contains(item);
+        }
+
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            InnerDictionary.CopyTo(array, arrayIndex);
+        }
+
+        int ICollection<KeyValuePair<string, object>>.Count
+        {
+            get { return InnerDictionary.Count; }
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+        {
+            return InnerDictionary.Remove(item);
+        }
+
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return InnerDictionary.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
+
+
+       
+    }
+}

--- a/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
@@ -35,131 +35,141 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Converters
 {
-  /// <summary>
-  /// Converts an ExpandoObject to and from JSON.
-  /// </summary>
-  public class ExpandoObjectConverter : JsonConverter
-  {
     /// <summary>
-    /// Writes the JSON representation of the object.
+    /// Converts an ExpandoObject to and from JSON.
     /// </summary>
-    /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
-    /// <param name="value">The value.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    public class ExpandoObjectConverter : JsonConverter
     {
-      // can write is set to false
-    }
-
-    /// <summary>
-    /// Reads the JSON representation of the object.
-    /// </summary>
-    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
-    /// <param name="objectType">Type of the object.</param>
-    /// <param name="existingValue">The existing value of object being read.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    /// <returns>The object value.</returns>
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-    {
-      return ReadValue(reader);
-    }
-
-    private object ReadValue(JsonReader reader)
-    {
-      while (reader.TokenType == JsonToken.Comment)
-      {
-        if (!reader.Read())
-          throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
-      }
-
-      switch (reader.TokenType)
-      {
-        case JsonToken.StartObject:
-          return ReadObject(reader);
-        case JsonToken.StartArray:
-          return ReadList(reader);
-        default:
-          if (JsonReader.IsPrimitiveToken(reader.TokenType))
-            return reader.Value;
-
-          throw JsonSerializationException.Create(reader, "Unexpected token when converting ExpandoObject: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
-      }
-    }
-
-    private object ReadList(JsonReader reader)
-    {
-      IList<object> list = new List<object>();
-
-      while (reader.Read())
-      {
-        switch (reader.TokenType)
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-          case JsonToken.Comment:
-            break;
-          default:
-            object v = ReadValue(reader);
-
-            list.Add(v);
-            break;
-          case JsonToken.EndArray:
-            return list;
+            // can write is set to false
         }
-      }
 
-      throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
-    }
-
-    private object ReadObject(JsonReader reader)
-    {
-      IDictionary<string, object> expandoObject = new ExpandoObject();
-
-      while (reader.Read())
-      {
-        switch (reader.TokenType)
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-          case JsonToken.PropertyName:
-            string propertyName = reader.Value.ToString();
-
-            if (!reader.Read())
-              throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
-
-            object v = ReadValue(reader);
-
-            expandoObject[propertyName] = v;
-            break;
-          case JsonToken.Comment:
-            break;
-          case JsonToken.EndObject:
-            return expandoObject;
+            return ReadValue(reader, objectType);
         }
-      }
 
-      throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
-    }
+        private object ReadValue(JsonReader reader, Type objectType)
+        {
+            while (reader.TokenType == JsonToken.Comment)
+            {
+                if (!reader.Read())
+                    throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+            }
 
-    /// <summary>
-    /// Determines whether this instance can convert the specified object type.
-    /// </summary>
-    /// <param name="objectType">Type of the object.</param>
-    /// <returns>
-    /// 	<c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
-    /// </returns>
-    public override bool CanConvert(Type objectType)
-    {
-      return (objectType == typeof (ExpandoObject));
-    }
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    return ReadObject(reader, objectType);
+                case JsonToken.StartArray:
+                    return ReadList(reader, objectType);
+                default:
+                    if (JsonReader.IsPrimitiveToken(reader.TokenType))
+                        return reader.Value;
 
-    /// <summary>
-    /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
-    /// </summary>
-    /// <value>
-    /// 	<c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.
-    /// </value>
-    public override bool CanWrite
-    {
-      get { return false; }
+                    throw JsonSerializationException.Create(reader, "Unexpected token when converting ExpandoObject: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+        }
+
+        private object ReadList(JsonReader reader, Type objectType)
+        {
+            IList<object> list = new List<object>();
+
+            while (reader.Read())
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.Comment:
+                        break;
+                    default:
+                        object v = ReadValue(reader, objectType);
+
+                        list.Add(v);
+                        break;
+                    case JsonToken.EndArray:
+                        return list;
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+        }
+
+        private object ReadObject(JsonReader reader, Type objectType)
+        {
+            // test for a regular expando object to avoid overhead of Activator.CreateInstance for most common usage
+
+            IDictionary<string, object> expandoObject = objectType == typeof(ExpandoObject) ?
+                new ExpandoObject() :
+                (IDictionary<string, object>)Activator.CreateInstance(objectType);
+
+            while (reader.Read())
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string propertyName = reader.Value.ToString();
+
+                        if (!reader.Read())
+                            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+
+                        object v = ReadValue(reader, objectType);
+
+                        expandoObject[propertyName] = v;
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        return expandoObject;
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// 	<c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+
+            return objectType.IsClass &&
+                objectType.GetAllInterfaces()
+                    .Where(item =>
+                        item == typeof(IDynamicMetaObjectProvider) ||
+                        item == typeof(IDictionary<string, object>))
+                    .Count() == 2;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="JsonConverter"/> can write JSON.
+        /// </summary>
+        /// <value>
+        /// 	<c>true</c> if this <see cref="JsonConverter"/> can write JSON; otherwise, <c>false</c>.
+        /// </value>
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
     }
-  }
 }
 
 #endif


### PR DESCRIPTION
I revised `ExpandoObjectConverter` to be aware of `IDynamicMetaObjectProvider` implementations other than `ExpandoObject`. The framework `ExpandoObject` is problematic because it's sealed. In my projects I frequently use a custom implementation that permits accessing missing members directly and just returns a special value or null to mimic behavior of a Javascript object. I included a basic implementation like this for the test. 

As far as I can tell there was no way to have JSON.NET deserialize anything other than the outermost level of a JSON structure into a custom dynamic type, any inner objects would become `JObject` types. These changes will test an object for inheriting `IDictionary<string,object>` and `IDynamicMetaObjectProvider` instead of just testing for being an `ExpandoObject`, and use create instances of the type provided instead.
