### PR TITLE
Support for 2 character abbreviations with CamelCasePropertyNamesContractResolver

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverTests.cs
@@ -80,6 +80,32 @@ namespace Newtonsoft.Json.Tests.Serialization
 
     }
 
+		[Test]
+		public void JsonConvertSerializerWith2CharAbbreviation ( ) 
+		{
+			var dummyObject = new {
+				ID = 1,
+				ReferenceID = 2,
+				AnotherReference_ID = 3,
+				LookOutForThatTree = "george",
+				WantItToBeOK = true,
+				HasIDInTheMiddle = true
+			};
+
+			string json = JsonConvert.SerializeObject ( dummyObject, Formatting.Indented, new JsonSerializerSettings {
+				ContractResolver = new CamelCasePropertyNamesContractResolver ( )
+			} );
+
+			Assert.AreEqual ( @"{
+  ""id"": 1,
+  ""referenceId"": 2,
+  ""anotherReference_Id"": 3,
+  ""lookOutForThatTree"": ""george"",
+  ""wantItToBeOk"": true,
+  ""hasIdInTheMiddle"": true
+}", json );
+		}
+
     [Test]
     public void JTokenWriter()
     {


### PR DESCRIPTION
Adds support for 2 character abbreviations that are all upper case. Some
frameworks do not follow the correct convention of not capitalizing the
second character, like EntityFramework. Properties like "ID" and
"PersonID" will currently resolve as "iD" and "personID". This corrects
that and they resolve to "id" and "personId" 

Relates to [this workitem](http://json.codeplex.com/workitem/23329)
