### PR TITLE
Octathorpes have no case.

### DIFF
--- a/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
@@ -98,7 +98,7 @@ namespace Newtonsoft.Json.Schema
             {
                 string reference = schema.DeferredReference;
 
-                bool locationReference = (reference.StartsWith("#", StringComparison.OrdinalIgnoreCase));
+                bool locationReference = (reference.StartsWith("#", StringComparison.Ordinal));
                 if (locationReference)
                     reference = UnescapeReference(reference);
 


### PR DESCRIPTION
Swapped in StringComparison.Ordinal for the literal comparison against # since those are non-caseable. This is a micro-improvement, but still good practice.
