### PR TITLE
Add support for Mono 3.5 Full AOT (for Unity 3D compatibility)

### DIFF
--- a/Src/Newtonsoft.Json.MonoAot35.sln
+++ b/Src/Newtonsoft.Json.MonoAot35.sln
@@ -1,0 +1,23 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Newtonsoft.Json.MonoAot35", "Newtonsoft.Json\Newtonsoft.Json.MonoAot35.csproj", "{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Newtonsoft.Json\Newtonsoft.Json.MonoAot35.csproj
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.MonoAot35.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.MonoAot35.csproj
@@ -1,0 +1,325 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{3E6E2335-B079-4B5B-A65A-9D586914BCBB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Newtonsoft.Json.Tests</RootNamespace>
+    <AssemblyName>Newtonsoft.Json.Tests</AssemblyName>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <SignAssembly>false</SignAssembly>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\MonoAot35\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET35;AOT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\MonoAot35\</OutputPath>
+    <DefineConstants>TRACE;NET35;AOT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.Serialization">
+      <RequiredTargetFramework>3.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel">
+      <RequiredTargetFramework>3.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.ServiceModel.Web">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\Lib\NUnit\DotNet\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bson\BsonWriterTests.cs" />
+    <Compile Include="Bson\BsonReaderTests.cs" />
+    <Compile Include="Converters\BinaryConverterTests.cs" />
+    <Compile Include="Converters\ExpandoObjectConverterTests.cs" />
+    <Compile Include="Converters\RegexConverterTests.cs" />
+    <Compile Include="Converters\DataTableConverterTests.cs" />
+    <Compile Include="Converters\DataSetConverterTests.cs" />
+    <Compile Include="Converters\CustomCreationConverterTests.cs" />
+    <Compile Include="Converters\ObjectIdConverterTests.cs" />
+    <Compile Include="Converters\StringEnumConverterTests.cs" />
+    <Compile Include="Converters\VersionConverterTests.cs" />
+    <Compile Include="JsonArrayAttributeTests.cs" />
+    <Compile Include="ExceptionTests.cs" />
+    <Compile Include="JsonValidatingReaderTests.cs" />
+    <Compile Include="LinqToSql\Department.cs" />
+    <Compile Include="LinqToSql\DepartmentConverter.cs" />
+    <Compile Include="LinqToSql\GuidByteArrayConverter.cs" />
+    <Compile Include="LinqToSql\Role.cs" />
+    <Compile Include="LinqToSql\LinqToSqlClasses.designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LinqToSqlClasses.dbml</DependentUpon>
+    </Compile>
+    <Compile Include="LinqToSql\LinqToSqlClassesSerializationTests.cs" />
+    <Compile Include="LinqToSql\Person.cs" />
+    <Compile Include="Linq\ComponentModel\BindingTests.cs" />
+    <Compile Include="Linq\ComponentModel\JPropertyDescriptorTests.cs" />
+    <Compile Include="Linq\DynamicTests.cs" />
+    <Compile Include="Linq\JPathTests.cs" />
+    <Compile Include="Linq\JRawTests.cs" />
+    <Compile Include="Serialization\ConstructorHandlingTests.cs" />
+    <Compile Include="Serialization\ContractResolverTests.cs" />
+    <Compile Include="Serialization\DefaultValueHandlingTests.cs" />
+    <Compile Include="Serialization\DynamicTests.cs" />
+    <Compile Include="Serialization\JsonPropertyCollectionTests.cs" />
+    <Compile Include="Serialization\NullValueHandlingTests.cs" />
+    <Compile Include="Serialization\ReferenceLoopHandlingTests.cs" />
+    <Compile Include="Serialization\TraceWriterTests.cs" />
+    <Compile Include="Serialization\WebApiIntegrationTests.cs" />
+    <Compile Include="TestObjects\Bar.cs" />
+    <Compile Include="TestObjects\Car.cs" />
+    <Compile Include="TestObjects\Computer.cs" />
+    <Compile Include="TestObjects\ConstructorReadonlyFields.cs" />
+    <Compile Include="TestObjects\Container.cs" />
+    <Compile Include="TestObjects\ContentBaseClass.cs" />
+    <Compile Include="TestObjects\ContentSubClass.cs" />
+    <Compile Include="TestObjects\Foo.cs" />
+    <Compile Include="TestObjects\HolderClass.cs" />
+    <Compile Include="TestObjects\IPrivateImplementationA.cs" />
+    <Compile Include="TestObjects\IPrivateImplementationB.cs" />
+    <Compile Include="TestObjects\IPrivateOverriddenImplementation.cs" />
+    <Compile Include="TestObjects\ListOfIds.cs" />
+    <Compile Include="TestObjects\Movie.cs" />
+    <Compile Include="TestObjects\PrivateImplementationAClass.cs" />
+    <Compile Include="TestObjects\PrivateImplementationBClass.cs" />
+    <Compile Include="TestObjects\PublicParametizedConstructorRequiringConverterTestClass.cs" />
+    <Compile Include="TestObjects\PublicParametizedConstructorTestClass.cs" />
+    <Compile Include="TestObjects\PersonError.cs" />
+    <Compile Include="TestObjects\PersonPropertyClass.cs" />
+    <Compile Include="TestObjects\PrivateConstructorTestClass.cs" />
+    <Compile Include="TestObjects\PrivateConstructorWithPublicParametizedConstructorTestClass.cs" />
+    <Compile Include="TestObjects\Content.cs" />
+    <Compile Include="TestObjects\DateTimeErrorObjectCollection.cs" />
+    <Compile Include="Serialization\EntitiesSerializationTests.cs" />
+    <Compile Include="TestObjects\DictionaryInterfaceClass.cs" />
+    <Compile Include="TestObjects\Event.cs" />
+    <Compile Include="TestObjects\GoogleMapGeocoderStructure.cs" />
+    <Compile Include="TestObjects\InterfacePropertyTestClass.cs" />
+    <Compile Include="TestObjects\JsonPropertyClass.cs" />
+    <Compile Include="TestObjects\ListErrorObject.cs" />
+    <Compile Include="TestObjects\ListErrorObjectCollection.cs" />
+    <Compile Include="Serialization\MissingMemberHandlingTests.cs" />
+    <Compile Include="Serialization\PopulateTests.cs" />
+    <Compile Include="Serialization\SerializationErrorHandlingTests.cs" />
+    <Compile Include="Serialization\SerializationEventAttributeTests.cs" />
+    <Compile Include="Schema\ExtensionsTests.cs" />
+    <Compile Include="Schema\JsonSchemaModelBuilderTests.cs" />
+    <Compile Include="Schema\JsonSchemaNodeTests.cs" />
+    <Compile Include="Serialization\CamelCasePropertyNamesContractResolverTests.cs" />
+    <Compile Include="Serialization\PreserveReferencesHandlingTests.cs" />
+    <Compile Include="Serialization\TypeNameHandlingTests.cs" />
+    <Compile Include="TestObjects\ListTestClass.cs" />
+    <Compile Include="TestObjects\LogEntry.cs" />
+    <Compile Include="TestObjects\NonRequest.cs" />
+    <Compile Include="TestObjects\ObjectArrayPropertyTest.cs" />
+    <Compile Include="TestObjects\PublicParametizedConstructorWithNonPropertyParameterTestClass.cs" />
+    <Compile Include="TestObjects\PublicParametizedConstructorWithPropertyNameConflict.cs" />
+    <Compile Include="TestObjects\SearchResult.cs" />
+    <Compile Include="TestObjects\StructTest.cs" />
+    <Compile Include="TestObjects\WagePerson.cs" />
+    <Compile Include="TestObjects\PropertyCase.cs" />
+    <Compile Include="TestObjects\RequestOnly.cs" />
+    <Compile Include="TestObjects\RoleTransfer.cs" />
+    <Compile Include="TestObjects\SetOnlyPropertyClass2.cs" />
+    <Compile Include="TestObjects\SubKlass.cs" />
+    <Compile Include="TestObjects\SuperKlass.cs" />
+    <Compile Include="TestObjects\VersionKeyedCollection.cs" />
+    <Compile Include="TestObjects\AbstractGenericBase.cs" />
+    <Compile Include="TestObjects\ArgumentConverterPrecedenceClassConverter.cs" />
+    <Compile Include="TestObjects\BadJsonPropertyClass.cs" />
+    <Compile Include="TestObjects\CircularReferenceClass.cs" />
+    <Compile Include="TestObjects\ClassAndMemberConverterClass.cs" />
+    <Compile Include="TestObjects\ClassConverterPrecedenceClassConverter.cs" />
+    <Compile Include="TestObjects\ConstructorCaseSensitivityClass.cs" />
+    <Compile Include="TestObjects\ConverterPrecedenceClass.cs" />
+    <Compile Include="TestObjects\ConverterPrecedenceClassConverter.cs" />
+    <Compile Include="TestObjects\CircularReferenceWithIdClass.cs" />
+    <Compile Include="TestObjects\EmployeeReference.cs" />
+    <Compile Include="TestObjects\JsonPropertyWithHandlingValues.cs" />
+    <Compile Include="TestObjects\DefaultValueAttributeTestClass.cs" />
+    <Compile Include="TestObjects\DoubleClass.cs" />
+    <Compile Include="TestObjects\GenericImpl.cs" />
+    <Compile Include="TestObjects\GenericListAndDictionaryInterfaceProperties.cs" />
+    <Compile Include="TestObjects\GetOnlyPropertyClass.cs" />
+    <Compile Include="TestObjects\IncompatibleJsonAttributeClass.cs" />
+    <Compile Include="TestObjects\Invoice.cs" />
+    <Compile Include="TestObjects\JsonIgnoreAttributeTestClass.cs" />
+    <Compile Include="TestObjects\MemberConverterPrecedenceClassConverter.cs" />
+    <Compile Include="TestObjects\MethodExecutorObject.cs" />
+    <Compile Include="TestObjects\JaggedArray.cs" />
+    <Compile Include="TestObjects\MyClass.cs" />
+    <Compile Include="TestObjects\Name.cs" />
+    <Compile Include="TestObjects\PersonRaw.cs" />
+    <Compile Include="TestObjects\PhoneNumber.cs" />
+    <Compile Include="TestObjects\PrivateMembersClass.cs" />
+    <Compile Include="TestObjects\RequiredMembersClass.cs" />
+    <Compile Include="TestObjects\SerializationEventTestDictionary.cs" />
+    <Compile Include="TestObjects\SerializationEventTestList.cs" />
+    <Compile Include="TestObjects\SerializationEventTestObject.cs" />
+    <Compile Include="TestObjects\SerializationEventTestObjectWithConstructor.cs" />
+    <Compile Include="TestObjects\SetOnlyPropertyClass.cs" />
+    <Compile Include="TestObjects\Article.cs" />
+    <Compile Include="TestObjects\ArticleCollection.cs" />
+    <Compile Include="TestObjects\ClassWithArray.cs" />
+    <Compile Include="TestObjects\ClassWithGuid.cs" />
+    <Compile Include="TestObjects\ConverableMembers.cs" />
+    <Compile Include="TestObjects\JsonIgnoreAttributeOnClassTestClass.cs" />
+    <Compile Include="Linq\JConstructorTests.cs" />
+    <Compile Include="Linq\JPropertyTests.cs" />
+    <Compile Include="TestObjects\MemberConverterClass.cs" />
+    <Compile Include="TestObjects\Product.cs" />
+    <Compile Include="TestObjects\ProductCollection.cs" />
+    <Compile Include="TestObjects\ProductShort.cs" />
+    <Compile Include="TestObjects\Shortie.cs" />
+    <Compile Include="TestObjects\Store.cs" />
+    <Compile Include="TestObjects\StoreColor.cs" />
+    <Compile Include="TestObjects\Person.cs" />
+    <Compile Include="Schema\JsonSchemaBuilderTests.cs" />
+    <Compile Include="Schema\JsonSchemaGeneratorTests.cs" />
+    <Compile Include="Schema\JsonSchemaTests.cs" />
+    <Compile Include="TestObjects\NullableDateTimeTestClass.cs" />
+    <Compile Include="TestObjects\DateTimeTestClass.cs" />
+    <Compile Include="Converters\IsoDateTimeConverterTests.cs" />
+    <Compile Include="JsonConvertTest.cs" />
+    <Compile Include="Converters\JavaScriptDateTimeConverterTests.cs" />
+    <Compile Include="Serialization\JsonSerializerTest.cs" />
+    <Compile Include="JsonTextReaderTest.cs" />
+    <Compile Include="JsonTextWriterTest.cs" />
+    <Compile Include="Linq\JTokenReaderTest.cs" />
+    <Compile Include="Linq\JTokenWriterTest.cs" />
+    <Compile Include="Linq\JArrayTests.cs" />
+    <Compile Include="Linq\JObjectTests.cs" />
+    <Compile Include="Linq\JTokenEqualityComparerTests.cs" />
+    <Compile Include="Linq\JTokenTests.cs" />
+    <Compile Include="Linq\JValueTests.cs" />
+    <Compile Include="Linq\LinqToJsonTest.cs" />
+    <Compile Include="PerformanceTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SilverlightTests.cs" />
+    <Compile Include="TestFixtureBase.cs" />
+    <Compile Include="Converters\XmlNodeConverterTest.cs" />
+    <Compile Include="TestObjects\TypeClass.cs" />
+    <Compile Include="TestObjects\TypedSubHashtable.cs" />
+    <Compile Include="TestObjects\UserNullable.cs" />
+    <Compile Include="Utilities\DynamicReflectionDelegateFactoryTests.cs" />
+    <Compile Include="Utilities\ReflectionUtilsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="LinqToSql\LinqToSqlClasses.dbml">
+      <Generator>MSLinqToSQLGenerator</Generator>
+      <LastGenOutput>LinqToSqlClasses.designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{3259AA49-8AA1-44D3-9025-A0B520596A8C}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="LinqToSql\LinqToSqlClasses.dbml.layout">
+      <DependentUpon>LinqToSqlClasses.dbml</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="bunny_pancake.jpg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Newtonsoft.Json\Newtonsoft.Json.MonoAot35.csproj">
+      <Project>{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}</Project>
+      <Name>Newtonsoft.Json.MonoAot35</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.MonoAot35.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.MonoAot35.csproj
@@ -1,0 +1,287 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A9AE40FF-1A21-414A-9FE7-3BE13644CC6D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Newtonsoft.Json</RootNamespace>
+    <AssemblyName>Newtonsoft.Json</AssemblyName>
+    <SignAssembly>false</SignAssembly>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\MonoAot35\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;NET35;AOT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Net35\Newtonsoft.Json.xml</DocumentationFile>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRules>
+    </CodeAnalysisRules>
+    <CodeAnalysisRuleSet>Newtonsoft.Json.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\MonoAot35\</OutputPath>
+    <DefineConstants>TRACE;NET35;AOT</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Net35\Newtonsoft.Json.xml</DocumentationFile>
+    <CodeAnalysisRuleSet>Newtonsoft.Json.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization">
+      <RequiredTargetFramework>3.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bson\BsonBinaryType.cs" />
+    <Compile Include="Bson\BsonBinaryWriter.cs" />
+    <Compile Include="Bson\BsonReader.cs" />
+    <Compile Include="Bson\BsonToken.cs" />
+    <Compile Include="Bson\BsonType.cs" />
+    <Compile Include="Bson\BsonWriter.cs" />
+    <Compile Include="Bson\BsonObjectId.cs" />
+    <Compile Include="Converters\BinaryConverter.cs" />
+    <Compile Include="Converters\DataSetConverter.cs" />
+    <Compile Include="Converters\DataTableConverter.cs" />
+    <Compile Include="Converters\CustomCreationConverter.cs" />
+    <Compile Include="Converters\DateTimeConverterBase.cs" />
+    <Compile Include="Converters\EntityKeyMemberConverter.cs" />
+    <Compile Include="Converters\ExpandoObjectConverter.cs" />
+    <Compile Include="Converters\KeyValuePairConverter.cs" />
+    <Compile Include="Converters\BsonObjectIdConverter.cs" />
+    <Compile Include="Converters\RegexConverter.cs" />
+    <Compile Include="Converters\StringEnumConverter.cs" />
+    <Compile Include="ConstructorHandling.cs" />
+    <Compile Include="Converters\VersionConverter.cs" />
+    <Compile Include="DateFormatHandling.cs" />
+    <Compile Include="DateParseHandling.cs" />
+    <Compile Include="DateTimeZoneHandling.cs" />
+    <Compile Include="FloatFormatHandling.cs" />
+    <Compile Include="FloatParseHandling.cs" />
+    <Compile Include="FormatterAssemblyStyle.cs" />
+    <Compile Include="Formatting.cs" />
+    <Compile Include="JsonConstructorAttribute.cs" />
+    <Compile Include="JsonDictionaryAttribute.cs" />
+    <Compile Include="JsonException.cs" />
+    <Compile Include="JsonPosition.cs" />
+    <Compile Include="Linq\JPropertyDescriptor.cs" />
+    <Compile Include="Linq\JPropertyKeyedCollection.cs" />
+    <Compile Include="SerializationBinder.cs" />
+    <Compile Include="Serialization\DiagnosticsTraceWriter.cs" />
+    <Compile Include="Serialization\ITraceWriter.cs" />
+    <Compile Include="Serialization\JsonContainerContract.cs" />
+    <Compile Include="Serialization\MemoryTraceWriter.cs" />
+    <Compile Include="StreamingContext.cs" />
+    <Compile Include="StringEscapeHandling.cs" />
+    <Compile Include="TraceLevel.cs" />
+    <Compile Include="Utilities\DynamicProxy.cs" />
+    <Compile Include="Linq\JPath.cs" />
+    <Compile Include="Linq\JRaw.cs" />
+    <Compile Include="Required.cs" />
+    <Compile Include="Serialization\JsonDynamicContract.cs" />
+    <Compile Include="Serialization\JsonFormatterConverter.cs" />
+    <Compile Include="Serialization\JsonISerializableContract.cs" />
+    <Compile Include="Serialization\JsonLinqContract.cs" />
+    <Compile Include="Serialization\JsonPrimitiveContract.cs" />
+    <Compile Include="Serialization\DynamicValueProvider.cs" />
+    <Compile Include="Serialization\ErrorEventArgs.cs" />
+    <Compile Include="Serialization\DefaultReferenceResolver.cs" />
+    <Compile Include="PreserveReferencesHandling.cs" />
+    <Compile Include="IJsonLineInfo.cs" />
+    <Compile Include="JsonArrayAttribute.cs" />
+    <Compile Include="JsonContainerAttribute.cs" />
+    <Compile Include="DefaultValueHandling.cs" />
+    <Compile Include="JsonConverterAttribute.cs" />
+    <Compile Include="JsonObjectAttribute.cs" />
+    <Compile Include="JsonSerializerSettings.cs" />
+    <Compile Include="JsonValidatingReader.cs" />
+    <Compile Include="Linq\IJEnumerable.cs" />
+    <Compile Include="Linq\JTokenEqualityComparer.cs" />
+    <Compile Include="MemberSerialization.cs" />
+    <Compile Include="ObjectCreationHandling.cs" />
+    <Compile Include="Converters\IsoDateTimeConverter.cs" />
+    <Compile Include="Converters\JavaScriptDateTimeConverter.cs" />
+    <Compile Include="Converters\XmlNodeConverter.cs" />
+    <Compile Include="JsonTextReader.cs" />
+    <Compile Include="JsonPropertyAttribute.cs" />
+    <Compile Include="JsonIgnoreAttribute.cs" />
+    <Compile Include="JsonTextWriter.cs" />
+    <Compile Include="JsonWriterException.cs" />
+    <Compile Include="JsonReaderException.cs" />
+    <Compile Include="JsonConverter.cs" />
+    <Compile Include="JsonConverterCollection.cs" />
+    <Compile Include="JsonReader.cs" />
+    <Compile Include="JsonConvert.cs" />
+    <Compile Include="JsonSerializationException.cs" />
+    <Compile Include="JsonSerializer.cs" />
+    <Compile Include="Linq\Extensions.cs" />
+    <Compile Include="Linq\JConstructor.cs" />
+    <Compile Include="Linq\JContainer.cs" />
+    <Compile Include="Linq\JEnumerable.cs" />
+    <Compile Include="Linq\JObject.cs" />
+    <Compile Include="Linq\JArray.cs" />
+    <Compile Include="Linq\JTokenReader.cs" />
+    <Compile Include="Linq\JTokenWriter.cs" />
+    <Compile Include="Linq\JToken.cs" />
+    <Compile Include="Linq\JProperty.cs" />
+    <Compile Include="Linq\JTokenType.cs" />
+    <Compile Include="Linq\JValue.cs" />
+    <Compile Include="Schema\Extensions.cs" />
+    <Compile Include="Schema\JsonSchemaException.cs" />
+    <Compile Include="Schema\JsonSchemaModel.cs" />
+    <Compile Include="Schema\JsonSchemaModelBuilder.cs" />
+    <Compile Include="Schema\JsonSchemaNodeCollection.cs" />
+    <Compile Include="Schema\JsonSchemaNode.cs" />
+    <Compile Include="Schema\JsonSchemaResolver.cs" />
+    <Compile Include="Schema\JsonSchemaWriter.cs" />
+    <Compile Include="Schema\UndefinedSchemaIdHandling.cs" />
+    <Compile Include="Schema\ValidationEventArgs.cs" />
+    <Compile Include="Schema\ValidationEventHandler.cs" />
+    <Compile Include="Serialization\CamelCasePropertyNamesContractResolver.cs" />
+    <Compile Include="Serialization\DefaultContractResolver.cs" />
+    <Compile Include="Serialization\DefaultSerializationBinder.cs" />
+    <Compile Include="Serialization\ErrorContext.cs" />
+    <Compile Include="Serialization\IContractResolver.cs" />
+    <Compile Include="Serialization\IValueProvider.cs" />
+    <Compile Include="Serialization\JsonArrayContract.cs" />
+    <Compile Include="Serialization\JsonContract.cs" />
+    <Compile Include="Serialization\JsonDictionaryContract.cs" />
+    <Compile Include="Serialization\JsonProperty.cs" />
+    <Compile Include="Serialization\JsonPropertyCollection.cs" />
+    <Compile Include="MissingMemberHandling.cs" />
+    <Compile Include="NullValueHandling.cs" />
+    <Compile Include="ReferenceLoopHandling.cs" />
+    <Compile Include="Schema\JsonSchema.cs" />
+    <Compile Include="Schema\JsonSchemaBuilder.cs" />
+    <Compile Include="Schema\JsonSchemaConstants.cs" />
+    <Compile Include="Schema\JsonSchemaGenerator.cs" />
+    <Compile Include="Serialization\IReferenceResolver.cs" />
+    <Compile Include="Schema\JsonSchemaType.cs" />
+    <Compile Include="Serialization\JsonObjectContract.cs" />
+    <Compile Include="Serialization\JsonSerializerInternalBase.cs" />
+    <Compile Include="Serialization\JsonSerializerInternalReader.cs" />
+    <Compile Include="Serialization\JsonSerializerInternalWriter.cs" />
+    <Compile Include="Serialization\JsonSerializerProxy.cs" />
+    <Compile Include="Serialization\JsonStringContract.cs" />
+    <Compile Include="Serialization\JsonTypeReflector.cs" />
+    <Compile Include="Serialization\CachedAttributeGetter.cs" />
+    <Compile Include="Serialization\LateBoundMetadataTypeAttribute.cs" />
+    <Compile Include="Serialization\ReflectionValueProvider.cs" />
+    <Compile Include="Serialization\OnErrorAttribute.cs" />
+    <Compile Include="Utilities\Base64Encoder.cs" />
+    <Compile Include="Utilities\DynamicProxyMetaObject.cs" />
+    <Compile Include="Utilities\DynamicUtils.cs" />
+    <Compile Include="Utilities\DynamicWrapper.cs" />
+    <Compile Include="Utilities\DynamicReflectionDelegateFactory.cs" />
+    <Compile Include="Serialization\ObjectConstructor.cs" />
+    <Compile Include="Utilities\ILGeneratorExtensions.cs" />
+    <Compile Include="Utilities\ReflectionDelegateFactory.cs" />
+    <Compile Include="Utilities\LateBoundReflectionDelegateFactory.cs" />
+    <Compile Include="Utilities\MethodCall.cs" />
+    <Compile Include="Utilities\StringReference.cs" />
+    <Compile Include="Utilities\ThreadSafeStore.cs" />
+    <Compile Include="TypeNameHandling.cs" />
+    <Compile Include="Utilities\BidirectionalDictionary.cs" />
+    <Compile Include="Utilities\ConvertUtils.cs" />
+    <Compile Include="Utilities\CollectionWrapper.cs" />
+    <Compile Include="Utilities\DateTimeUtils.cs" />
+    <Compile Include="Utilities\DictionaryWrapper.cs" />
+    <Compile Include="Utilities\EnumUtils.cs" />
+    <Compile Include="Utilities\EnumValue.cs" />
+    <Compile Include="Utilities\EnumValues.cs" />
+    <Compile Include="Utilities\JavaScriptUtils.cs" />
+    <Compile Include="JsonToken.cs" />
+    <Compile Include="JsonWriter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\StringBuffer.cs" />
+    <Compile Include="Utilities\CollectionUtils.cs" />
+    <Compile Include="Utilities\MathUtils.cs" />
+    <Compile Include="Utilities\MiscellaneousUtils.cs" />
+    <Compile Include="Utilities\ReflectionUtils.cs" />
+    <Compile Include="Utilities\StringUtils.cs" />
+    <Compile Include="Utilities\TypeExtensions.cs" />
+    <Compile Include="Utilities\ValidationUtils.cs" />
+    <Compile Include="WriteState.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy FileWidth="120" TabWidth="2" IndentWidth="2" EolMarker="Unix" inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentSwitchBody="True" BeforeMethodDeclarationParentheses="False" BeforeMethodCallParentheses="False" BeforeConstructorDeclarationParentheses="False" BeforeDelegateDeclarationParentheses="False" NewParentheses="False" SpacesBeforeBrackets="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
+</Project>

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -82,6 +82,23 @@ namespace Newtonsoft.Json.Serialization
     }
   }
 
+#if AOT
+  internal class ResolverContractKeyEqualityComparer : System.Collections.Generic.IEqualityComparer<ResolverContractKey>
+  {
+    public static readonly ResolverContractKeyEqualityComparer Default = new ResolverContractKeyEqualityComparer();
+    
+    public bool Equals(ResolverContractKey x, ResolverContractKey y)
+    {
+      return x.Equals(y);
+    }
+    
+    public int GetHashCode(ResolverContractKey obj)
+    {
+      return obj.GetHashCode();
+    }
+  }
+#endif
+
   /// <summary>
   /// Used by <see cref="JsonSerializer"/> to resolves a <see cref="JsonContract"/> for a given <see cref="Type"/>.
   /// </summary>
@@ -237,8 +254,16 @@ namespace Newtonsoft.Json.Serialization
           cache = GetCache();
           Dictionary<ResolverContractKey, JsonContract> updatedCache =
             (cache != null)
-              ? new Dictionary<ResolverContractKey, JsonContract>(cache)
-              : new Dictionary<ResolverContractKey, JsonContract>();
+              ? new Dictionary<ResolverContractKey, JsonContract>(cache
+#if AOT
+                                                                  , ResolverContractKeyEqualityComparer.Default
+#endif
+                                                                  )
+              : new Dictionary<ResolverContractKey, JsonContract>(
+#if AOT
+                                                                  ResolverContractKeyEqualityComparer.Default
+#endif
+                );
           updatedCache[key] = contract;
 
           UpdateCache(updatedCache);

--- a/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
@@ -38,7 +38,11 @@ namespace Newtonsoft.Json.Serialization
   {
     internal static readonly DefaultSerializationBinder Instance = new DefaultSerializationBinder();
 
-    private readonly ThreadSafeStore<TypeNameKey, Type> _typeCache = new ThreadSafeStore<TypeNameKey, Type>(GetTypeFromTypeNameKey);
+    private readonly ThreadSafeStore<TypeNameKey, Type> _typeCache = new ThreadSafeStore<TypeNameKey, Type>(GetTypeFromTypeNameKey
+#if AOT
+                                                                                                            , TypeNameKeyEqualityComparer.Default
+#endif
+                                                                                                            );
 
     private static Type GetTypeFromTypeNameKey(TypeNameKey typeNameKey)
     {
@@ -105,6 +109,23 @@ namespace Newtonsoft.Json.Serialization
         return (AssemblyName == other.AssemblyName && TypeName == other.TypeName);
       }
     }
+
+#if AOT
+	internal class TypeNameKeyEqualityComparer : System.Collections.Generic.IEqualityComparer<TypeNameKey>
+	{
+    public static readonly TypeNameKeyEqualityComparer Default = new TypeNameKeyEqualityComparer();
+
+		public bool Equals(TypeNameKey x, TypeNameKey y)
+		{
+			return x.Equals(y);
+		}
+		
+		public int GetHashCode(TypeNameKey obj)
+		{
+			return obj.GetHashCode();
+		}
+	}
+#endif
 
     /// <summary>
     /// When overridden in a derived class, controls the binding of a serialized object to a type.

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -377,7 +377,7 @@ namespace Newtonsoft.Json.Serialization
       {
         if (_dynamicCodeGeneration == null)
         {
-#if !(SILVERLIGHT || NETFX_CORE || PORTABLE40 || PORTABLE)
+#if !(SILVERLIGHT || NETFX_CORE || PORTABLE40 || PORTABLE || AOT)
           try
           {
             new ReflectionPermission(ReflectionPermissionFlag.MemberAccess).Demand();

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -270,8 +270,29 @@ namespace Newtonsoft.Json.Utilities
       }
     }
 
+#if AOT
+    internal class TypeConvertKeyEqualityComparer : System.Collections.Generic.IEqualityComparer<TypeConvertKey>
+    {
+      public static readonly TypeConvertKeyEqualityComparer Default = new TypeConvertKeyEqualityComparer();
+      
+      public bool Equals(TypeConvertKey x, TypeConvertKey y)
+      {
+        return x.Equals(y);
+      }
+      
+      public int GetHashCode(TypeConvertKey obj)
+      {
+        return obj.GetHashCode();
+      }
+    }
+#endif
+
     private static readonly ThreadSafeStore<TypeConvertKey, Func<object, object>> CastConverters =
-      new ThreadSafeStore<TypeConvertKey, Func<object, object>>(CreateCastConverter);
+      new ThreadSafeStore<TypeConvertKey, Func<object, object>>(CreateCastConverter
+#if AOT
+                                                                , TypeConvertKeyEqualityComparer.Default
+#endif
+                                                                );
 
     private static Func<object, object> CreateCastConverter(TypeConvertKey t)
     {

--- a/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
@@ -33,7 +33,7 @@ namespace Newtonsoft.Json.Utilities
   {
     public static TimeSpan GetUtcOffset(this DateTime d)
     {
-#if NET20
+#if NET20 || AOT
       return TimeZone.CurrentTimeZone.GetUtcOffset(d);
 #else
       return TimeZoneInfo.Local.GetUtcOffset(d);

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -485,7 +485,12 @@ namespace Newtonsoft.Json.Utilities
         case MemberTypes.Property:
           try
           {
+#if AOT
+            // This approach doesn't JIT (but is a bit slower) compared to below.
+            return ((PropertyInfo)member).GetGetMethod().Invoke(target, null);
+#else
             return ((PropertyInfo)member).GetValue(target, null);
+#endif
           }
           catch (TargetParameterCountException e)
           {

--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -137,13 +137,29 @@ namespace Newtonsoft.Json.Utilities
       var caseInsensitiveResults = source.Where(s => string.Equals(valueSelector(s), testValue, StringComparison.OrdinalIgnoreCase));
       if (caseInsensitiveResults.Count() <= 1)
       {
+#if !AOT
         return caseInsensitiveResults.SingleOrDefault();
+#else
+        if(caseInsensitiveResults.Count() == 0)
+          return default(TSource);
+        else
+          return caseInsensitiveResults.First();
+#endif
       }
       else
       {
         // multiple results returned. now filter using case sensitivity
         var caseSensitiveResults = source.Where(s => string.Equals(valueSelector(s), testValue, StringComparison.Ordinal));
+#if !AOT
         return caseSensitiveResults.SingleOrDefault();
+#else
+        if(caseInsensitiveResults.Count() == 0)
+          return default(TSource);
+        if(caseInsensitiveResults.Count() == 1)
+          return caseSensitiveResults.First();
+        else
+          throw new InvalidOperationException();
+#endif
       }
     }
 


### PR DESCRIPTION
These patches enable building the library with the Mono AOT compiler to run on iOS. These changes were tested with Unity 4 but will likely work on MonoTouch as well.
