### PR TITLE
Ensure JsonConverter associated with root object $type is used during deserialization.

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -406,6 +406,11 @@ namespace Newtonsoft.Json.Serialization
             {
                 case JsonContractType.Object:
                 {
+                    var converter = GetConverter(contract, null, null, null);
+                    if (converter != null && converter.CanRead)
+                        return DeserializeConvertable(converter, reader, objectType, existingValue);
+
+
                     bool createdFromNonDefaultConstructor = false;
                     JsonObjectContract objectContract = (JsonObjectContract)contract;
                     object targetObject;


### PR DESCRIPTION
Fixes #243 

When deserializing an object of unknown type (i.e., `serializer.Deserialize<Object>(jsonWriter);`) and the root object specifies a `$type`, ensure any registered JsonConverter is used for deserialization.

Full description in Issue #243.
