### PR TITLE
Add a property to disallow accepting of integer values.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
@@ -357,6 +357,22 @@ namespace Newtonsoft.Json.Tests.Converters
           });
     }
 
+    [Test]
+    public void DeserializeIntegerButNotAllowed()
+    {
+      string json = "{ \"Value\" : 123 }";
+
+      ExceptionAssert.Throws<JsonSerializationException>(
+        @"Integer value 123 is not allowed (AllowIntegerValues == false). Path 'Value', line 1, position 15.",
+        () =>
+        {
+          var serializer = new JsonSerializer();
+          serializer.Converters.Add(new StringEnumConverter {AllowIntegerValues = false});
+          serializer.Deserialize<Bucket>(new JsonTextReader(new StringReader(json)));
+        });
+      
+    }
+
     public class Bucket
     {
       public MyEnum Value;

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -42,6 +42,14 @@ namespace Newtonsoft.Json.Converters
   /// </summary>
   public class StringEnumConverter : JsonConverter
   {
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public StringEnumConverter()
+    {
+      AllowIntegerValues = true;
+    }
+
     private readonly Dictionary<Type, BidirectionalDictionary<string, string>> _enumMemberNamesPerType = new Dictionary<Type, BidirectionalDictionary<string, string>>();
 
     /// <summary>
@@ -49,7 +57,13 @@ namespace Newtonsoft.Json.Converters
     /// </summary>
     /// <value><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</value>
     public bool CamelCaseText { get; set; }
-    
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not integer values are allowed.
+    /// </summary>
+    /// <value><c>true</c> if integers are allowed; otherwise, <c>false</c>.</value>
+    public bool AllowIntegerValues { get; set; }
+
     /// <summary>
     /// Writes the JSON representation of the object.
     /// </summary>
@@ -119,6 +133,9 @@ namespace Newtonsoft.Json.Converters
         return null;
       }
 
+      if (!AllowIntegerValues && reader.TokenType == JsonToken.Integer)
+        throw JsonSerializationException.Create(reader, "Integer value {0} is not allowed (AllowIntegerValues == false).".FormatWith(CultureInfo.InvariantCulture, reader.Value));
+
       try
       {
         if (reader.TokenType == JsonToken.String)
@@ -158,8 +175,8 @@ namespace Newtonsoft.Json.Converters
         throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}'.".FormatWith(CultureInfo.InvariantCulture, MiscellaneousUtils.FormatValueForPrint(reader.Value), objectType), ex);
       }
 
-
-      throw JsonSerializationException.Create(reader, "Unexpected token when parsing enum. Expected String or Integer, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+      // we don't actually expect to get here.
+      throw JsonSerializationException.Create(reader, "Unexpected token ({0}) when parsing enum.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
     }
 
     private static string ResolvedEnumName(BidirectionalDictionary<string, string> map, string enumText)


### PR DESCRIPTION
Add a new property to StringEnumConverter to disallow integers.  For backward compatibility, AllowIntegerValues defaults to true.

When using WebApi, enum types are oftentimes used in contract models.  Typically, we'd do this to force the client to provide a value that falls in a set of values.  If integers are allowed, however, not only does that defeat the intended encapsulation, it also can result in errant behavior...

Example contract types:

``` C#
enum Behavior
{
  Behavior1,
  Behavior2
}

class ContractModel
{
   Behavior Behavior { get; set;}
}
```

In this example, the client can pass in { "Behavior" : 99 }.  

Json.NET defers to the .NET type system (in which enums are syntactical sugar around other integral primitives) which does not balk at this and is happy to store 99 in the target ContractModel.Behavior.

This causes unforeseen problems if there's code elsewhere like this:

``` C#
switch (_model.Behavior)
{
   case Behavior1:
     // do something
   case Behavior2:
     // do something else
   default:
      // oh no!  I'll actually get here
}
```
