### PR TITLE
Trim JProperty ChildrenTokens overhead

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JProperty.cs
+++ b/Src/Newtonsoft.Json/Linq/JProperty.cs
@@ -36,7 +36,7 @@ namespace Newtonsoft.Json.Linq
     /// </summary>
     public class JProperty : JContainer
     {
-        private readonly List<JToken> _content = new List<JToken>();
+        private readonly List<JToken> _content = new List<JToken>(1);
         private readonly string _name;
 
         /// <summary>


### PR DESCRIPTION
No need for the List<T>'s default capacity of 4 for a JProperty as it only has one value
