### PR TITLE
Added automatic quoting of properties with invalid characters

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -358,6 +358,48 @@ namespace Newtonsoft.Json.Tests
     }
 
     [Test]
+    public void AutoQuoteNameHandling()
+    {
+      StringBuilder sb = new StringBuilder();
+      StringWriter sw = new StringWriter(sb);
+
+      using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+      {
+        jsonWriter.Formatting = Formatting.Indented;
+        jsonWriter.QuoteNameHandling = QuoteNameHandling.Auto;
+
+        jsonWriter.WriteStartObject();
+        jsonWriter.WritePropertyName("Id");
+        jsonWriter.WriteValue("A");
+        jsonWriter.WritePropertyName("Id12_$");
+        jsonWriter.WriteValue("B");
+        jsonWriter.WritePropertyName("Id With Space");
+        jsonWriter.WriteValue("C");
+        jsonWriter.WritePropertyName("?#@!&^*");
+        jsonWriter.WriteValue("D");
+        jsonWriter.WriteEndObject();
+        Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+      }
+
+      // {
+      //   Id: "A",
+      //   Id12_$: "B",
+      //   "Id With Space": "C",
+      //   "?#@!&^*": "D"
+      // }
+
+      string expected = @"{
+  Id: ""A"",
+  Id12_$: ""B"",
+  ""Id With Space"": ""C"",
+  ""?#@!&^*"": ""D""
+}";
+      string result = sb.ToString();
+
+      Assert.AreEqual(expected, result);
+    }
+
+    [Test]
     public void State()
     {
       StringBuilder sb = new StringBuilder();
@@ -788,8 +830,8 @@ namespace Newtonsoft.Json.Tests
         Assert.AreEqual(5, jsonWriter.Indentation);
         jsonWriter.IndentChar = '_';
         Assert.AreEqual('_', jsonWriter.IndentChar);
-        jsonWriter.QuoteName = true;
-        Assert.AreEqual(true, jsonWriter.QuoteName);
+        jsonWriter.QuoteNameHandling = QuoteNameHandling.Quoted;
+        Assert.AreEqual(QuoteNameHandling.Quoted, jsonWriter.QuoteNameHandling);
         jsonWriter.QuoteChar = '\'';
         Assert.AreEqual('\'', jsonWriter.QuoteChar);
 
@@ -1138,7 +1180,7 @@ _____'propertyName': NaN
           Console.WriteLine("Position: " + (int)c);
 
         StringWriter swNew = new StringWriter();
-        JavaScriptUtils.WriteEscapedJavaScriptString(swNew, c.ToString(), '"', true, JavaScriptUtils.DoubleQuoteCharEscapeFlags, StringEscapeHandling.Default);
+        JavaScriptUtils.WriteEscapedJavaScriptString(swNew, c.ToString(), '"', QuoteNameHandling.Quoted, JavaScriptUtils.DoubleQuoteCharEscapeFlags, StringEscapeHandling.Default);
 
         StringWriter swOld = new StringWriter();
         WriteEscapedJavaScriptStringOld(swOld, c.ToString(), '"', true);

--- a/Src/Newtonsoft.Json.Tests/PerformanceTests.cs
+++ b/Src/Newtonsoft.Json.Tests/PerformanceTests.cs
@@ -324,7 +324,7 @@ If attributes are not mentioned, default values are used in each case.
         {
           using (StringWriter w = StringUtils.CreateStringWriter(StringUtils.GetLength(text) ?? 16))
           {
-            JavaScriptUtils.WriteEscapedJavaScriptString(w, text, '"', true, JavaScriptUtils.DoubleQuoteCharEscapeFlags, StringEscapeHandling.Default);
+            JavaScriptUtils.WriteEscapedJavaScriptString(w, text, '"', QuoteNameHandling.Quoted, JavaScriptUtils.DoubleQuoteCharEscapeFlags, StringEscapeHandling.Default);
           }
         }
 

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -823,7 +823,7 @@ namespace Newtonsoft.Json
         ShiftBufferIfNeeded();
         ReadStringIntoBuffer(quoteChar);
       }
-      else if (ValidIdentifierChar(firstChar))
+      else if (JavaScriptUtils.IsValidIdentifierChar(firstChar))
       {
         quoteChar = '\0';
         ShiftBufferIfNeeded();
@@ -850,11 +850,6 @@ namespace Newtonsoft.Json
       return true;
     }
 
-    private bool ValidIdentifierChar(char value)
-    {
-      return (char.IsLetterOrDigit(value) || value == '_' || value == '$');
-    }
-
     private void ParseUnquotedProperty()
     {
       int initialPosition = _charPos;
@@ -878,7 +873,7 @@ namespace Newtonsoft.Json
           default:
             char currentChar = _chars[_charPos];
 
-            if (ValidIdentifierChar(currentChar))
+            if (JavaScriptUtils.IsValidIdentifierChar(currentChar))
             {
               _charPos++;
               break;

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -46,7 +46,7 @@ namespace Newtonsoft.Json
     private char _indentChar;
     private int _indentation;
     private char _quoteChar;
-    private bool _quoteName;
+    private QuoteNameHandling _quoteNameHandling;
     private bool[] _charEscapeFlags;
 
     private Base64Encoder Base64Encoder
@@ -103,10 +103,20 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Gets or sets a value indicating whether object names will be surrounded with quotes.
     /// </summary>
+    [Obsolete("This property is obsolete and has been replaced by QuoteNameHandling property.")]
     public bool QuoteName
     {
-      get { return _quoteName; }
-      set { _quoteName = value; }
+      get { return _quoteNameHandling != QuoteNameHandling.Unquoted; }
+      set { _quoteNameHandling = value ? QuoteNameHandling.Quoted : QuoteNameHandling.Unquoted; }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether object names will be surrounded with quotes.
+    /// </summary>
+    public QuoteNameHandling QuoteNameHandling
+    {
+      get { return _quoteNameHandling; }
+      set { _quoteNameHandling = value; }
     }
 
     /// <summary>
@@ -120,7 +130,7 @@ namespace Newtonsoft.Json
 
       _writer = textWriter;
       _quoteChar = '"';
-      _quoteName = true;
+      _quoteNameHandling = QuoteNameHandling.Quoted;
       _indentChar = ' ';
       _indentation = 2;
 
@@ -213,7 +223,7 @@ namespace Newtonsoft.Json
     {
       InternalWritePropertyName(name);
 
-      JavaScriptUtils.WriteEscapedJavaScriptString(_writer, name, _quoteChar, _quoteName, _charEscapeFlags, StringEscapeHandling);
+      JavaScriptUtils.WriteEscapedJavaScriptString(_writer, name, _quoteChar, _quoteNameHandling, _charEscapeFlags, StringEscapeHandling);
 
       _writer.Write(':');
     }
@@ -229,16 +239,18 @@ namespace Newtonsoft.Json
 
       if (escape)
       {
-        JavaScriptUtils.WriteEscapedJavaScriptString(_writer, name, _quoteChar, _quoteName, _charEscapeFlags, StringEscapeHandling);
+        JavaScriptUtils.WriteEscapedJavaScriptString(_writer, name, _quoteChar, _quoteNameHandling, _charEscapeFlags, StringEscapeHandling);
       }
       else
       {
-        if (_quoteName)
+        bool quoteName = _quoteNameHandling == QuoteNameHandling.Quoted
+          || _quoteNameHandling == QuoteNameHandling.Auto && !JavaScriptUtils.IsValidIdentifier(name);
+        if (quoteName)
           _writer.Write(_quoteChar);
 
         _writer.Write(name);
 
-        if (_quoteName)
+        if (quoteName)
           _writer.Write(_quoteChar);
       }
 
@@ -343,7 +355,7 @@ namespace Newtonsoft.Json
       if (value == null)
         WriteValueInternal(JsonConvert.Null, JsonToken.Null);
       else
-        JavaScriptUtils.WriteEscapedJavaScriptString(_writer, value, _quoteChar, true, _charEscapeFlags, StringEscapeHandling);
+        JavaScriptUtils.WriteEscapedJavaScriptString(_writer, value, _quoteChar, QuoteNameHandling.Quoted, _charEscapeFlags, StringEscapeHandling);
     }
 
     /// <summary>

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net20.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net20.csproj
@@ -190,6 +190,7 @@
     <Compile Include="MissingMemberHandling.cs" />
     <Compile Include="NullValueHandling.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Schema\JsonSchema.cs" />
     <Compile Include="Schema\JsonSchemaBuilder.cs" />
     <Compile Include="Schema\JsonSchemaConstants.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net35.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net35.csproj
@@ -202,6 +202,7 @@
     <Compile Include="MissingMemberHandling.cs" />
     <Compile Include="NullValueHandling.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Schema\JsonSchema.cs" />
     <Compile Include="Schema\JsonSchemaBuilder.cs" />
     <Compile Include="Schema\JsonSchemaConstants.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net40.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net40.csproj
@@ -200,6 +200,7 @@
     <Compile Include="MissingMemberHandling.cs" />
     <Compile Include="NullValueHandling.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Schema\JsonSchema.cs" />
     <Compile Include="Schema\JsonSchemaBuilder.cs" />
     <Compile Include="Schema\JsonSchemaConstants.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Portable.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Portable.csproj
@@ -127,6 +127,7 @@
     <Compile Include="PreserveReferencesHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Required.cs" />
     <Compile Include="Schema\Extensions.cs" />
     <Compile Include="Schema\JsonSchema.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Silverlight.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Silverlight.csproj
@@ -163,6 +163,7 @@
     <Compile Include="PreserveReferencesHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Required.cs" />
     <Compile Include="SerializationBinder.cs" />
     <Compile Include="Serialization\CachedAttributeGetter.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.WinRT.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.WinRT.csproj
@@ -191,6 +191,7 @@
     <Compile Include="PreserveReferencesHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Required.cs" />
     <Compile Include="Schema\Extensions.cs" />
     <Compile Include="Schema\JsonSchema.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.WindowsPhone.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.WindowsPhone.csproj
@@ -134,6 +134,7 @@
     <Compile Include="PreserveReferencesHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Required.cs" />
     <Compile Include="SerializationBinder.cs" />
     <Compile Include="Serialization\CachedAttributeGetter.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -123,6 +123,7 @@
     <Compile Include="PreserveReferencesHandling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="QuoteNameHandling.cs" />
     <Compile Include="Required.cs" />
     <Compile Include="Schema\Extensions.cs" />
     <Compile Include="Schema\JsonSchema.cs" />

--- a/Src/Newtonsoft.Json/QuoteNameHandling.cs
+++ b/Src/Newtonsoft.Json/QuoteNameHandling.cs
@@ -1,0 +1,46 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json
+{
+  /// <summary>
+  /// Specifies how object names are surrounded with quotes when writing JSON by the <see cref="JsonTextWriter"/>.
+  /// </summary>
+  public enum QuoteNameHandling
+  {
+    /// <summary>
+    /// Surround object names with quotes.
+    /// </summary>
+    Quoted = 0,
+    /// <summary>
+    /// Do not surround object names with quotes.
+    /// </summary>
+    Unquoted = 1,
+    /// <summary>
+    /// Surround object names with quotes only if they contain invalid characters (any characters except letters, digits, _ and $).
+    /// </summary>
+    Auto = 2
+  }
+}

--- a/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
@@ -71,9 +71,11 @@ namespace Newtonsoft.Json.Utilities
 
     private const string EscapedUnicodeText = "!";
 
-    public static void WriteEscapedJavaScriptString(TextWriter writer, string s, char delimiter, bool appendDelimiters, bool[] charEscapeFlags, StringEscapeHandling stringEscapeHandling)
+    public static void WriteEscapedJavaScriptString(TextWriter writer, string s, char delimiter, QuoteNameHandling appendDelimitersHandling, bool[] charEscapeFlags, StringEscapeHandling stringEscapeHandling)
     {
       // leading delimiter
+      bool appendDelimiters = appendDelimitersHandling == QuoteNameHandling.Quoted
+        || appendDelimitersHandling == QuoteNameHandling.Auto && !IsValidIdentifier(s);
       if (appendDelimiters)
         writer.Write(delimiter);
 
@@ -198,9 +200,19 @@ namespace Newtonsoft.Json.Utilities
     {
       using (StringWriter w = StringUtils.CreateStringWriter(StringUtils.GetLength(value) ?? 16))
       {
-        WriteEscapedJavaScriptString(w, value, delimiter, appendDelimiters, (delimiter == '"') ? DoubleQuoteCharEscapeFlags : SingleQuoteCharEscapeFlags, StringEscapeHandling.Default);
+        WriteEscapedJavaScriptString(w, value, delimiter, appendDelimiters ? QuoteNameHandling.Quoted : QuoteNameHandling.Unquoted, (delimiter == '"') ? DoubleQuoteCharEscapeFlags : SingleQuoteCharEscapeFlags, StringEscapeHandling.Default);
         return w.ToString();
       }
+    }
+
+    public static bool IsValidIdentifierChar (char value)
+    {
+      return (Char.IsLetterOrDigit(value) || value == '_' || value == '$');
+    }
+
+    public static bool IsValidIdentifier (string value)
+    {
+      return value.All(IsValidIdentifierChar);
     }
   }
 }


### PR DESCRIPTION
Changed boolean `JsonTextWriter.QuoteName` to `QuoteNameHandling` (`Auto` value added to quote invalid characters). Previously setting `QuoteName` to `false` could generate unreadable files. Name characters are checked only when `QuoteNameHandling` is set to `Auto`, to avoid performance penalty (which should be minor, but just in case). Unit test included.

Use case: JSON is a good generic human-readable and human-writable format, not only when JavaScript is involved, but as a format for configuration and other files, where readability is most important and compatibility with JS is completely redundant. This is why disabling quotes is a useful feature, even though it's not strictly JSON.

Exact use case: `DbConnectionStringBuilder` class generates properties with spaces.

P.S. Sorry for possible mistakes in doc comments, my native language is C#.
