### PR TITLE
Added option to serialize to obfuscated JSON and to deserialize from obfuscated JSON

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -978,6 +978,178 @@ now brown cow?", '"', true);
             Assert.AreEqual(@"""2000-01-01T01:01:01Z""", json);
         }
 
+        private class ObfuscationTest
+        {
+            public ObfuscationTest()
+            {
+                #region Set Values
+                StringProperty1 = "Should be StringProperty1";
+                AnIntProperty2 = 2;
+                StringProperty3 = "Should be StringProperty3";
+                ADoubleProperty4 = 4.4;
+                ComplexProperty5 = new ComplexObjectTest();
+                StringProperty6 = "Should be StringProperty6";
+                StringProperty7 = "Should be StringProperty7";
+                StringProperty8 = "Should be StringProperty8";
+                StringProperty9 = "Should be StringProperty9";
+                StringProperty10 = "Should be StringProperty10";
+                StringProperty11 = "Should be StringProperty11";
+                StringProperty12 = "Should be StringProperty12";
+                StringProperty13 = "Should be StringProperty13";
+                StringProperty14 = "Should be StringProperty14";
+                StringProperty15 = "Should be StringProperty15";
+                StringProperty16 = "Should be StringProperty16";
+                StringProperty17 = "Should be StringProperty17";
+                StringProperty18 = "Should be StringProperty18";
+                StringProperty19 = "Should be StringProperty19";
+                StringProperty20 = "Should be StringProperty20";
+                StringProperty21 = "Should be StringProperty21";
+                StringProperty22 = "Should be StringProperty22";
+                StringProperty23 = "Should be StringProperty23";
+                StringProperty24 = "Should be StringProperty24";
+                StringProperty25 = "Should be StringProperty25";
+                StringProperty26 = "Should be StringProperty26";
+                StringProperty27 = "Should be StringProperty27";
+                StringProperty28 = "Should be StringProperty28";
+                StringProperty29 = "Should be StringProperty29";
+                StringProperty30 = "Should be StringProperty30";
+                StringProperty31 = "Should be StringProperty31";
+                StringProperty32 = "Should be StringProperty32";
+                StringProperty33 = "Should be StringProperty33";
+                StringProperty34 = "Should be StringProperty34";
+                StringProperty35 = "Should be StringProperty35";
+                StringProperty36 = "Should be StringProperty36";
+                StringProperty37 = "Should be StringProperty37";
+                StringProperty38 = "Should be StringProperty38";
+                StringProperty39 = "Should be StringProperty39";
+                StringProperty40 = "Should be StringProperty40";
+                StringProperty41 = "Should be StringProperty41";
+                StringProperty42 = "Should be StringProperty42";
+                StringProperty43 = "Should be StringProperty43";
+                StringProperty44 = "Should be StringProperty44";
+                StringProperty45 = "Should be StringProperty45";
+                StringProperty46 = "Should be StringProperty46";
+                StringProperty47 = "Should be StringProperty47";
+                StringProperty48 = "Should be StringProperty48";
+                StringProperty49 = "Should be StringProperty49";
+                StringProperty50 = "Should be StringProperty50";
+                StringProperty51 = "Should be StringProperty51";
+                StringProperty52 = "Should be StringProperty52";
+                StringProperty53 = "Should be StringProperty53";
+                #endregion Set Values
+            }
+
+            #region properties
+            public string StringProperty1 { get; set; }
+            public int AnIntProperty2 { get; set; }
+            public string StringProperty3 { get; set; }
+            public double ADoubleProperty4 { get; set; }
+            public ComplexObjectTest ComplexProperty5 { get; set; }
+            public string StringProperty6 { get; set; }
+            public string StringProperty7 { get; set; }
+            public string StringProperty8 { get; set; }
+            public string StringProperty9 { get; set; }
+            public string StringProperty10 { get; set; }
+            public string StringProperty11 { get; set; }
+            public string StringProperty12 { get; set; }
+            public string StringProperty13 { get; set; }
+            public string StringProperty14 { get; set; }
+            public string StringProperty15 { get; set; }
+            public string StringProperty16 { get; set; }
+            public string StringProperty17 { get; set; }
+            public string StringProperty18 { get; set; }
+            public string StringProperty19 { get; set; }
+            public string StringProperty20 { get; set; }
+            public string StringProperty21 { get; set; }
+            public string StringProperty22 { get; set; }
+            public string StringProperty23 { get; set; }
+            public string StringProperty24 { get; set; }
+            public string StringProperty25 { get; set; }
+            public string StringProperty26 { get; set; }
+            public string StringProperty27 { get; set; }
+            public string StringProperty28 { get; set; }
+            public string StringProperty29 { get; set; }
+            public string StringProperty30 { get; set; }
+            public string StringProperty31 { get; set; }
+            public string StringProperty32 { get; set; }
+            public string StringProperty33 { get; set; }
+            public string StringProperty34 { get; set; }
+            public string StringProperty35 { get; set; }
+            public string StringProperty36 { get; set; }
+            public string StringProperty37 { get; set; }
+            public string StringProperty38 { get; set; }
+            public string StringProperty39 { get; set; }
+            public string StringProperty40 { get; set; }
+            public string StringProperty41 { get; set; }
+            public string StringProperty42 { get; set; }
+            public string StringProperty43 { get; set; }
+            public string StringProperty44 { get; set; }
+            public string StringProperty45 { get; set; }
+            public string StringProperty46 { get; set; }
+            public string StringProperty47 { get; set; }
+            public string StringProperty48 { get; set; }
+            public string StringProperty49 { get; set; }
+            public string StringProperty50 { get; set; }
+            public string StringProperty51 { get; set; }
+            public string StringProperty52 { get; set; }
+            public string StringProperty53 { get; set; }
+            #endregion properties
+        }
+
+        private class ComplexObjectTest
+        {
+            public string StringProperty1 { get; set; }
+            public int AnIntProperty2 { get; set; }
+            public string StringProperty3 { get; set; }
+            public double ADoubleProperty4 { get; set; }
+
+            public ComplexObjectTest()
+            {
+                StringProperty1 = "Should be StringProperty1";
+                AnIntProperty2 = 2;
+                StringProperty3 = "Should be StringProperty3";
+                ADoubleProperty4 = 4.4;
+            }
+        }
+
+        [Test]
+        public void SerializeEnableObfuscation()
+        {
+            string text = JsonConvert.SerializeObject(new ObfuscationTest(), new JsonSerializerSettings { ObfuscationEnabled = true });
+
+            var json = JObject.Parse(text);
+            Assert.AreEqual(json["a"].Value<string>(), "Should be StringProperty1");
+            Assert.AreEqual(json["b"].Value<int>(), 2);
+            Assert.AreEqual(json["d"].Value<double>(), 4.4);
+            Assert.AreEqual(json["e"]["a"].Value<string>(), "Should be StringProperty1");
+            Assert.AreEqual(json["z"].Value<string>(), "Should be StringProperty26");
+            Assert.AreEqual(json["aa"].Value<string>(), "Should be StringProperty27");
+            Assert.AreEqual(json["az"].Value<string>(), "Should be StringProperty52");
+            Assert.AreEqual(json["ba"].Value<string>(), "Should be StringProperty53");
+
+            json["a"] = "Should be StringProperty1 Modified";
+            json["b"] = 3;
+            json["d"] = 4.5;
+            json["e"]["a"] = "Should be StringProperty1 Modified";
+            json["z"] = "Should be StringProperty26 Modified";
+            json["aa"] = "Should be StringProperty27 Modified";
+            json["az"] = "Should be StringProperty52 Modified";
+            json["ba"] = "Should be StringProperty53 Modified";
+
+            var modifiedText = json.ToString();
+
+            ObfuscationTest deserialized = JsonConvert.DeserializeObject<ObfuscationTest>(modifiedText, new JsonSerializerSettings { ObfuscationEnabled = true });
+
+            Assert.AreEqual(json["a"].Value<string>(), deserialized.StringProperty1);
+            Assert.AreEqual(json["b"].Value<int>(), deserialized.AnIntProperty2);
+            Assert.AreEqual(json["d"].Value<double>(), deserialized.ADoubleProperty4);
+            Assert.AreEqual(json["e"]["a"].Value<string>(), deserialized.ComplexProperty5.StringProperty1);
+            Assert.AreEqual(json["z"].Value<string>(), deserialized.StringProperty26);
+            Assert.AreEqual(json["aa"].Value<string>(), deserialized.StringProperty27);
+            Assert.AreEqual(json["az"].Value<string>(), deserialized.StringProperty52);
+            Assert.AreEqual(json["ba"].Value<string>(), deserialized.StringProperty53);
+        }
+
         [Test]
         public void DeserializeObject()
         {

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -73,6 +73,7 @@ namespace Newtonsoft.Json
         private bool? _checkAdditionalContent;
         private string _dateFormatString;
         private bool _dateFormatStringSet;
+        private bool _obfuscationEnabled;
 
         /// <summary>
         /// Occurs when the <see cref="JsonSerializer"/> errors during serialization and deserialization.
@@ -429,6 +430,15 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Gets or sets whether obfuscation is enabled or not.
+        /// </summary>
+        public virtual bool ObfuscationEnabled
+        {
+            get { return _obfuscationEnabled; }
+            set { _obfuscationEnabled = value; }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonSerializer"/> class.
         /// </summary>
         public JsonSerializer()
@@ -594,6 +604,8 @@ namespace Newtonsoft.Json
                 serializer._maxDepth = settings._maxDepth;
                 serializer._maxDepthSet = settings._maxDepthSet;
             }
+            if (settings._obfuscationEnabled)
+                serializer._obfuscationEnabled = settings._obfuscationEnabled;
         }
 
         /// <summary>
@@ -905,6 +917,13 @@ namespace Newtonsoft.Json
                 jsonWriter.DateFormatString = _dateFormatString;
             }
 
+            bool previousObfuscationEnabled = false;
+            if(_obfuscationEnabled && jsonWriter.ObfuscationEnabled != _obfuscationEnabled)
+            {
+                previousObfuscationEnabled = jsonWriter.ObfuscationEnabled;
+                jsonWriter.ObfuscationEnabled = _obfuscationEnabled;
+            }
+
             TraceJsonWriter traceJsonWriter = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? new TraceJsonWriter(jsonWriter)
                 : null;
@@ -930,6 +949,8 @@ namespace Newtonsoft.Json
                 jsonWriter.DateFormatString = previousDateFormatString;
             if (previousCulture != null)
                 jsonWriter.Culture = previousCulture;
+            if (previousObfuscationEnabled != _obfuscationEnabled)
+                jsonWriter.ObfuscationEnabled = previousObfuscationEnabled;
         }
 
         internal IReferenceResolver GetReferenceResolver()

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -85,6 +85,7 @@ namespace Newtonsoft.Json
         internal ConstructorHandling? _constructorHandling;
         internal TypeNameHandling? _typeNameHandling;
         internal MetadataPropertyHandling? _metadataPropertyHandling;
+        internal bool _obfuscationEnabled;
 
         /// <summary>
         /// Gets or sets how reference loops (e.g. a class referencing itself) is handled.
@@ -346,6 +347,12 @@ namespace Newtonsoft.Json
         {
             get { return _checkAdditionalContent ?? DefaultCheckAdditionalContent; }
             set { _checkAdditionalContent = value; }
+        }
+
+        public bool ObfuscationEnabled
+        {
+            get { return _obfuscationEnabled; }
+            set { _obfuscationEnabled = value; }
         }
 
         static JsonSerializerSettings()

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -129,6 +129,11 @@ namespace Newtonsoft.Json
         public bool CloseOutput { get; set; }
 
         /// <summary>
+        /// Enables JSON Obfuscation
+        /// </summary>
+        public bool ObfuscationEnabled { get; set; }
+
+        /// <summary>
         /// Gets the top.
         /// </summary>
         /// <value>The top.</value>

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -601,6 +601,7 @@ namespace Newtonsoft.Json.Serialization
 
             JsonPropertyCollection parameterCollection = new JsonPropertyCollection(constructor.DeclaringType);
 
+            int index = 0;
             foreach (ParameterInfo parameterInfo in constructorParameters)
             {
                 // it is possible to generate a ParameterInfo with a null name using Reflection.Emit
@@ -619,6 +620,8 @@ namespace Newtonsoft.Json.Serialization
 
                     if (property != null)
                     {
+                        //set the obfuscated property name.
+                        property.MinName = GetObfuscatedName(index++);
                         parameterCollection.AddProperty(property);
                     }
                 }
@@ -1110,11 +1113,38 @@ namespace Newtonsoft.Json.Serialization
                 JsonProperty property = CreateProperty(member, memberSerialization);
 
                 if (property != null)
+                {
+                    //set the obfuscated property name.
+                    property.MinName = GetObfuscatedName(members.IndexOf(member));
+
                     properties.AddProperty(property);
+                }
             }
 
             IList<JsonProperty> orderedProperties = properties.OrderBy(p => p.Order ?? -1).ToList();
             return orderedProperties;
+        }
+
+        /// <summary>
+        /// Generates an obfuscated name based on the passed index
+        /// </summary>
+        /// <param name="index">Index to derive name from.  Generally, this will be the position of the property in a class.</param>
+        /// <returns>Returns the obfuscated name.</returns>
+        static protected string GetObfuscatedName (int index)
+        {
+            //get the letter of the property position.
+            var letterPos = (index) % (26);
+            string letter = ((Char)(97 + letterPos)).ToString();
+
+            if (index >= 26) //26 letters in the english alphabet
+            {
+                //get the next set of letters
+                var nextSet = (index / 26) - 1; 
+
+                letter = GetObfuscatedName(nextSet) + letter;
+            }
+
+            return letter;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -271,9 +271,18 @@ namespace Newtonsoft.Json.Serialization
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }
 
+        /// <summary>
+        /// Gets or sets the obfuscated name of this property
+        /// </summary>
+        public string MinName { get; set; }
+
         internal void WritePropertyName(JsonWriter writer)
         {
-            if (_skipPropertyNameEscape)
+            if (writer.ObfuscationEnabled)
+            {
+                writer.WritePropertyName(MinName);
+            }
+            else if (_skipPropertyNameEscape)
                 writer.WritePropertyName(PropertyName, false);
             else
                 writer.WritePropertyName(PropertyName);

--- a/Src/Newtonsoft.Json/Serialization/JsonPropertyCollection.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonPropertyCollection.cs
@@ -122,6 +122,24 @@ namespace Newtonsoft.Json.Serialization
             return property;
         }
 
+        /// <summary>
+        /// Gets the <see cref="JsonProperty"/> object that matches the obfuscated property name passed.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>A matching property if found.</returns>
+        public JsonProperty GetObfuscatedProperty(string propertyName)
+        {
+            foreach (JsonProperty property in this)
+            {
+                if (string.Equals(propertyName, property.MinName))
+                {
+                    return property;
+                }
+            }
+
+            return null;
+        }
+
         private bool TryGetValue(string key, out JsonProperty item)
         {
             if (Dictionary == null)

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1898,8 +1898,13 @@ To fix this error either change the environment to be fully trusted, change the 
                         {
                             // attempt exact case match first
                             // then try match ignoring case
-                            JsonProperty property = contract.Properties.GetClosestMatchProperty(memberName);
+                            JsonProperty property = null;
 
+                            if (this.Serializer.ObfuscationEnabled)
+                                property = contract.Properties.GetObfuscatedProperty(memberName);
+                            else
+                                property = contract.Properties.GetClosestMatchProperty(memberName);
+                            
                             if (property == null)
                             {
                                 if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)


### PR DESCRIPTION
This PR allows you to serialize an object to an obfuscated JSON object and to deserialize from an obfuscated JSON object.

For example:

``` c#
    private class ClassToObfuscate
    {
        public int Property1 { get; set;  }
        public string Property2 { get; set; }
    }

    public void SerializeEnableObfuscation()
    {
        var startingObject = new ClassToObfuscate
        {
            Property1 = 5,
            Property2 = "Second"
        };

        string text = JsonConvert.SerializeObject(startingObject, new JsonSerializerSettings { ObfuscationEnabled = true });
        // startingObject will be serialized as: {"a":5,"b":"Second"}

        var finalObject = JsonConvert.DeserializeObject<ClassToObfuscate>(text, new JsonSerializerSettings { ObfuscationEnabled = true });
        // finalObject.Property1 == 5
        // finalObject.Property2 == "Second"
    }
```
