### PR TITLE
null check if value is null before trying to convert into jtoken

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -92,6 +92,29 @@ namespace Newtonsoft.Json.Tests.Serialization
     [TestFixture]
     public class JsonSerializerTest : TestFixtureBase
     {
+
+        [Test]
+        public void ExtensionDataWithNull()
+        {
+            string json = @"{
+            'TaxRate': 0.125,
+            'a':null
+            }";
+
+            var invoice = JsonConvert.DeserializeObject<ExtendedObject>(json);
+
+            string result = JsonConvert.SerializeObject(invoice);
+
+            Assert.AreEqual(@"{""TaxRate"":0.125,""a"":null}", result);
+        }
+
+
+        class ExtendedObject
+        {
+            [JsonExtensionData]
+            private IDictionary<string, JToken> _additionalData;
+        }
+
         public class GenericItem<T>
         {
             public T Value { get; set; }

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -482,7 +482,7 @@ namespace Newtonsoft.Json.Serialization
 
                 // convert object value to JToken so it is compatible with dictionary
                 // could happen because of primitive types, type name handling and references
-                if (isJTokenValueType && !(value is JToken))
+                if (isJTokenValueType && !(value is JToken) && value!=null)
                     value = JToken.FromObject(value);
 
                 setExtensionDataDictionaryValue(dictionary, key, value);


### PR DESCRIPTION
consider the following test:

``` c#
        [Test]
        public void ExtensionDataWithNullValueProperty()
        {
            string json = @"{
            'TaxRate': 0.125,
            'a':null
            }";

            var invoice = JsonConvert.DeserializeObject<ExtendedObject>(json);

            string result = JsonConvert.SerializeObject(invoice);

            Assert.AreEqual(@"{""TaxRate"":0.125,""a"":null}", result);
        }

        class ExtendedObject
        {
            [JsonExtensionData]
            private IDictionary<string, JToken> _additionalData;
        }
```

the code throws argument null exception from jtoken.fromobject
the issue resides in DefaultContractResolver line 485 where the check does not include a check if the value is null.

adding that null check resolves the failing tests, and seralization for such cases no longer throws argumentnullexception
