### PR TITLE
Allow the Binder to omit the $type property by returning null.

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -494,6 +494,9 @@ namespace Newtonsoft.Json.Serialization
         {
             string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormat, Serializer._binder);
 
+            if (string.IsNullOrEmpty(typeName))
+                return;
+
             if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
 


### PR DESCRIPTION
This allows full control over the "$type" property, a feature that has been sorely missed.
