### PR TITLE
Adhere property ordering to datamember order rules.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -5569,13 +5569,13 @@ To fix this error either change the environment to be fully trusted, change the 
             string json = JsonConvert.SerializeObject(d, Formatting.Indented);
 
             Assert.AreEqual(@"{
-  ""dinosaur"": null,
-  ""dog"": null,
-  ""cat"": null,
   ""zebra"": null,
+  ""dinosaur"": null,
+  ""cat"": null,
+  ""dog"": null,
   ""bird"": null,
-  ""parrot"": null,
   ""albatross"": null,
+  ""parrot"": null,
   ""antelope"": null
 }", json);
         }

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -271,6 +271,14 @@ namespace Newtonsoft.Json.Serialization
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }
 
+        /// <summary>
+        /// Gets or sets the level within the inheritance hierarchy, based on the reflected and declaring types.
+        /// If the property is declared by the reflected type, the level will be 0.
+        /// A level of n indicates that the property was declared by the n-th base class of the reflected type.
+        /// </summary>
+        /// <value>The inheritance hierarchy level of this property.</value>
+        public int InheritanceHierarchyLevel { get; set; }
+
         internal void WritePropertyName(JsonWriter writer)
         {
             if (_skipPropertyNameEscape)


### PR DESCRIPTION
The basic rules for data ordering include:
- If a data contract type is a part of an inheritance hierarchy, data members of its base types are always first in the order.
- Next in order are the current type’s data members that do not have the Order property of the DataMemberAttribute attribute set, in alphabetical order.
- Next are any data members that have the Order property of the DataMemberAttribute attribute set. These are ordered by the value of the Order property first and then alphabetically if there is more than one member of a certain Order value. Order values may be skipped.

source:
http://msdn.microsoft.com/en-us/library/ms729813(v=vs.110).aspx
