### PR TITLE
Symbol chars used instead of single length strings

### DIFF
--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1352,7 +1352,7 @@ namespace Newtonsoft.Json.Converters
 
             string elementPrefix = MiscellaneousUtils.GetPrefix(propertyName);
 
-            if (propertyName.StartsWith("@", StringComparison.Ordinal))
+            if (propertyName.StartsWith('@'))
             {
                 string attributeName = propertyName.Substring(1);
                 string attributeValue = reader.Value.ToString();

--- a/Src/Newtonsoft.Json/JsonPosition.cs
+++ b/Src/Newtonsoft.Json/JsonPosition.cs
@@ -60,14 +60,14 @@ namespace Newtonsoft.Json
             {
                 case JsonContainerType.Object:
                     if (sb.Length > 0)
-                        sb.Append(".");
+                        sb.Append('.');
                     sb.Append(PropertyName);
                     break;
                 case JsonContainerType.Array:
                 case JsonContainerType.Constructor:
-                    sb.Append("[");
+                    sb.Append('[');
                     sb.Append(Position);
-                    sb.Append("]");
+                    sb.Append(']');
                     break;
             }
         }
@@ -96,7 +96,7 @@ namespace Newtonsoft.Json
             {
                 message = message.Trim();
 
-                if (!message.EndsWith(".", StringComparison.Ordinal))
+                if (!message.EndsWith('.'))
                     message += ".";
 
                 message += " ";

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -158,7 +158,7 @@ namespace Newtonsoft.Json
         {
             InternalWriteStart(JsonToken.StartObject, JsonContainerType.Object);
 
-            _writer.Write("{");
+            _writer.Write('{');
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Newtonsoft.Json
         {
             InternalWriteStart(JsonToken.StartArray, JsonContainerType.Array);
 
-            _writer.Write("[");
+            _writer.Write('[');
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Newtonsoft.Json
 
             _writer.Write("new ");
             _writer.Write(name);
-            _writer.Write("(");
+            _writer.Write('(');
         }
 
         /// <summary>
@@ -193,13 +193,13 @@ namespace Newtonsoft.Json
             switch (token)
             {
                 case JsonToken.EndObject:
-                    _writer.Write("}");
+                    _writer.Write('}');
                     break;
                 case JsonToken.EndArray:
-                    _writer.Write("]");
+                    _writer.Write(']');
                     break;
                 case JsonToken.EndConstructor:
-                    _writer.Write(")");
+                    _writer.Write(')');
                     break;
                 default:
                     throw JsonWriterException.Create(this, "Invalid JsonToken: " + token, null);

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -206,7 +206,7 @@ namespace Newtonsoft.Json.Linq
                                 JProperty property = (JProperty)current;
 
                                 if (sb.Length > 0)
-                                    sb.Append(".");
+                                    sb.Append('.');
 
                                 sb.Append(property.Name);
                                 break;
@@ -214,9 +214,9 @@ namespace Newtonsoft.Json.Linq
                             case JTokenType.Constructor:
                                 int index = ((IList<JToken>)current).IndexOf(next);
 
-                                sb.Append("[");
+                                sb.Append('[');
                                 sb.Append(index);
-                                sb.Append("]");
+                                sb.Append(']');
                                 break;
                         }
                     }

--- a/Src/Newtonsoft.Json/Linq/JTokenReader.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenReader.cs
@@ -341,8 +341,8 @@ namespace Newtonsoft.Json.Linq
                     if (string.IsNullOrEmpty(path))
                         return _initialPath;
 
-                    if (_initialPath.EndsWith("]", StringComparison.Ordinal)
-                        || path.StartsWith("[", StringComparison.Ordinal))
+                    if (_initialPath.EndsWith(']')
+                        || path.StartsWith('['))
                         path = _initialPath + path;
                     else
                         path = _initialPath + "." + path;

--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -197,5 +197,16 @@ namespace Newtonsoft.Json.Utilities
             return (c >= 56320 && c <= 57343);
 #endif
         }
+
+        public static bool StartsWith(this string source, char value)
+        {
+            return (source.Length != 0 && source[0] == value);
+        }
+
+        public static bool EndsWith(this string source, char value)
+        {
+            int sourceLen = source.Length;
+            return (sourceLen != 0 && source[sourceLen - 1] == value);
+        }
     }
 }


### PR DESCRIPTION
StartsWith(char) and EndsWith(char) extension methods are twice as fast as the string based versions.
StringBuilder.Append(char) is a direct assignment to it's internal buffer and doesn't setup a memory copy operation.
TextWriter.Write(char) is the same as the StringBuilder. Typically a direct assignment to an internal buffer.
