### PR TITLE
Extracting converter assignment

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -141,14 +141,15 @@ namespace Newtonsoft.Json.Serialization
                 return;
             }
 
-            JsonConverter converter;
-            if ((((converter = (member != null) ? member.Converter : null) != null)
-                 || ((converter = (containerProperty != null) ? containerProperty.ItemConverter : null) != null)
-                 || ((converter = (containerContract != null) ? containerContract.ItemConverter : null) != null)
-                 || ((converter = valueContract.Converter) != null)
-                 || ((converter = Serializer.GetMatchingConverter(valueContract.UnderlyingType)) != null)
-                 || ((converter = valueContract.InternalConverter) != null))
-                && converter.CanWrite)
+            JsonConverter converter = 
+                ((member != null) ? member.Converter : null) ??
+                ((containerProperty != null) ? containerProperty.ItemConverter : null) ??
+                ((containerContract != null) ? containerContract.ItemConverter : null) ??
+                valueContract.Converter ??
+                Serializer.GetMatchingConverter(valueContract.UnderlyingType) ??
+                valueContract.InternalConverter;
+
+            if (converter != null && converter.CanWrite)
             {
                 SerializeConvertable(writer, converter, value, valueContract, containerContract, containerProperty);
                 return;


### PR DESCRIPTION
I got a compiler warning when using the latest version of mono(but not previous versions) not being assigned a value.

These changes does two things.
- Separate the assignment of converter from the CanWrite if-statement
- Simplified the code using the null coalescing operator
