### PR TITLE
Include possible values when failing to convert from string to enum

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
@@ -348,12 +348,26 @@ namespace Newtonsoft.Json.Tests.Converters
       string json = "{ \"Value\" : \"Three\" }";
 
       ExceptionAssert.Throws<JsonSerializationException>(
-        @"Error converting value ""Three"" to type 'Newtonsoft.Json.Tests.Converters.StringEnumConverterTests+MyEnum'. Path 'Value', line 1, position 19.",
+        @"Error converting value ""Three"" to type 'Newtonsoft.Json.Tests.Converters.StringEnumConverterTests+MyEnum' (must be in [Alpha, Beta]). Path 'Value', line 1, position 19.",
         () =>
           {
             var serializer = new JsonSerializer();
             serializer.Converters.Add(new StringEnumConverter());
             serializer.Deserialize<Bucket>(new JsonTextReader(new StringReader(json)));
+          });
+    }
+
+    [Test]
+    public void DeserializeInvalidFlagEnum()
+    {
+      ExceptionAssert.Throws<JsonSerializationException>(
+        @"Error converting value ""NotInFlags"" to type 'Newtonsoft.Json.Tests.TestObjects.StoreColor' (must be flags in [Black, Red, Yellow, White, DarkGoldenrod]). Path 'StoreColor', line 2, position 29.",
+        () =>
+          {
+            string json = @"{
+  ""StoreColor"": ""NotInFlags""
+}";
+            JsonConvert.DeserializeObject<EnumClass>(json, new StringEnumConverter());
           });
     }
 

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -155,7 +155,12 @@ namespace Newtonsoft.Json.Converters
       }
       catch (Exception ex)
       {
-        throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}'.".FormatWith(CultureInfo.InvariantCulture, MiscellaneousUtils.FormatValueForPrint(reader.Value), objectType), ex);
+        throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}' (must be{2} in [{3}]).".FormatWith(
+          CultureInfo.InvariantCulture,
+          MiscellaneousUtils.FormatValueForPrint(reader.Value),
+          objectType,
+          EnumUtils.IsFlagsEnum(objectType) ? " flags" : null,
+          string.Join(", ", EnumUtils.GetValues(objectType))), ex);
       }
 
 

--- a/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
@@ -41,7 +41,7 @@ namespace Newtonsoft.Json.Utilities
     {
       Type enumType = typeof(T);
 
-      if (!enumType.IsDefined(typeof(FlagsAttribute), false))
+      if (!IsFlagsEnum(enumType))
         throw new ArgumentException("Enum type {0} is not a set of flags.".FormatWith(CultureInfo.InvariantCulture, enumType));
 
       Type underlyingType = Enum.GetUnderlyingType(value.GetType());
@@ -142,6 +142,11 @@ namespace Newtonsoft.Json.Utilities
       }
 
       return values;
+    }
+
+    public static bool IsFlagsEnum(Type objectType)
+    {
+      return objectType.IsDefined(typeof (FlagsAttribute), false);
     }
   }
 }


### PR DESCRIPTION
Instead of just saying "Error converting value X to type EnumType", add:

"...(must be in [Alpha, Beta])"
"...(must be flags in [Red, Blue, Green])"
