### PR TITLE
Brackets have no case.

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JTokenReader.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenReader.cs
@@ -341,8 +341,8 @@ namespace Newtonsoft.Json.Linq
                     if (string.IsNullOrEmpty(path))
                         return _initialPath;
 
-                    if (_initialPath.EndsWith("]", StringComparison.OrdinalIgnoreCase)
-                        || path.StartsWith("[", StringComparison.OrdinalIgnoreCase))
+                    if (_initialPath.EndsWith("]", StringComparison.Ordinal)
+                        || path.StartsWith("[", StringComparison.Ordinal))
                         path = _initialPath + path;
                     else
                         path = _initialPath + "." + path;


### PR DESCRIPTION
Swapped in StringComparison.Ordinal for the literal comparison against [ and ] since those are non-caseable. This is a micro-improvement, but still good practice.
