### PR TITLE
BUGFIX - Reference loop checking (check reference, not equality)

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
@@ -56,6 +56,23 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
+        public void HandleObjectReferenceLoopBadEquality()
+        {
+            ReferenceLoopHandlingObjectBadEquality o = new ReferenceLoopHandlingObjectBadEquality();
+            o.Value = new ReferenceLoopHandlingObjectBadEquality();
+
+            string json = JsonConvert.SerializeObject(o, Formatting.Indented, new JsonSerializerSettings
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Error
+            });
+            Assert.AreEqual(@"{
+  ""Value"": {
+    ""Value"": null
+  }
+}", json);
+        }
+
+        [Test]
         public void IgnoreObjectReferenceLoop()
         {
             ReferenceLoopHandlingObjectContainerAttribute o = new ReferenceLoopHandlingObjectContainerAttribute();
@@ -304,6 +321,22 @@ namespace Newtonsoft.Json.Tests.Serialization
     [JsonDictionary(ItemReferenceLoopHandling = ReferenceLoopHandling.Ignore)]
     public class ReferenceLoopHandlingDictionary : Dictionary<string, ReferenceLoopHandlingDictionary>
     {
+    }
+
+    [JsonObject(ItemReferenceLoopHandling = ReferenceLoopHandling.Error)]
+    public class ReferenceLoopHandlingObjectBadEquality
+    {
+        public override bool Equals(object obj)
+        {
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return 0;
+        }
+
+        public ReferenceLoopHandlingObjectBadEquality Value { get; set; }
     }
 
     [JsonObject(ItemReferenceLoopHandling = ReferenceLoopHandling.Ignore)]

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -264,7 +264,7 @@ namespace Newtonsoft.Json.Serialization
             if (referenceLoopHandling == null && containerContract != null)
                 referenceLoopHandling = containerContract.ItemReferenceLoopHandling;
 
-            if (_serializeStack.IndexOf(value) != -1)
+            if (_serializeStack.IndexOf(o => ReferenceEquals(o,value)) != -1)
             {
                 string message = "Self referencing loop detected";
                 if (property != null)


### PR DESCRIPTION
Reference loop checking's use of List<T>.IndexOf() performs an equality comparison, and not a reference comparison. 

Serializing object hierarchies with custom Object.Equals() overrides may falsely trigger reference loop exceptions.

Proposed fix attached.
