### PR TITLE
Implemented support for optional constructors in JsonConverters for passing in the MemberInfo object.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -1058,5 +1058,143 @@ namespace Newtonsoft.Json.Tests
         {
             public Nest A { get; set; }
         }
+
+        [Test(Description = "Verifies that the optional JsonConverter.ctor(object) is invoked (if defined) with the attribute provider.")]
+        public void MemberInfoPassedToJsonConvertConstructor()
+        {
+            var clobber = new ClobberMyProperties { One = "Red", Two = "Green" };
+            string json = JsonConvert.SerializeObject(clobber);
+
+            Assert.AreEqual("{\"One\":\"One-Red\",\"Two\":\"Two-Green\"}", json);
+        }
+
+        public class ClobberMyProperties
+        {
+            [JsonConverter(typeof(ClobberingJsonConverter))]
+            public string One { get; set; }
+
+            [JsonConverter(typeof(ClobberingJsonConverter))]
+            public string Two { get; set; }
+        }
+
+        public class ClobberingJsonConverter : JsonConverter
+        {
+            public System.Reflection.MemberInfo MemberInfo { get; private set; }
+
+            public ClobberingJsonConverter(object attributeProvider)
+            {
+                MemberInfo = (System.Reflection.MemberInfo)attributeProvider;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue(MemberInfo.Name + "-" + value.ToString());
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(string);
+            }
+        }
+
+        [Test(Description = "Uses optional JsonConverter.ctor(object) to demonstrate custom rounding of doubles on a property-by-property basis.")]
+        public void CustomDoubleRounding()
+        {
+            var measurements = new Measurements
+            {
+                Loads = new List<double> { 23283.567554707258, 23224.849899771067, 23062.5, 22846.272519910868, 22594.281246368635 },
+                Positions = new List<double> { 57.724227689317019, 60.440934405753069, 63.444192925248643, 66.813119113482557, 70.4496501404433	},
+                Gain = 12345.67895111213
+            };
+
+            string json = JsonConvert.SerializeObject(measurements);
+
+
+            Assert.AreEqual("{\"Positions\":[57.72,60.44,63.44,66.81,70.45],\"Loads\":[23284.0,23225.0,23062.0,22846.0,22594.0],\"Gain\":12345.679}", json);
+        }
+
+        public class Measurements
+        {
+            [JsonConverter(typeof(RoundingJsonConverter))]
+            public List<double> Positions { get; set; }
+
+            [JsonConverter(typeof(RoundingJsonConverter))]
+            [JsonRounding(0, MidpointRounding.ToEven)]
+            public List<double> Loads { get; set; }
+
+            [JsonConverter(typeof(RoundingJsonConverter))]
+            [JsonRounding(4)]
+            public double Gain { get; set; }
+        }
+
+        public class RoundingJsonConverter : JsonConverter
+        {
+            JsonRoundingAttribute _rounding;
+
+            public RoundingJsonConverter(object attributeProvider)
+            {
+                var memberInfo = (System.Reflection.MemberInfo)attributeProvider;
+                var roundingAttribute = Attribute.GetCustomAttribute(memberInfo, typeof(JsonRoundingAttribute), true) as JsonRoundingAttribute;
+
+                _rounding = roundingAttribute != null ? roundingAttribute : new JsonRoundingAttribute();
+            }
+
+            public override bool CanRead
+            {
+                get { return false; }
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(double);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var enumerable = value as IEnumerable<double>;
+
+                if (null != enumerable)
+                {
+                    writer.WriteStartArray();
+                    foreach (var element in enumerable)
+                    {
+                        writer.WriteValue(RoundValue(element));
+                    }
+                    writer.WriteEndArray();
+                }
+                else if(value is double)
+                {
+                    writer.WriteValue(RoundValue((double)value));
+                }
+            }
+
+            double RoundValue(double value)
+            {
+                return Math.Round(value, _rounding.Precision, _rounding.Rounding);
+            }
+        }
+
+        public class JsonRoundingAttribute : Attribute
+        {
+            public int Precision { get; private set; }
+
+            public MidpointRounding Rounding { get; private set; }
+
+            public JsonRoundingAttribute(int iPrecision = 2, MidpointRounding rounding = MidpointRounding.AwayFromZero)
+            {
+                Precision = iPrecision;
+                Rounding = rounding;
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi,

This PR adds the capability of passing an attribute provider object instance to an optional initializing constructor in JsonConverters. This opens up possibilities for configuring custom JsonConverters.

The limitation I've run into on occasion when using a custom JsonConverter, is that I cannot configure or otherwise parameterize the behavior of my converter.  This has led people to kludges such as creating multiple child classes of their JsonConverter for each combination of options they need.

This PR doesn't quite give you the ability to pass any arbitrary arguments to your JsonConverter instance constructor -- I've made no changes to the JsonConverterAttribute.  Instead, I've added the ability to invoke your JsonConverter's initializing constructor, if defined, with the "attribute provider" object.  For properties and fields, this will be a MemberInfo derived instance.  For a class, this will be Type.

Armed with this additional context, JsonConverters can now choose to behave differently according to the member being serialized instead of being blind to the context in which they're being used. Primarily, the JsonConverter can look at any other Attributes defined for the member.

I've included two unit test:  `MemberInfoPassedToJsonConvertConstructor` simply exercises the features and confirms that the JsonConverter got its initializing ctor invoked.  `CustomDoubleRounding` is more of a demonstration that uses a practical application of this feature, including the use of a custom Attribute to control the behavior of the JsonConverter.

Thanks, and please let me know if you require any further changes for this PR to be suitable. I think this simple change could help out a lot of folks.
