### PR TITLE
Throwing previously masked exception.

### DIFF
--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -173,6 +173,10 @@ namespace Newtonsoft.Json.Converters
                     return ConvertUtils.ConvertOrCast(reader.Value, CultureInfo.InvariantCulture, t);
                 }
             }
+            catch (JsonSerializationException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}'.".FormatWith(CultureInfo.InvariantCulture, MiscellaneousUtils.FormatValueForPrint(reader.Value), objectType), ex);


### PR DESCRIPTION
The exception JsonSerializationException.Create(reader, "Integer value {0} is not allowed." is masked by catch (Exception ex).
In this way we allow that original exception is just re thrown.
