### PR TITLE
Added Universal App support for Newtonsoft.Json.Portable40.csproj

### DIFF
--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Portable40.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Portable40.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Newtonsoft.Json</RootNamespace>
     <AssemblyName>Newtonsoft.Json</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
I modified Newtonsoft.Json.Portable40.csproj so that other libs using Newtonsoft.Json can be included with universal apps while also supporting older versions of .NET
