### PR TITLE
Serializing empty JRaw does not create correct json output

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -1866,6 +1866,22 @@ keyword such as type of business.""
         }
 
         [Test]
+        public void SerializeJsonRawEmptyJRaw()
+        {
+            PersonRaw personRaw = new PersonRaw
+            {
+                FirstName = "FirstNameValue",
+                RawContent = new JRaw(""),
+                LastName = "LastNameValue"
+            };
+
+            string json;
+
+            json = JsonConvert.SerializeObject(personRaw);
+            Assert.AreEqual(@"{""first_name"":""FirstNameValue"",""RawContent"":"""",""last_name"":""LastNameValue""}", json);
+        }
+
+        [Test]
         public void DeserializeJsonRaw()
         {
             string json = @"{""first_name"":""FirstNameValue"",""RawContent"":[1,2,3,4,5],""last_name"":""LastNameValue""}";


### PR DESCRIPTION
I ran across this bug while logging json coming into my app. I was taking the POST body of a request and creating a JRaw object out of it. Naturally for requests such as GET, there would be no request body, just an empty string. When I created a JRaw object out of an empty string and tried to serialize it, JSON.net would not put an empty string or an empty object in the serialized output. It would just skip it all together.

I added a test in nunit, and here is the output

```
Newtonsoft.Json.Tests.Serialization.JsonSerializerTest.SerializeJsonRawEmptyJRaw:
  Expected string length 75 but was 73. Strings differ at index 44.
  Expected: / But Was:
"..."FirstNameValue","RawContent":"","last_name":"LastNameValue"}" 
"..."FirstNameValue","RawContent":,"last_name":"LastNameValue"}"
```

This part: `"RawContent":,` is not valid json and breaks my logging app's parsing (splunk).

My work around was to do this:

```
  // Fixes issue where newtonsoft can't correctly serialize its own Jraw objects
  if(string.IsNullOrEmpty(requestMessageAsJson.ToString()))
  {
      requestMessageAsJson = null;
  }
```

`requestMessageAsJson` is a `JRaw`
