### PR TITLE
Use FloatParseHandling setting when getting column data types

### DIFF
--- a/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
@@ -182,7 +182,10 @@ namespace Newtonsoft.Json.Converters
                 case JsonToken.Integer:
                     return typeof(long);
                 case JsonToken.Float:
-                    return typeof(double);
+                    if (reader._floatParseHandling == FloatParseHandling.Decimal)
+                        return typeof(decimal);
+                    else
+                    	return typeof(double);
                 case JsonToken.String:
                 case JsonToken.Null:
                 case JsonToken.Undefined:


### PR DESCRIPTION
Was having issue where datatable columns were being created as double instead of decimal even though I had set the FloatParseHandling setting.   The change simply observes this setting and creates the column as double or decimal based on the setting
