### PR TITLE
Patching override for BigInteger parse to use without cultureinfo

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -1268,7 +1268,7 @@ namespace Newtonsoft.Json
                     {
 #if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
                         string number = _stringReference.ToString();
-                        numberValue = BigInteger.Parse(number, CultureInfo.InvariantCulture);
+                        numberValue = BigInteger.Parse(number);
                         numberType = JsonToken.Integer;
 #else
     // todo - validate number was a valid integer to make sure overflow was the reason for failure


### PR DESCRIPTION
This overload is not implemented in Mono. While the other options such as the compiler time variables avoid this altogether, these lines of code are not avoided in mono. As a result, I've just removed the overload so it can be called with success in mono.
