### PR TITLE
CRLFs and Newline

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -266,7 +266,7 @@ namespace Newtonsoft.Json
         /// </summary>
         protected override void WriteIndent()
         {
-            _writer.Write(Environment.NewLine);
+            _writer.WriteLine();
 
             // levels of indentation multiplied by the indent count
             int currentIndentCount = Top * _indentation;


### PR DESCRIPTION
Use the the under laying writer to write new lines as opposed to
Environment.NewLine which is global.
