### PR TITLE
Add schema properties title and description to JsonPropertyAttribute

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
@@ -800,6 +800,33 @@ namespace Newtonsoft.Json.Tests.Schema
   }
 }", json);
         }
+
+        public class Z
+        {
+            [JsonProperty(Title = "title", Description = "description")]
+            public int z;
+        }
+
+        [Test]
+        public void GenerateSchemaForPropertyWithTitleAndDescription()
+        {
+            JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator();
+            JsonSchema schema = jsonSchemaGenerator.Generate(typeof(Z));
+
+            string json = schema.ToString();
+
+            Assert.AreEqual(@"{
+  ""type"": ""object"",
+  ""properties"": {
+    ""z"": {
+      ""title"": ""title"",
+      ""description"": ""description"",
+      ""required"": true,
+      ""type"": ""integer""
+    }
+  }
+}", json);
+        }
     }
 
     public class NullableInt32TestClass

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -172,6 +172,18 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Gets or sets the title.
+        /// </summary>
+        /// <value>The title.</value>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        /// <value>The description.</value>
+        public string Description { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonPropertyAttribute"/> class.
         /// </summary>
         public JsonPropertyAttribute()

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
@@ -377,6 +377,12 @@ namespace Newtonsoft.Json.Schema
 
                     JsonSchema propertySchema = GenerateInternal(property.PropertyType, property.Required, !optional);
 
+                    if (property.Title != null)
+                        propertySchema.Title = property.Title;
+
+                    if (property.Description != null)
+                        propertySchema.Description = property.Description;
+
                     if (property.DefaultValue != null)
                         propertySchema.Default = JToken.FromObject(property.DefaultValue);
 

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1191,6 +1191,8 @@ namespace Newtonsoft.Json.Serialization
                 property._required = propertyAttribute._required;
                 property.Order = propertyAttribute._order;
                 property.DefaultValueHandling = propertyAttribute._defaultValueHandling;
+                property.Title = propertyAttribute.Title;
+                property.Description = propertyAttribute.Description;
                 hasMemberAttribute = true;
             }
 #if !NET20

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -271,6 +271,18 @@ namespace Newtonsoft.Json.Serialization
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }
 
+        /// <summary>
+        /// Gets or sets the title.
+        /// </summary>
+        /// <value>The title.</value>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        /// <value>The description.</value>
+        public string Description { get; set; }
+
         internal void WritePropertyName(JsonWriter writer)
         {
             if (_skipPropertyNameEscape)


### PR DESCRIPTION
Allow specifying the JSON Schema properties Title and Description
per-property using the JsonPropertyAttribute. Properly add those in
JsonSchemaGenerator and add a unit test for said behaviour.
