### PR TITLE
Allow a serialization binder to be specified for a particular property (using jsonpropertyattribute)

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
@@ -662,6 +662,56 @@ namespace Newtonsoft.Json.Tests.Serialization
       Assert.AreEqual("Elbow Grease", purchase.ProductName);
     }
 
+
+    public class TypeNameSerializationBinderParameterlessConstructor : TypeNameSerializationBinder
+    {
+      public TypeNameSerializationBinderParameterlessConstructor()
+          : base("Newtonsoft.Json.Tests.Serialization.{0}, Newtonsoft.Json.Tests")
+      {
+      }
+    }
+
+    public class TestClassWithSerializationBinderSpecifed
+    {
+      [JsonProperty(SerializationBinderType = typeof(TypeNameSerializationBinderParameterlessConstructor))]
+      public object Customer { get; set; }
+    }
+
+    [Test]
+    public void SerializeUsingCustomBinderSpecifiedByJsonPropertyAttribute()
+    {
+      var obj = new TestClassWithSerializationBinderSpecifed
+      {
+        Customer = new Customer
+        {
+          Name = "Caroline Customer"
+        }
+      };
+        
+      string json = JsonConvert.SerializeObject(obj, Formatting.Indented, new JsonSerializerSettings
+        {
+          TypeNameHandling = TypeNameHandling.Auto
+        });
+
+      Assert.AreEqual(@"{
+  ""Customer"": {
+    ""$type"": ""Customer"",
+    ""Name"": ""Caroline Customer""
+  }
+}", json);
+
+      var newObj = JsonConvert.DeserializeObject<TestClassWithSerializationBinderSpecifed>(json, new JsonSerializerSettings
+        {
+          TypeNameHandling = TypeNameHandling.Auto
+        });
+
+      CustomAssert.IsInstanceOfType(typeof (TestClassWithSerializationBinderSpecifed), newObj);
+
+      CustomAssert.IsInstanceOfType(typeof (Customer), newObj.Customer);
+      Customer customer = (Customer)newObj.Customer;
+      Assert.AreEqual("Caroline Customer", customer.Name);
+    }
+
     public class TypeNameSerializationBinder : SerializationBinder
     {
       public string TypeFormat { get; private set; }

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -24,6 +24,9 @@
 #endregion
 
 using System;
+using System.Globalization;
+using System.Runtime.Serialization;
+using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json
 {
@@ -172,6 +175,12 @@ namespace Newtonsoft.Json
     }
 
     /// <summary>
+    /// Gets or sets the serialization binder used for this property
+    /// </summary>
+    /// <value>Serialization binder with parameterless constructor.</value>
+    public Type SerializationBinderType { get; set; }
+
+      /// <summary>
     /// Initializes a new instance of the <see cref="JsonPropertyAttribute"/> class.
     /// </summary>
     public JsonPropertyAttribute()
@@ -185,6 +194,18 @@ namespace Newtonsoft.Json
     public JsonPropertyAttribute(string propertyName)
     {
       PropertyName = propertyName;
+    }
+
+    public static SerializationBinder CreateSerializationBinderInstance(Type serializationBinderType)
+    {
+        try
+        {
+            return (SerializationBinder)Activator.CreateInstance(serializationBinderType);
+        }
+        catch (Exception ex)
+        {
+            throw new JsonException("Error creating {0}".FormatWith(CultureInfo.InvariantCulture, serializationBinderType), ex);
+        }
     }
   }
 }

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1123,6 +1123,7 @@ namespace Newtonsoft.Json.Serialization
       property.ReferenceLoopHandling = (propertyAttribute != null) ? propertyAttribute._referenceLoopHandling : null;
       property.ObjectCreationHandling = (propertyAttribute != null) ? propertyAttribute._objectCreationHandling : null;
       property.TypeNameHandling = (propertyAttribute != null) ? propertyAttribute._typeNameHandling : null;
+      property.SerializationBinder = (propertyAttribute != null && propertyAttribute.SerializationBinderType != null) ? JsonPropertyAttribute.CreateSerializationBinderInstance(propertyAttribute.SerializationBinderType) : null;
       property.IsReference = (propertyAttribute != null) ? propertyAttribute._isReference : null;
 
       property.ItemIsReference = (propertyAttribute != null) ? propertyAttribute._itemIsReference : null;

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -25,6 +25,7 @@
 
 using System;
 using Newtonsoft.Json.Utilities;
+using System.Runtime.Serialization;
 
 #if NET20
 using Newtonsoft.Json.Utilities.LinqBridge;
@@ -32,7 +33,7 @@ using Newtonsoft.Json.Utilities.LinqBridge;
 
 namespace Newtonsoft.Json.Serialization
 {
-  /// <summary>
+    /// <summary>
   /// Maps a JSON property to a .NET member or constructor parameter.
   /// </summary>
   public class JsonProperty
@@ -273,6 +274,12 @@ namespace Newtonsoft.Json.Serialization
     /// </summary>
     /// <value>The collection's items reference loop handling.</value>
     public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }
+
+    /// <summary>
+    /// Gets or sets the the serialization binder for this property.
+    /// </summary>
+    /// <value>The serialization binder.</value>
+    public SerializationBinder SerializationBinder { get; set; }
 
     internal void WritePropertyName(JsonWriter writer)
     {

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -520,12 +520,13 @@ To fix this error either change the JSON to a {1} or change the deserialized typ
               {
                 string typeName;
                 string assemblyName;
+                var serializationBinder = ((member != null) ? member.SerializationBinder : null) ?? Serializer._binder;
                 ReflectionUtils.SplitFullyQualifiedTypeName(qualifiedTypeName, out typeName, out assemblyName);
 
                 Type specifiedType;
                 try
                 {
-                  specifiedType = Serializer._binder.BindToType(assemblyName, typeName);
+                  specifiedType = serializationBinder.BindToType(assemblyName, typeName);
                 }
                 catch (Exception ex)
                 {

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -92,7 +92,7 @@ namespace Newtonsoft.Json.Serialization
         if (includeTypeDetails)
         {
           writer.WriteStartObject();
-          WriteTypeProperty(writer, contract.CreatedType);
+          WriteTypeProperty(writer, contract.CreatedType, member);
           writer.WritePropertyName(JsonTypeReflector.ValuePropertyName, false);
 
           JsonWriter.WriteValue(writer, contract.TypeCode, value);
@@ -450,7 +450,7 @@ namespace Newtonsoft.Json.Serialization
       }
       if (ShouldWriteType(TypeNameHandling.Objects, contract, member, collectionContract, containerProperty))
       {
-        WriteTypeProperty(writer, contract.UnderlyingType);
+        WriteTypeProperty(writer, contract.UnderlyingType, member);
       }
     }
 
@@ -465,9 +465,9 @@ namespace Newtonsoft.Json.Serialization
       writer.WriteValue(reference);
     }
 
-    private void WriteTypeProperty(JsonWriter writer, Type type)
+    private void WriteTypeProperty(JsonWriter writer, Type type, JsonProperty member)
     {
-      string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormat, Serializer._binder);
+      string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormat, (member != null ? member.SerializationBinder : null) ?? Serializer._binder);
 
       if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
         TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
@@ -661,7 +661,7 @@ namespace Newtonsoft.Json.Serialization
         }
         if (includeTypeDetails)
         {
-          WriteTypeProperty(writer, values.GetType());
+          WriteTypeProperty(writer, values.GetType(), member);
         }
         writer.WritePropertyName(JsonTypeReflector.ArrayValuesPropertyName, false);
       }


### PR DESCRIPTION
When attempting to create a SerializationBinder to customize the $type property on json, I realised that if I customized it for one property, i'd be customizing it for them all.

Since there is no context available within BindToType and BindToName, its impossible to know which property is currently being serialized/deserialized. 

Therefore it is possible with this modification to specify a different SerializationBinder per property.. each with their own behaviour.
