### PR TITLE
Fixed #143 (JObject's implementation of ICustomTypeDescriptor.GetProperties returns incorrect property types)

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/ComponentModel/JPropertyDescriptorTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/ComponentModel/JPropertyDescriptorTests.cs
@@ -37,8 +37,8 @@ namespace Newtonsoft.Json.Tests.Linq.ComponentModel
         {
             JObject o = JObject.Parse("{prop1:'12345!',prop2:[1,'two','III']}");
 
-            JPropertyDescriptor prop1 = new JPropertyDescriptor("prop1", typeof(string));
-            JPropertyDescriptor prop2 = new JPropertyDescriptor("prop2", typeof(JArray));
+            JPropertyDescriptor prop1 = new JPropertyDescriptor("prop1");
+            JPropertyDescriptor prop2 = new JPropertyDescriptor("prop2");
 
             Assert.AreEqual("12345!", ((JValue)prop1.GetValue(o)).Value);
             Assert.AreEqual(o["prop2"], prop2.GetValue(o));
@@ -49,7 +49,7 @@ namespace Newtonsoft.Json.Tests.Linq.ComponentModel
         {
             JObject o = JObject.Parse("{prop1:'12345!'}");
 
-            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1", typeof(string));
+            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1");
 
             propertyDescriptor1.SetValue(o, "54321!");
 
@@ -61,7 +61,7 @@ namespace Newtonsoft.Json.Tests.Linq.ComponentModel
         {
             JObject o = JObject.Parse("{prop1:'12345!'}");
 
-            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1", typeof(string));
+            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1");
             propertyDescriptor1.ResetValue(o);
 
             Assert.AreEqual("12345!", (string)o["prop1"]);
@@ -70,7 +70,7 @@ namespace Newtonsoft.Json.Tests.Linq.ComponentModel
         [Test]
         public void IsReadOnly()
         {
-            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1", typeof(string));
+            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1");
 
             Assert.AreEqual(false, propertyDescriptor1.IsReadOnly);
         }
@@ -78,9 +78,9 @@ namespace Newtonsoft.Json.Tests.Linq.ComponentModel
         [Test]
         public void PropertyType()
         {
-            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1", typeof(string));
+            JPropertyDescriptor propertyDescriptor1 = new JPropertyDescriptor("prop1");
 
-            Assert.AreEqual(typeof(string), propertyDescriptor1.PropertyType);
+            Assert.AreEqual(typeof(object), propertyDescriptor1.PropertyType);
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
@@ -1694,40 +1694,26 @@ Parameter name: arrayIndex",
         [Test]
         public void GetProperties()
         {
-            JObject o = JObject.Parse("{'prop1':12,'prop2':'hi!','prop3':null,'prop4':[1,2,3]}");
+            JObject o = JObject.Parse("{'prop1':12,'prop2':'hi!'}");
 
             ICustomTypeDescriptor descriptor = o;
 
             PropertyDescriptorCollection properties = descriptor.GetProperties();
-            Assert.AreEqual(4, properties.Count);
+            Assert.AreEqual(2, properties.Count);
 
             PropertyDescriptor prop1 = properties[0];
             Assert.AreEqual("prop1", prop1.Name);
-            Assert.AreEqual(typeof(long), prop1.PropertyType);
+            Assert.AreEqual(typeof(object), prop1.PropertyType);
             Assert.AreEqual(typeof(JObject), prop1.ComponentType);
             Assert.AreEqual(false, prop1.CanResetValue(o));
             Assert.AreEqual(false, prop1.ShouldSerializeValue(o));
 
             PropertyDescriptor prop2 = properties[1];
             Assert.AreEqual("prop2", prop2.Name);
-            Assert.AreEqual(typeof(string), prop2.PropertyType);
+            Assert.AreEqual(typeof(object), prop2.PropertyType);
             Assert.AreEqual(typeof(JObject), prop2.ComponentType);
             Assert.AreEqual(false, prop2.CanResetValue(o));
             Assert.AreEqual(false, prop2.ShouldSerializeValue(o));
-
-            PropertyDescriptor prop3 = properties[2];
-            Assert.AreEqual("prop3", prop3.Name);
-            Assert.AreEqual(typeof(object), prop3.PropertyType);
-            Assert.AreEqual(typeof(JObject), prop3.ComponentType);
-            Assert.AreEqual(false, prop3.CanResetValue(o));
-            Assert.AreEqual(false, prop3.ShouldSerializeValue(o));
-
-            PropertyDescriptor prop4 = properties[3];
-            Assert.AreEqual("prop4", prop4.Name);
-            Assert.AreEqual(typeof(JArray), prop4.PropertyType);
-            Assert.AreEqual(typeof(JObject), prop4.ComponentType);
-            Assert.AreEqual(false, prop4.CanResetValue(o));
-            Assert.AreEqual(false, prop4.ShouldSerializeValue(o));
         }
 #endif
 

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -611,17 +611,6 @@ namespace Newtonsoft.Json.Linq
             return ((ICustomTypeDescriptor)this).GetProperties(null);
         }
 
-        private static Type GetTokenPropertyType(JToken token)
-        {
-            if (token is JValue)
-            {
-                JValue v = (JValue)token;
-                return (v.Value != null) ? v.Value.GetType() : typeof(object);
-            }
-
-            return token.GetType();
-        }
-
         /// <summary>
         /// Returns the properties for this instance of a component using the attribute array as a filter.
         /// </summary>
@@ -635,7 +624,7 @@ namespace Newtonsoft.Json.Linq
 
             foreach (KeyValuePair<string, JToken> propertyValue in this)
             {
-                descriptors.Add(new JPropertyDescriptor(propertyValue.Key, GetTokenPropertyType(propertyValue.Value)));
+                descriptors.Add(new JPropertyDescriptor(propertyValue.Key));
             }
 
             return descriptors;

--- a/Src/Newtonsoft.Json/Linq/JPropertyDescriptor.cs
+++ b/Src/Newtonsoft.Json/Linq/JPropertyDescriptor.cs
@@ -26,7 +26,6 @@
 #if !(NETFX_CORE || PORTABLE || PORTABLE40)
 using System;
 using System.ComponentModel;
-using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq
 {
@@ -35,20 +34,13 @@ namespace Newtonsoft.Json.Linq
     /// </summary>
     public class JPropertyDescriptor : PropertyDescriptor
     {
-        private readonly Type _propertyType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="JPropertyDescriptor"/> class.
         /// </summary>
         /// <param name="name">The name.</param>
-        /// <param name="propertyType">Type of the property.</param>
-        public JPropertyDescriptor(string name, Type propertyType)
+        public JPropertyDescriptor(string name)
             : base(name, null)
         {
-            ValidationUtils.ArgumentNotNull(name, "name");
-            ValidationUtils.ArgumentNotNull(propertyType, "propertyType");
-
-            _propertyType = propertyType;
         }
 
         private static JObject CastInstance(object instance)
@@ -149,7 +141,7 @@ namespace Newtonsoft.Json.Linq
         /// </returns>
         public override Type PropertyType
         {
-            get { return _propertyType; }
+            get { return typeof(object); }
         }
 
         /// <summary>


### PR DESCRIPTION
`PropertyDescriptor.PropertyType` must return the type of the _property_, not the type of the _current value_ (and neither the type of the _unwrapped current value_). Considering properties in `JObject` can be assigned a value of any type, the correct property type is `object`. Returning `JToken` should probably be avoided, because, in case the code checks types of values assigned to dynamic properties (these checks are present in the framework, for example in WPF bindings), this will limit already provided functionality (wrapping in `JValue`).

**Implementation details:** removed `_propertyType` field from `JPropertyDescriptor`, removed all code which became redundant as a result. Argument check removed from the constructor, because it is already present in the base type.

**Possible backwards compatibility issues:** if someone manually calls methods of `ICustomTypeDescriptor` interface on `JObject` values and expects properties to return types of the current values, this code may be broken. However, this behavior is incorrect and must not be expected from any dynamic type descriptors. Workaround: get values after getting properties, check their types.
