### PR TITLE
Remove explicit only interface for IEnumerable, and IList for JArray 

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JArray.cs
+++ b/Src/Newtonsoft.Json/Linq/JArray.cs
@@ -269,6 +269,15 @@ namespace Newtonsoft.Json.Linq
     public void RemoveAt(int index)
     {
       RemoveItemAt(index);
+    }  
+    
+    #endregion
+    
+    #region IEnumerable<JToken> Members
+
+    public IEnumerator<JToken> GetEnumerator()
+    {
+        return Children().GetEnumerator();
     }
 
     #endregion
@@ -306,14 +315,14 @@ namespace Newtonsoft.Json.Linq
       return ContainsItem(item);
     }
 
-    void ICollection<JToken>.CopyTo(JToken[] array, int arrayIndex)
+    public void CopyTo(JToken[] array, int arrayIndex)
     {
-      CopyItemsTo(array, arrayIndex);
+        CopyItemsTo(array, arrayIndex);
     }
 
-    bool ICollection<JToken>.IsReadOnly
+    public bool IsReadOnly
     {
-      get { return false; }
+        get { return false; }
     }
 
     /// <summary>


### PR DESCRIPTION
Although for pretty much all standard usages, having an explicit IEnumerable interface is not an issue.  

However, there are some dlr issues with this, and by removing this limitation it allows dynamic JObjects to be wrapped with an Interface using [ImpromptuInterface](https://code.google.com/p/impromptu-interface/) similar to what Mark Rendle does with [HOWTO: Dial up the static on Simple.Data](http://blog.markrendle.net/2012/10/12/howto-dial-up-the-static-on-simple-data/)

Also referenced on [StackOverflow](http://stackoverflow.com/questions/15873136/custom-impromptuobject)
