### PR TITLE
adding support for remote schema urls

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -363,6 +363,9 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="packages.config" />
+    <Content Include="remoteSchema.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Schema\Specs\additionalItems.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -438,6 +441,7 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{3259AA49-8AA1-44D3-9025-A0B520596A8C}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Newtonsoft.Json\Newtonsoft.Json.csproj">

--- a/Src/Newtonsoft.Json.Tests/remoteSchema.json
+++ b/Src/Newtonsoft.Json.Tests/remoteSchema.json
@@ -1,0 +1,7 @@
+﻿{
+	'properties': {
+		'jedis': {
+			'enum': ['luke', 'obi-wan', 'yoda']
+		}
+	}
+}

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
@@ -133,6 +133,11 @@ namespace Newtonsoft.Json.Schema
                         if (currentToken != null)
                             resolvedSchema = BuildSchema(currentToken);
                     }
+                    else
+                    {
+                        string remoteSchema = new System.Net.WebClient().DownloadString(schema.DeferredReference);
+                        resolvedSchema = JsonSchema.Parse(remoteSchema);
+                    }
 
                     if (resolvedSchema == null)
                         throw new JsonException("Could not resolve schema reference '{0}'.".FormatWith(CultureInfo.InvariantCulture, schema.DeferredReference));


### PR DESCRIPTION
Adding a schema with a $ref element that is a URL throws an exception, this adds support for that
