### PR TITLE
Fixing TargetExceptions on invalid json when OnError is used

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -378,7 +378,7 @@ namespace Newtonsoft.Json.Serialization
 
     internal void InvokeOnError(object o, StreamingContext context, ErrorContext errorContext)
     {
-      if (_onErrorCallbacks != null)
+      if (o != null && _onErrorCallbacks != null)
       {
         foreach (SerializationErrorCallback callback in _onErrorCallbacks)
         {


### PR DESCRIPTION
Issue: #104

I chose to fix this in `InvokeOnError`, since it seems like all error callbacks in a JsonContract will require a non-null object.  If that's not the case, this could also be fixed by modifying JsonContract.cs:397, where the callbacks are created.
