### PR TITLE
Fix for CodePlex issue 24348

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
@@ -690,6 +690,22 @@ namespace Newtonsoft.Json.Tests.Serialization
 
       Assert.AreEqual(@"{""Scott"":[],""James"":[]}", output);
     }
+
+    [Test]
+    public void UnquotedStringAsPropertyValue()
+    {
+      // JsonConvert.DeserializeObject<ErrorItem>() should throw upon encountering invalid json.
+      const string json = @"{ ""ItemName"": ""value"", ""u"":netanelsalinger,""r"":9 }";
+      try
+      {
+        JsonConvert.DeserializeObject<ErrorItem>(json);
+        Assert.Fail("Expected an exception of type '{0}' with message '{1}'", "Newtonsoft.Json.JsonReaderException", "Unexpected end while parsing constructor. Path 'u', line 1, position 27.");
+      }
+      catch (JsonReaderException e)
+      {
+        Assert.AreEqual(e.Message, "Unexpected end while parsing constructor. Path 'u', line 1, position 27.");
+      }
+    }
   }
 
   interface IErrorPerson2

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -1150,6 +1150,8 @@ namespace Newtonsoft.Json
 
         SetToken(JsonToken.StartConstructor, constructorName);
       }
+
+      throw JsonReaderException.Create(this, "Unexpected end while parsing constructor.");
     }
 
     private void ParseNumber()


### PR DESCRIPTION
Throw when failing to parse a constructor. Fixes issue [24348](https://json.codeplex.com/workitem/24348)
