### PR TITLE
Periods have no case.

### DIFF
--- a/Src/Newtonsoft.Json/JsonPosition.cs
+++ b/Src/Newtonsoft.Json/JsonPosition.cs
@@ -96,7 +96,7 @@ namespace Newtonsoft.Json
             {
                 message = message.Trim();
 
-                if (!message.EndsWith("."))
+                if (!message.EndsWith(".", StringComparison.Ordinal))
                     message += ".";
 
                 message += " ";


### PR DESCRIPTION
Swapped in StringComparison.Ordinal for the literal comparison against . since those are non-caseable. This is a micro-improvement, but still good practice.
