### PR TITLE
Added IgnoreDataContractAttribute in DefaultContractResolver

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -173,6 +173,11 @@ namespace Newtonsoft.Json.Serialization
         /// 	<c>true</c> if the <see cref="SerializableAttribute"/> attribute will be ignored when serializing and deserializing types; otherwise, <c>false</c>.
         /// </value>
         public bool IgnoreSerializableAttribute { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore the <see cref="DataContractAttribute"/> attribute when serializing and deserializing types.
+        /// </summary>
+        public bool IgnoreDataContractAttribute { get; set; }
 #endif
 
         /// <summary>
@@ -270,7 +275,7 @@ namespace Newtonsoft.Json.Serialization
             ignoreSerializableAttribute = true;
 #endif
 
-            MemberSerialization memberSerialization = JsonTypeReflector.GetObjectMemberSerialization(objectType, ignoreSerializableAttribute);
+            MemberSerialization memberSerialization = JsonTypeReflector.GetObjectMemberSerialization(objectType, ignoreSerializableAttribute,IgnoreDataContractAttribute);
 
             List<MemberInfo> allMembers = ReflectionUtils.GetFieldsAndProperties(objectType, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
                 .Where(m => !ReflectionUtils.IsIndexedProperty(m)).ToList();
@@ -366,7 +371,7 @@ namespace Newtonsoft.Json.Serialization
             ignoreSerializableAttribute = true;
 #endif
 
-            contract.MemberSerialization = JsonTypeReflector.GetObjectMemberSerialization(contract.NonNullableUnderlyingType, ignoreSerializableAttribute);
+            contract.MemberSerialization = JsonTypeReflector.GetObjectMemberSerialization(contract.NonNullableUnderlyingType, ignoreSerializableAttribute, IgnoreDataContractAttribute);
             contract.Properties.AddRange(CreateProperties(contract.NonNullableUnderlyingType, contract.MemberSerialization));
 
             JsonObjectAttribute attribute = JsonTypeReflector.GetJsonObjectAttribute(contract.NonNullableUnderlyingType);

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -149,16 +149,19 @@ namespace Newtonsoft.Json.Serialization
         }
 #endif
 
-        public static MemberSerialization GetObjectMemberSerialization(Type objectType, bool ignoreSerializableAttribute)
+        public static MemberSerialization GetObjectMemberSerialization(Type objectType, bool ignoreSerializableAttribute, bool ignoreDataContractAttribute)
         {
             JsonObjectAttribute objectAttribute = GetJsonObjectAttribute(objectType);
             if (objectAttribute != null)
                 return objectAttribute.MemberSerialization;
 
 #if !NET20
-            DataContractAttribute dataContractAttribute = GetDataContractAttribute(objectType);
-            if (dataContractAttribute != null)
-                return MemberSerialization.OptIn;
+            if (!ignoreDataContractAttribute)
+            {
+                DataContractAttribute dataContractAttribute = GetDataContractAttribute(objectType);
+                if (dataContractAttribute != null)
+                    return MemberSerialization.OptIn;
+            }
 #endif
 
 #if !(NETFX_CORE || PORTABLE40 || PORTABLE)


### PR DESCRIPTION
It is useful when you want to serialize data and ignore DataContractAttribute, or you don't have access to source code.
In my case I need to store data to Redis and keep data intact.
