### PR TITLE
Fix Bug in case xml children have namespace but not have data

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
@@ -1928,6 +1928,24 @@ namespace Newtonsoft.Json.Tests.Converters
             var equals = XElement.DeepEquals(xmlBack, xml);
             Assert.IsTrue(equals);
         }
+
+        [Test]
+        public void SerializeAndDeserializeXmlWithNamespaceInChildrenAndNoValueInChildren()
+        {
+            var xmlString = @"<root>
+                              <b xmlns='http://www.example.com/ns'/>
+                              <c>AAA</c>
+                              <test>adad</test>
+                              </root>";
+
+            var xml = XElement.Parse(xmlString);
+
+            var json1 = JsonConvert.SerializeXNode(xml);
+            var xmlBack = JsonConvert.DeserializeObject<XElement>(json1);
+
+            var equals = XElement.DeepEquals(xmlBack, xml);
+            Assert.IsTrue(equals);
+        }
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1234,8 +1234,9 @@ namespace Newtonsoft.Json.Converters
                         manager.PushScope();
                         DeserializeNode(reader, document, manager, element);
                         manager.PopScope();
-                        manager.RemoveNamespace(string.Empty, manager.DefaultNamespace);
                     }
+
+                    manager.RemoveNamespace(string.Empty, manager.DefaultNamespace);
                 }
             }
         }


### PR DESCRIPTION
Hi,
I found an another issue when you try to serialize and deserialize an XML that 
don't have namespace in root, and one of children have a namespace but don't have a value.
in example if you have an XML like this
![image](https://f.cloud.github.com/assets/4958307/2240834/9e72661a-9cb0-11e3-8076-52bc85548cfd.png)

it will be deserialized to that thing:
![image](https://f.cloud.github.com/assets/4958307/2240836/bfd45c28-9cb0-11e3-9e0c-b6897662b5e4.png)

I fix this issue by chnaging the line that remove namespace after push scope, in XMLNodeConverter.

I write a test that fail, and after fix pass.
All other test pass too.
Thanks to accepts this request.

Ygal
