### PR TITLE
Limited integer parsing to javascript integer size.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -995,6 +995,18 @@ now brown cow?", '"', true);
             Assert.AreEqual("Bad Boys", m.Name);
         }
 
+        [Test]
+        public void IntegerLengthOverflows()
+        {
+            // Maximum javascript number length (in characters) is 380
+
+            dynamic d = JObject.Parse(@"{""biginteger"":" + new String('9', 380) + "}");
+
+            ExceptionAssert.Throws<JsonReaderException>(
+                "JSON integer " + new String('9', 381) + " is too large to parse. Path 'biginteger', line 1, position 395.",
+                () => JObject.Parse(@"{""biginteger"":" + new String('9', 381) + "}"));
+        }
+
         //[Test]
         public void StackOverflowTest()
         {

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -57,6 +57,8 @@ namespace Newtonsoft.Json
     {
         private const char UnicodeReplacementChar = '\uFFFD';
 
+        private const int MaximumJavascriptIntegerLengthInCharacters = 380;
+
         private readonly TextReader _reader;
         private char[] _chars;
         private int _charsUsed;
@@ -1268,6 +1270,10 @@ namespace Newtonsoft.Json
                     {
 #if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
                         string number = _stringReference.ToString();
+                        if (number.Length > MaximumJavascriptIntegerLengthInCharacters)
+                            throw JsonReaderException.Create(this, "JSON integer {0} is too large to parse.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+
+                        
                         numberValue = BigInteger.Parse(number, CultureInfo.InvariantCulture);
                         numberType = JsonToken.Integer;
 #else


### PR DESCRIPTION
Javascript has a maximum size on integers, there's no need to attempt to convert integers once they get above that size (in characters), so don't.
