### PR TITLE
fixed SelectTokens for empty containers

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
@@ -18,7 +18,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
 
                 while (true)
                 {
-                    if (container != null)
+                    if (container != null && container.HasValues)
                     {
                         value = container.First;
                     }


### PR DESCRIPTION
There was a bug when you trying execute JObject.SelectTokens("$..test") for a json that have empty container it returns empty result.

Example:
{
  'cont': [],
  'test': 'no one will find me'
}
