### PR TITLE
Fix Json.Net Portable NuGet when targeting Xamarin in PCLs

### DIFF
--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -20,6 +20,7 @@
     @{Name = "Newtonsoft.Json"; TestsName = "Newtonsoft.Json.Tests"; Constants=""; FinalDir="Net45"; NuGetDir = "net45"; Framework="net-4.0"; Sign=$true},
     @{Name = "Newtonsoft.Json.Portable"; TestsName = "Newtonsoft.Json.Tests.Portable"; Constants="PORTABLE"; FinalDir="Portable"; NuGetDir = "portable-net45+wp80+win8"; Framework="net-4.0"; Sign=$true},
     @{Name = "Newtonsoft.Json.Portable40"; TestsName = "Newtonsoft.Json.Tests.Portable40"; Constants="PORTABLE40"; FinalDir="Portable40"; NuGetDir = "portable-net40+sl5+wp80+win8+monotouch+monoandroid"; Framework="net-4.0"; Sign=$true},
+    @{Name = "Newtonsoft.Json.Portable40"; TestsName = "Newtonsoft.Json.Tests.Portable40"; Constants="PORTABLE40"; FinalDir="Portable45Mono"; NuGetDir = "portable-net45+wp80+win8+monotouch+monoandroid"; Framework="net-4.0"; Sign=$true},
     @{Name = "Newtonsoft.Json.WinRT"; TestsName = $null; Constants="NETFX_CORE"; FinalDir="WinRT"; NuGetDir = "netcore45"; Framework="net-4.5"; Sign=$true},
     @{Name = "Newtonsoft.Json.Net40"; TestsName = "Newtonsoft.Json.Tests.Net40"; Constants="NET40"; FinalDir="Net40"; NuGetDir = "net40"; Framework="net-4.0"; Sign=$true},
     @{Name = "Newtonsoft.Json.Net35"; TestsName = "Newtonsoft.Json.Tests.Net35"; Constants="NET35"; FinalDir="Net35"; NuGetDir = "net35"; Framework="net-2.0"; Sign=$true},


### PR DESCRIPTION
The issue here is that the .NET 4.5 version is not compatible with
Profile 78 when Xamarin.iOS is selected. This is because
System.Runtime.Dynamic is not available on iOS. The work around to get
this working correctly is to build the Portable40 version and put this
in portable-net45+wp80+win8+monotouch+monoandroid. If the user has
xamarin installed it will pull from this directory when monotouch or
mono android are selected, else it will install the standard Portable
like it always has.
