### PR TITLE
[ObjectContract] Added support for custom member serialization

### DIFF
--- a/Src/Newtonsoft.Json/Formatting.cs
+++ b/Src/Newtonsoft.Json/Formatting.cs
@@ -38,6 +38,11 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Causes child objects to be indented according to the <see cref="JsonTextWriter.Indentation"/> and <see cref="JsonTextWriter.IndentChar"/> settings.
         /// </summary>
-        Indented
+        Indented,
+
+        /// <summary>
+        /// Indented formatting with ObjectStart and ArrayStart starting on new line.
+        /// </summary>
+        IndentedNewLine,
     }
 }

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -680,7 +680,7 @@ namespace Newtonsoft.Json
                 if (_currentState == State.Property)
                     WriteNull();
 
-                if (_formatting == Formatting.Indented)
+                if (_formatting == Formatting.Indented || _formatting == Json.Formatting.IndentedNewLine)
                 {
                     if (_currentState != State.ObjectStart && _currentState != State.ArrayStart)
                         WriteIndent();
@@ -751,8 +751,8 @@ namespace Newtonsoft.Json
             {
                 WriteValueDelimiter();
             }
-
-            if (_formatting == Formatting.Indented)
+                        
+            if (_formatting == Formatting.Indented || _formatting == Json.Formatting.IndentedNewLine)
             {
                 if (_currentState == State.Property)
                     WriteIndentSpace();
@@ -760,6 +760,12 @@ namespace Newtonsoft.Json
                 // don't indent a property when it is the first token to be written (i.e. at the start)
                 if ((_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.Constructor || _currentState == State.ConstructorStart)
                     || (tokenBeingWritten == JsonToken.PropertyName && _currentState != State.Start))
+                    WriteIndent();
+            }
+
+            if (_formatting == Json.Formatting.IndentedNewLine && _currentState != State.Start)
+            {
+                if (tokenBeingWritten == JsonToken.StartArray || tokenBeingWritten == JsonToken.StartObject)
                     WriteIndent();
             }
 

--- a/Src/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -80,6 +80,22 @@ namespace Newtonsoft.Json.Serialization
     public delegate IEnumerable<KeyValuePair<object, object>> ExtensionDataGetter(object o);
 
     /// <summary>
+    /// Reads additional members of object which can be specified at runtime.
+    /// </summary>
+    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+    /// <param name="obj">The existing value of object being read.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    public delegate void MemberReader(JsonReader reader, object obj, JsonSerializer serializer);
+
+    /// <summary>
+    /// Writes additional members of object which can be specified at runtime.
+    /// </summary>
+    /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+    /// <param name="value">The value.</param>
+    /// <param name="serializer">The calling serializer.</param>
+    public delegate void MemberWriter(JsonWriter writer, object obj, JsonSerializer serializer);
+
+    /// <summary>
     /// Contract details for a <see cref="Type"/> used by the <see cref="JsonSerializer"/>.
     /// </summary>
     public abstract class JsonContract

--- a/Src/Newtonsoft.Json/Serialization/JsonObjectContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonObjectContract.cs
@@ -133,6 +133,16 @@ namespace Newtonsoft.Json.Serialization
         /// </summary>
         public ExtensionDataGetter ExtensionDataGetter { get; set; }
 
+        /// <summary>
+        /// Gets or sets the member reader.
+        /// </summary>
+        public MemberReader MemberReader { get; set; }
+
+        /// <summary>
+        /// Gets or sets the member writer.
+        /// </summary>
+        public MemberWriter MemberWriter { get; set; }
+
         private bool? _hasRequiredOrDefaultValueProperties;
         private ConstructorInfo _parametrizedConstructor;
         private ConstructorInfo _overrideConstructor;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -428,89 +428,89 @@ namespace Newtonsoft.Json.Serialization
             switch (contract.ContractType)
             {
                 case JsonContractType.Object:
-                {
-                    bool createdFromNonDefaultCreator = false;
-                    JsonObjectContract objectContract = (JsonObjectContract)contract;
-                    object targetObject;
-                    // check that if type name handling is being used that the existing value is compatible with the specified type
-                    if (existingValue != null && (resolvedObjectType == objectType || resolvedObjectType.IsAssignableFrom(existingValue.GetType())))
-                        targetObject = existingValue;
-                    else
-                        targetObject = CreateNewObject(reader, objectContract, member, containerMember, id, out createdFromNonDefaultCreator);
+                    {
+                        bool createdFromNonDefaultCreator = false;
+                        JsonObjectContract objectContract = (JsonObjectContract)contract;
+                        object targetObject;
+                        // check that if type name handling is being used that the existing value is compatible with the specified type
+                        if (existingValue != null && (resolvedObjectType == objectType || resolvedObjectType.IsAssignableFrom(existingValue.GetType())))
+                            targetObject = existingValue;
+                        else
+                            targetObject = CreateNewObject(reader, objectContract, member, containerMember, id, out createdFromNonDefaultCreator);
 
-                    // don't populate if read from non-default creator because the object has already been read
-                    if (createdFromNonDefaultCreator)
-                        return targetObject;
+                        // don't populate if read from non-default creator because the object has already been read
+                        if (createdFromNonDefaultCreator)
+                            return targetObject;
 
-                    return PopulateObject(targetObject, reader, objectContract, member, id);
-                }
+                        return PopulateObject(targetObject, reader, objectContract, member, id);
+                    }
                 case JsonContractType.Primitive:
-                {
-                    JsonPrimitiveContract primitiveContract = (JsonPrimitiveContract)contract;
-                    // if the content is inside $value then read past it
-                    if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore
-                        && reader.TokenType == JsonToken.PropertyName
-                        && string.Equals(reader.Value.ToString(), JsonTypeReflector.ValuePropertyName, StringComparison.Ordinal))
                     {
-                        CheckedRead(reader);
+                        JsonPrimitiveContract primitiveContract = (JsonPrimitiveContract)contract;
+                        // if the content is inside $value then read past it
+                        if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore
+                            && reader.TokenType == JsonToken.PropertyName
+                            && string.Equals(reader.Value.ToString(), JsonTypeReflector.ValuePropertyName, StringComparison.Ordinal))
+                        {
+                            CheckedRead(reader);
 
-                        // the token should not be an object because the $type value could have been included in the object
-                        // without needing the $value property
-                        if (reader.TokenType == JsonToken.StartObject)
-                            throw JsonSerializationException.Create(reader, "Unexpected token when deserializing primitive value: " + reader.TokenType);
+                            // the token should not be an object because the $type value could have been included in the object
+                            // without needing the $value property
+                            if (reader.TokenType == JsonToken.StartObject)
+                                throw JsonSerializationException.Create(reader, "Unexpected token when deserializing primitive value: " + reader.TokenType);
 
-                        object value = CreateValueInternal(reader, resolvedObjectType, primitiveContract, member, null, null, existingValue);
+                            object value = CreateValueInternal(reader, resolvedObjectType, primitiveContract, member, null, null, existingValue);
 
-                        CheckedRead(reader);
-                        return value;
+                            CheckedRead(reader);
+                            return value;
+                        }
+                        break;
                     }
-                    break;
-                }
                 case JsonContractType.Dictionary:
-                {
-                    JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)contract;
-                    object targetDictionary;
-
-                    if (existingValue == null)
                     {
-                        bool createdFromNonDefaultCreator;
-                        IDictionary dictionary = CreateNewDictionary(reader, dictionaryContract, out createdFromNonDefaultCreator);
+                        JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)contract;
+                        object targetDictionary;
 
-                        if (createdFromNonDefaultCreator)
+                        if (existingValue == null)
                         {
-                            if (id != null)
-                                throw JsonSerializationException.Create(reader, "Cannot preserve reference to readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            bool createdFromNonDefaultCreator;
+                            IDictionary dictionary = CreateNewDictionary(reader, dictionaryContract, out createdFromNonDefaultCreator);
 
-                            if (contract.OnSerializingCallbacks.Count > 0)
-                                throw JsonSerializationException.Create(reader, "Cannot call OnSerializing on readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            if (createdFromNonDefaultCreator)
+                            {
+                                if (id != null)
+                                    throw JsonSerializationException.Create(reader, "Cannot preserve reference to readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
 
-                            if (contract.OnErrorCallbacks.Count > 0)
-                                throw JsonSerializationException.Create(reader, "Cannot call OnError on readonly list, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                                if (contract.OnSerializingCallbacks.Count > 0)
+                                    throw JsonSerializationException.Create(reader, "Cannot call OnSerializing on readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
 
-                            if (!dictionaryContract.HasParametrizedCreator)
-                                throw JsonSerializationException.Create(reader, "Cannot deserialize readonly or fixed size dictionary: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                                if (contract.OnErrorCallbacks.Count > 0)
+                                    throw JsonSerializationException.Create(reader, "Cannot call OnError on readonly list, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+
+                                if (!dictionaryContract.HasParametrizedCreator)
+                                    throw JsonSerializationException.Create(reader, "Cannot deserialize readonly or fixed size dictionary: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            }
+
+                            PopulateDictionary(dictionary, reader, dictionaryContract, member, id);
+
+                            if (createdFromNonDefaultCreator)
+                            {
+                                return dictionaryContract.ParametrizedCreator(dictionary);
+                            }
+                            else if (dictionary is IWrappedDictionary)
+                            {
+                                return ((IWrappedDictionary)dictionary).UnderlyingDictionary;
+                            }
+
+                            targetDictionary = dictionary;
+                        }
+                        else
+                        {
+                            targetDictionary = PopulateDictionary(dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(existingValue) : (IDictionary)existingValue, reader, dictionaryContract, member, id);
                         }
 
-                        PopulateDictionary(dictionary, reader, dictionaryContract, member, id);
-
-                        if (createdFromNonDefaultCreator)
-                        {
-                            return dictionaryContract.ParametrizedCreator(dictionary);
-                        }
-                        else if (dictionary is IWrappedDictionary)
-                        {
-                            return ((IWrappedDictionary)dictionary).UnderlyingDictionary;
-                        }
-
-                        targetDictionary = dictionary;
+                        return targetDictionary;
                     }
-                    else
-                    {
-                        targetDictionary = PopulateDictionary(dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(existingValue) : (IDictionary)existingValue, reader, dictionaryContract, member, id);
-                    }
-
-                    return targetDictionary;
-                }
 #if !(NET35 || NET20 || PORTABLE40)
                 case JsonContractType.Dynamic:
                     JsonDynamicContract dynamicContract = (JsonDynamicContract)contract;
@@ -730,9 +730,9 @@ namespace Newtonsoft.Json.Serialization
 
                 if (objectType != null
 #if !(NET35 || NET20 || PORTABLE40)
-                    && objectType != typeof(IDynamicMetaObjectProvider)
+ && objectType != typeof(IDynamicMetaObjectProvider)
 #endif
-                    && !objectType.IsAssignableFrom(specifiedType))
+ && !objectType.IsAssignableFrom(specifiedType))
                     throw JsonSerializationException.Create(reader, "Type specified in JSON '{0}' is not compatible with '{1}'.".FormatWith(CultureInfo.InvariantCulture, specifiedType.AssemblyQualifiedName, objectType.AssemblyQualifiedName));
 
                 objectType = specifiedType;
@@ -835,9 +835,9 @@ namespace Newtonsoft.Json.Serialization
         {
             return (contract == null || contract.UnderlyingType == typeof(object) || contract.ContractType == JsonContractType.Linq
 #if !(NET35 || NET20 || PORTABLE40)
-                    || contract.UnderlyingType == typeof(IDynamicMetaObjectProvider)
+ || contract.UnderlyingType == typeof(IDynamicMetaObjectProvider)
 #endif
-                );
+);
         }
 
         private object EnsureType(JsonReader reader, object value, CultureInfo culture, JsonContract contract, Type targetType)
@@ -1904,7 +1904,7 @@ namespace Newtonsoft.Json.Serialization
             {
                 if (!objectContract.IsInstantiable)
                     throw JsonSerializationException.Create(reader, "Could not create an instance of type {0}. Type is an interface or abstract class and cannot be instantiated.".FormatWith(CultureInfo.InvariantCulture, objectContract.UnderlyingType));
-                
+
                 throw JsonSerializationException.Create(reader, "Unable to find a constructor to use for type {0}. A class should either have a default constructor, one constructor with arguments or a constructor marked with the JsonConstructor attribute.".FormatWith(CultureInfo.InvariantCulture, objectContract.UnderlyingType));
             }
 
@@ -1926,75 +1926,82 @@ namespace Newtonsoft.Json.Serialization
 
             int initialDepth = reader.Depth;
 
-            bool finished = false;
-            do
+            if (contract.MemberReader != null)
             {
-                switch (reader.TokenType)
+                contract.MemberReader(reader, newObject, GetInternalSerializer());
+            }
+            else
+            {
+                bool finished = false;
+                do
                 {
-                    case JsonToken.PropertyName:
+                    switch (reader.TokenType)
                     {
-                        string memberName = reader.Value.ToString();
-
-                        if (CheckPropertyName(reader, memberName))
-                            continue;
-
-                        try
-                        {
-                            // attempt exact case match first
-                            // then try match ignoring case
-                            JsonProperty property = contract.Properties.GetClosestMatchProperty(memberName);
-
-                            if (property == null)
+                        case JsonToken.PropertyName:
                             {
-                                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
-                                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
+                                string memberName = reader.Value.ToString();
 
-                                if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
-                                    throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType.Name));
+                                if (CheckPropertyName(reader, memberName))
+                                    continue;
 
-                                if (!reader.Read())
-                                    break;
+                                try
+                                {
+                                    // attempt exact case match first
+                                    // then try match ignoring case
+                                    JsonProperty property = contract.Properties.GetClosestMatchProperty(memberName);
 
-                                SetExtensionData(contract, member, reader, memberName, newObject);
-                                continue;
+                                    if (property == null)
+                                    {
+                                        if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                                            TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
+
+                                        if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
+                                            throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType.Name));
+
+                                        if (!reader.Read())
+                                            break;
+
+                                        SetExtensionData(contract, member, reader, memberName, newObject);
+                                        continue;
+                                    }
+
+                                    if (property.PropertyContract == null)
+                                        property.PropertyContract = GetContractSafe(property.PropertyType);
+
+                                    JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.MemberConverter, contract, member);
+
+                                    if (!ReadForType(reader, property.PropertyContract, propertyConverter != null))
+                                        throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+
+                                    SetPropertyPresence(reader, property, propertiesPresence);
+
+                                    // set extension data if property is ignored or readonly
+                                    if (!SetPropertyValue(property, propertyConverter, contract, member, reader, newObject))
+                                        SetExtensionData(contract, member, reader, memberName, newObject);
+                                }
+                                catch (Exception ex)
+                                {
+                                    if (IsErrorHandled(newObject, contract, memberName, reader as IJsonLineInfo, reader.Path, ex))
+                                        HandleError(reader, true, initialDepth);
+                                    else
+                                        throw;
+                                }
+                                break;
                             }
-
-                            if (property.PropertyContract == null)
-                                property.PropertyContract = GetContractSafe(property.PropertyType);
-
-                            JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.MemberConverter, contract, member);
-
-                            if (!ReadForType(reader, property.PropertyContract, propertyConverter != null))
-                                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
-
-                            SetPropertyPresence(reader, property, propertiesPresence);
-
-                            // set extension data if property is ignored or readonly
-                            if (!SetPropertyValue(property, propertyConverter, contract, member, reader, newObject))
-                                SetExtensionData(contract, member, reader, memberName, newObject);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (IsErrorHandled(newObject, contract, memberName, reader as IJsonLineInfo, reader.Path, ex))
-                                HandleError(reader, true, initialDepth);
-                            else
-                                throw;
-                        }
-                        break;
+                        case JsonToken.EndObject:
+                            finished = true;
+                            break;
+                        case JsonToken.Comment:
+                            // ignore
+                            break;
+                        default:
+                            throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
                     }
-                    case JsonToken.EndObject:
-                        finished = true;
-                        break;
-                    case JsonToken.Comment:
-                        // ignore
-                        break;
-                    default:
-                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
-                }
-            } while (!finished && reader.Read());
+                } while (!finished && reader.Read());
 
-            if (!finished)
-                ThrowUnexpectedEndException(reader, contract, newObject, "Unexpected end when deserializing object.");
+                if (!finished)
+                    ThrowUnexpectedEndException(reader, contract, newObject, "Unexpected end when deserializing object.");
+            }
 
             EndObject(newObject, reader, contract, initialDepth, propertiesPresence);
 

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -391,7 +391,7 @@ namespace Newtonsoft.Json.Serialization
             WriteObjectStart(writer, value, contract, member, collectionContract, containerProperty);
 
             int initialDepth = writer.Top;
-
+            
             for (int index = 0; index < contract.Properties.Count; index++)
             {
                 JsonProperty property = contract.Properties[index];
@@ -415,6 +415,11 @@ namespace Newtonsoft.Json.Serialization
                 }
             }
 
+            if (contract.MemberWriter != null)
+            {
+                contract.MemberWriter(writer, value, GetInternalSerializer());
+            }
+            
             if (contract.ExtensionDataGetter != null)
             {
                 IEnumerable<KeyValuePair<object, object>> extensionData = contract.ExtensionDataGetter(value);


### PR DESCRIPTION
Custom member (de)serialization allows me to have more control over serialization and decide at runtime what and how to serialize. Member abstraction (TypeHandling.Auto) works with this too. It was hard/impossible to get it working with Extension Data.

Using custom member (de)serialization and few other classes makes possible this, I'm used to this syntax from SharpDX.IDataSerializable:

```
public class Control : IJsonSerializable
{
    public string Name;
    public Vector2 Position;
    public Vector2 Size { get; set; }
    public HashSet<Control> Controls = new HashSet<Control>();

    // Same method used for serialization and deserialization
    public virtual void Serialize(JsonSerializableContext context)
    {
        if (context.Writing)
        {
            context.Serialize("Name", "--unnamed--");
        }
        else
        {
            context.Serialize("OldName", ref Name);
            context.Serialize("Name", ref Name);
        }

        if (Position != Vector2.Zero) // Decide here if serialize or not (similar to ShouldSerialize)
        {
            context.Serialize("Position", ref Position);
        }
        context.Serialize(() => Size); // Possible like this (this expression gets cached)
        //context.Serialize("Size", ref Size); // Or like this
        context.Serialize("Controls", ref Controls);
    }
}
```
