### PR TITLE
Fix a bug where certain JSON path expressions would spuriously fail.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathExecuteTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathExecuteTests.cs
@@ -273,6 +273,16 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
         }
 
         [Test]
+        public void EvaluatePropertyWithoutError()
+        {
+            JObject o = new JObject(
+                new JProperty("Blah", 1));
+
+            JValue v = (JValue)o.SelectToken("Blah", true);
+            Assert.AreEqual(1L, v.Value);
+        }
+
+        [Test]
         public void EvaluateMissingPropertyIndexWithError()
         {
             JObject o = new JObject(

--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
@@ -21,8 +21,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
 
                         if (v != null)
                             yield return v;
-
-                        if (errorWhenNoMatch)
+                        else if (errorWhenNoMatch)
                             throw new JsonException("Property '{0}' does not exist on JObject.".FormatWith(CultureInfo.InvariantCulture, Name));
                     }
                     else


### PR DESCRIPTION
Hi,

There seems to be an error with the way `FieldFilter` handles `errorsWhenNoMatch`. The branch throwing the exception is taken even though a match is found.
