### PR TITLE
Allow ExpandoObjectConverter under Portable40 platform

### DIFF
--- a/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET35 || NET20 || PORTABLE)
+#if !(NET35 || NET20)
 
 using System;
 using System.Collections.Generic;

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -29,7 +29,7 @@ using System.Globalization;
 #if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
 using System.Numerics;
 #endif
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
 using System.Threading.Tasks;
 #endif
 using Newtonsoft.Json.Linq;
@@ -633,7 +633,7 @@ namespace Newtonsoft.Json
             return sw.ToString();
         }
 
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
         /// <summary>
         /// Asynchronously serializes the specified object to a JSON string.
         /// Serialization will happen on a new thread.
@@ -831,7 +831,7 @@ namespace Newtonsoft.Json
             }
         }
 
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
         /// <summary>
         /// Asynchronously deserializes the JSON to the specified .NET type.
         /// Deserialization will happen on a new thread.
@@ -929,7 +929,7 @@ namespace Newtonsoft.Json
             }
         }
 
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
         /// <summary>
         /// Asynchronously populates the object with values from the JSON string using <see cref="JsonSerializerSettings"/>.
         /// </summary>

--- a/Src/Newtonsoft.Json/Linq/IJEnumerable.cs
+++ b/Src/Newtonsoft.Json/Linq/IJEnumerable.cs
@@ -32,7 +32,7 @@ namespace Newtonsoft.Json.Linq
     /// </summary>
     /// <typeparam name="T">The type of token</typeparam>
     public interface IJEnumerable<
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
         out
 #endif
             T> : IEnumerable<T> where T : JToken

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -30,7 +30,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 #endif
 using System.ComponentModel;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.Dynamic;
 using System.Linq.Expressions;
 #endif
@@ -747,7 +747,7 @@ namespace Newtonsoft.Json.Linq
 
 #endif
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         /// <summary>
         /// Returns the <see cref="T:System.Dynamic.DynamicMetaObject"/> responsible for binding operations performed on this object.
         /// </summary>

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -26,7 +26,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq.JsonPath;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.Dynamic;
 using System.Linq.Expressions;
 #endif
@@ -55,7 +55,7 @@ namespace Newtonsoft.Json.Linq
 #if !(NETFX_CORE || PORTABLE40 || PORTABLE)
         , ICloneable
 #endif
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         , IDynamicMetaObjectProvider
 #endif
     {
@@ -1971,7 +1971,7 @@ namespace Newtonsoft.Json.Linq
             return p.Evaluate(this, errorWhenNoMatch);
         }
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         /// <summary>
         /// Returns the <see cref="T:System.Dynamic.DynamicMetaObject"/> responsible for binding operations performed on this object.
         /// </summary>

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -27,7 +27,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Utilities;
 using System.Globalization;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.Dynamic;
 using System.Linq.Expressions;
 #endif
@@ -368,7 +368,7 @@ namespace Newtonsoft.Json.Linq
             return d1.CompareTo(d2);
         }
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         private static bool Operation(ExpressionType operation, object objA, object objB, out object result)
         {
             if (objA is string || objB is string)
@@ -823,7 +823,7 @@ namespace Newtonsoft.Json.Linq
                 return _value.ToString();
         }
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         /// <summary>
         /// Returns the <see cref="T:System.Dynamic.DynamicMetaObject"/> responsible for binding operations performed on this object.
         /// </summary>

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
@@ -336,7 +336,7 @@ namespace Newtonsoft.Json.Schema
                         GenerateISerializableContract(type, (JsonISerializableContract)contract);
                         break;
 #endif
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                     case JsonContractType.Dynamic:
 #endif
                     case JsonContractType.Linq:

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -30,7 +30,7 @@ using System.Collections.Concurrent;
 #endif
 using System.Collections.Generic;
 using System.ComponentModel;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.Dynamic;
 #endif
 using System.Globalization;
@@ -100,7 +100,7 @@ namespace Newtonsoft.Json.Serialization
 #if !(NET20 || NETFX_CORE || PORTABLE40 || PORTABLE)
             new EntityKeyMemberConverter(),
 #endif
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
             new ExpandoObjectConverter(),
 #endif
 #if !(PORTABLE40)
@@ -904,7 +904,7 @@ namespace Newtonsoft.Json.Serialization
         }
 #endif
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         /// <summary>
         /// Creates a <see cref="JsonDynamicContract"/> for the given type.
         /// </summary>
@@ -973,7 +973,7 @@ namespace Newtonsoft.Json.Serialization
                 return CreateISerializableContract(objectType);
 #endif
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(t))
                 return CreateDynamicContract(objectType);
 #endif

--- a/Src/Newtonsoft.Json/Serialization/JsonArrayContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonArrayContract.cs
@@ -115,7 +115,7 @@ namespace Newtonsoft.Json.Serialization
                     || ReflectionUtils.IsGenericDefinition(underlyingType, typeof(IList<>)))
                     CreatedType = typeof(List<>).MakeGenericType(CollectionItemType);
 
-#if !(NET20 || NET35 || PORTABLE40)
+#if !(NET20 || NET35)
                 if (ReflectionUtils.IsGenericDefinition(underlyingType, typeof(ISet<>)))
                     CreatedType = typeof(HashSet<>).MakeGenericType(CollectionItemType);
 #endif

--- a/Src/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -41,7 +41,7 @@ namespace Newtonsoft.Json.Serialization
         Primitive,
         String,
         Dictionary,
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         Dynamic,
 #endif
 #if !(NETFX_CORE || PORTABLE || PORTABLE40)

--- a/Src/Newtonsoft.Json/Serialization/JsonDynamicContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonDynamicContract.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -27,7 +27,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.ComponentModel;
 using System.Dynamic;
 #endif
@@ -310,7 +310,7 @@ namespace Newtonsoft.Json.Serialization
 #if !(NETFX_CORE || PORTABLE || PORTABLE40)
                 case JsonContractType.Serializable:
 #endif
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                 case JsonContractType.Dynamic:
 #endif
                     return @"JSON object (e.g. {""name"":""value""})";
@@ -456,7 +456,7 @@ namespace Newtonsoft.Json.Serialization
 
                     return targetDictionary;
                 }
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                 case JsonContractType.Dynamic:
                     JsonDynamicContract dynamicContract = (JsonDynamicContract)contract;
                     return CreateDynamic(reader, dynamicContract, member, id);
@@ -553,7 +553,7 @@ To fix this error either change the JSON to a {1} or change the deserialized typ
                                     TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Resolved type '{0}' to {1}.".FormatWith(CultureInfo.InvariantCulture, qualifiedTypeName, specifiedType)), null);
 
                                 if (objectType != null
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                                     && objectType != typeof(IDynamicMetaObjectProvider)
 #endif
                                     && !objectType.IsAssignableFrom(specifiedType))
@@ -689,7 +689,7 @@ To fix this error either change the JSON to a {1} or change the deserialized typ
         private bool HasNoDefinedType(JsonContract contract)
         {
             return (contract == null || contract.UnderlyingType == typeof(object) || contract.ContractType == JsonContractType.Linq
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                     || contract.UnderlyingType == typeof(IDynamicMetaObjectProvider)
 #endif
                 );
@@ -1356,7 +1356,7 @@ To fix this error either change the environment to be fully trusted, change the 
         }
 #endif
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         private object CreateDynamic(JsonReader reader, JsonDynamicContract contract, JsonProperty member, string id)
         {
             IDynamicMetaObjectProvider newObject;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -27,7 +27,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System.Dynamic;
 #endif
 using System.Diagnostics;
@@ -170,7 +170,7 @@ namespace Newtonsoft.Json.Serialization
                     JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)valueContract;
                     SerializeDictionary(writer, (value is IDictionary) ? (IDictionary)value : dictionaryContract.CreateWrapper(value), dictionaryContract, member, containerContract, containerProperty);
                     break;
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
                 case JsonContractType.Dynamic:
                     SerializeDynamic(writer, (IDynamicMetaObjectProvider)value, (JsonDynamicContract)valueContract, member, containerContract, containerProperty);
                     break;
@@ -756,7 +756,7 @@ To fix this error either change the environment to be fully trusted, change the 
         }
 #endif
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
         private void SerializeDynamic(JsonWriter writer, IDynamicMetaObjectProvider value, JsonDynamicContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
         {
             OnSerializing(writer, contract, value);

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -383,7 +383,7 @@ namespace Newtonsoft.Json.Serialization
                 {
 #if (NETFX_CORE || PORTABLE || PORTABLE40)
                     _fullyTrusted = false;
-#elif !(NET20 || NET35 || PORTABLE40)
+#elif !(NET20 || NET35)
                     AppDomain appDomain = AppDomain.CurrentDomain;
 
                     _fullyTrusted = appDomain.IsHomogenous && appDomain.IsFullyTrusted;

--- a/Src/Newtonsoft.Json/Utilities/DynamicProxy.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicProxy.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System;
 using System.Collections.Generic;
 using System.Dynamic;

--- a/Src/Newtonsoft.Json/Utilities/DynamicUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicUtils.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET35 || NET20 || PORTABLE40)
+#if !(NET35 || NET20)
 using System;
 using System.Collections.Generic;
 using System.Dynamic;


### PR DESCRIPTION
This seems to build successfully, so I'm guessing the check was meant to exclude PORTABLE not PORTABLE40
