### PR TITLE
Fix proposed for Issue #75

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -811,7 +811,7 @@ To fix this error either change the JSON to a {1} or change the deserialized typ
       }
 
       // test tokentype here because default value might not be convertable to actual type, e.g. default of "" for DateTime
-      if (HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Ignore)
+      if (!HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Populate)
           && JsonReader.IsPrimitiveToken(tokenType)
           && MiscellaneousUtils.ValueEquals(reader.Value, property.GetResolvedDefaultValue()))
       {
@@ -859,7 +859,7 @@ To fix this error either change the JSON to a {1} or change the deserialized typ
       if (property.NullValueHandling.GetValueOrDefault(Serializer._nullValueHandling) == NullValueHandling.Ignore && value == null)
         return false;
 
-      if (HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Ignore)
+      if (!HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Populate)
         && MiscellaneousUtils.ValueEquals(value, property.GetResolvedDefaultValue()))
         return false;
 


### PR DESCRIPTION
I found if the json node is provided with the default value in the json string, when in deserialization, the corresponding property will be set to null. Please refer to the following code, 

public class DefaultHandler
{
    [DefaultValue(-1)]
    public int field1;

```
[DefaultValue("default")]
public string field2;
```

}

The default value -1 is set to property field1, and default value "default" is set to property 'field2'. 

When the json string is {"field1":-1,"field2":"default"} and the DefaultValueHandling is set to 'IgnoreAndPopulate', the value of field1 will be ZERO and the value of the field2 of the deserialized object will be NULL, but I am expecting the value to be -1 and 'default'. I'm wondering whether it's a bug because it's working as I expected when DefaultValueHandling is set to 'Populate'. And I have to use IgnoreAndPopulate to make serialization ignore the field with default value, but populate the default value in deserialization, but currently it causes problem in deserialization as described in the issue.

The logic calling HasFlag seems not correct, in the original code, [IgnorePopulate] & Ignore == Ignore, so that the default value will not be set to the member when defaultHandling is IgnorePopulate
