### PR TITLE
Added support for reading multiple objects from single stream

### DIFF
--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -940,5 +940,14 @@ namespace Newtonsoft.Json
       _tokenType = JsonToken.None;
       _value = null;
     }
+
+    internal void Reset()
+    {
+      if (_currentState != State.Finished)
+        throw new InvalidOperationException();
+
+      _currentState = State.Start;
+      Read();
+    }
   }
 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -162,6 +162,8 @@ namespace Newtonsoft.Json.Serialization
           if (reader.Read() && reader.TokenType != JsonToken.Comment)
             throw new JsonSerializationException("Additional text found in JSON string after finishing deserializing object.");
         }
+        else
+          reader.Reset();
 
         return deserializedValue;
       }


### PR DESCRIPTION
[A question on SO](http://stackoverflow.com/q/18805735/41071) asked how to read multiple JSON objects from single stream. I believe JSON.NET isn't currently able to do this. And I think this is not the first time someone asked for this, so I thought implementing it could be useful.

I have made it so that this behavior is enabled when `CheckAdditionalContent` is `false`, which more or less makes sense to me. But using a new option for this would be another option.

With this change, code like this works:

```
var reader = new JsonTextReader(new StringReader(@"{ ""name"": ""bar"" }{ ""name"": ""baz"" }"));
var serializer = new JsonSerializer { CheckAdditionalContent = false };
var foo1 = serializer.Deserialize<Foo>(reader);
var foo2 = serializer.Deserialize<Foo>(reader);
```
