### PR TITLE
At Signs have no case.

### DIFF
--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1349,7 +1349,7 @@ namespace Newtonsoft.Json.Converters
 
             string elementPrefix = MiscellaneousUtils.GetPrefix(propertyName);
 
-            if (propertyName.StartsWith("@"))
+            if (propertyName.StartsWith("@", StringComparison.Ordinal))
             {
                 string attributeName = propertyName.Substring(1);
                 string attributeValue = reader.Value.ToString();


### PR DESCRIPTION
Swapped in StringComparison.Ordinal for the literal comparison against @ since those are non-caseable. This is a micro-improvement, but still good practice.
