### PR TITLE
Possible fix for Mono 2.10 compatibility

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -1300,7 +1300,7 @@ namespace Newtonsoft.Json
                         if (number.Length > MaximumJavascriptIntegerCharacterLength)
                             throw JsonReaderException.Create(this, "JSON integer {0} is too large to parse.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
 
-                        numberValue = BigInteger.Parse(number, CultureInfo.InvariantCulture);
+                        numberValue = BigInteger.Parse(number);
                         numberType = JsonToken.Integer;
 #else
                         throw JsonReaderException.Create(this, "JSON integer {0} is too large or small for an Int64.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -305,7 +305,7 @@ namespace Newtonsoft.Json.Utilities
             if (value is BigInteger)
                 return (BigInteger)value;
             if (value is string)
-                return BigInteger.Parse((string)value, CultureInfo.InvariantCulture);
+                return BigInteger.Parse((string)value);
             if (value is float)
                 return new BigInteger((float)value);
             if (value is double)


### PR DESCRIPTION
Mono 2.8/2.10 does not implement `BigInteger.Parse(string, IFormatProvider)`.
If only these calls don't exist, JSON.NET should work well on Mono/Linux platform.

Would you mind removing these calls for further compatibility?
