### PR TITLE
fix compile error under Mono 3.6.1

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -141,7 +141,7 @@ namespace Newtonsoft.Json.Serialization
                 return;
             }
 
-            JsonConverter converter;
+            JsonConverter converter = null;
             if ((((converter = (member != null) ? member.Converter : null) != null)
                  || ((converter = (containerProperty != null) ? containerProperty.ItemConverter : null) != null)
                  || ((converter = (containerContract != null) ? containerContract.ItemConverter : null) != null)


### PR DESCRIPTION
My version of Mono can't figure out that this short-circuit is valid.
