### PR TITLE
Added support for JObject dynamic casts

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/DynamicTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/DynamicTests.cs
@@ -33,6 +33,7 @@ using System.Numerics;
 #endif
 using System.Text;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Tests.TestObjects;
 #if !NETFX_CORE
 using NUnit.Framework;
 #else
@@ -161,6 +162,20 @@ namespace Newtonsoft.Json.Tests.Linq
             JToken v;
             Assert.IsTrue(d.TryGetValue("ChildValue", out v));
             Assert.AreEqual("blah blah", (string)v);
+        }
+
+
+        [Test]
+        public void JObjectConvert() {
+            JObject o = new JObject(
+                new JProperty("Original", "foobar"),
+                new JProperty("Error", new JObject(new JProperty("ErrorMessage", "error!"))));
+
+            Shortie s = (dynamic)o;
+
+            Assert.AreEqual("foobar", s.Original);
+            Assert.IsNotNull(s.Error);
+            Assert.AreEqual("error!", s.Error.ErrorMessage);
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -818,6 +818,19 @@ namespace Newtonsoft.Json.Linq
             {
                 return instance.Properties().Select(p => p.Name);
             }
+
+            public override bool TryConvert(JObject instance, ConvertBinder binder, out object result)
+            {
+                if (binder.Type.IsInstanceOfType(instance))
+                {
+                    result = instance;
+                    return true;
+                }
+
+                // this can throw if the object can not be converted
+                result = instance.ToObject(binder.Type);
+                return true;
+            }
         }
 #endif
     }


### PR DESCRIPTION
This pull requests adds support for casting dynamic JObject to any type (that ToObject works for).

Basically: `(T)(dynamic)jobject` is `jobject.ToObject<T>()`.

Use case is something like this:

```
public void Post(Container container) { ... }

public class Container {
    public dynamic Content { get; set; }
    // some properties that define what content actually is
}

// ...
X x = (X)container.Content; // no references to Newtonsoft.Json in this code
```

Another similar case I had was with `IDictionary<string, dynamic>` where value might need to be cast depending on the situation.

Comments on the modifications:
1. My main goal was to limit the changes, both because of limited time I have right now, and to avoid breakage/unexpected architectural decisions. If you think there is more to be done here (as per following items), it is fine -- I'll do it when I get more time.
2. I haven't passed the original serializer through to `ToObject`, since the proxy does not currently have access to that, so it would need more changes. However I think it is something that must be done sooner or later. Should I do that before this is merged?
3. I've added test on the positive case only, not sure if any exception testing is required.
4. The cast seems useful on `JToken` level, especially since `ToObject` is on `JToken` anyway (and I do not see why I wouldn't want to cast dynamic `JArray` to something like `X[]`). However there is no common base type for `JToken` `DynamicProxy`, and `JValue` implementation seems to use some custom logic for `TryConvert`.
