### PR TITLE
Added DictionaryConverter

### DIFF
--- a/Src/Newtonsoft.Json/Converters/DictionaryConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DictionaryConverter.cs
@@ -47,7 +47,7 @@ namespace Newtonsoft.Json.Converters
                 case JsonToken.StartObject:
                     return ReadObject(reader);
                 case JsonToken.StartArray:
-                    return ReadArray(reader);
+                    return ReadList(reader);
                 default:
                     if (JsonReader.IsPrimitiveToken(reader.TokenType))
                         return reader.Value;
@@ -56,7 +56,7 @@ namespace Newtonsoft.Json.Converters
             }
         }
 
-        private object ReadArray(JsonReader reader)
+        private object ReadList(JsonReader reader)
         {
             List<object> list = new List<object>();
 
@@ -72,7 +72,7 @@ namespace Newtonsoft.Json.Converters
                         list.Add(v);
                         break;
                     case JsonToken.EndArray:
-                        return list.ToArray();
+                        return list;
                 }
             }
 


### PR DESCRIPTION
This converter, which is not used by default (not in DefaultContractResolver), converts JSON to Dictionary<string, object> recursively. So any JSON dictionary gets converted to Dictionary<string, object>, and any JSON array to object[].

Such dictionary fulfills popular demand to deserialize JSON to simple dictionary/array, for example requested at http://stackoverflow.com/questions/1207731/how-can-i-deserialize-json-to-a-simple-dictionarystring-string-in-asp-net/23867458
