### PR TITLE
Removing the redundant requirement of having "fields property with empty array"

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
@@ -42,7 +42,7 @@ namespace Newtonsoft.Json.Tests.Converters
         {
             string json = JsonConvert.SerializeObject(Currency.AUD);
 
-            Assert.AreEqual(@"{""Case"":""AUD"",""Fields"":[]}", json);
+            Assert.AreEqual(@"{""Case"":""AUD""}", json);
         }
 
         [Test]
@@ -56,10 +56,10 @@ namespace Newtonsoft.Json.Tests.Converters
         [Test]
         public void DeserializeBasicUnion()
         {
-            Currency c = JsonConvert.DeserializeObject<Currency>(@"{""Case"":""AUD"",""Fields"":[]}");
+            Currency c = JsonConvert.DeserializeObject<Currency>(@"{""Case"":""AUD""}");
             Assert.AreEqual(Currency.AUD, c);
 
-            c = JsonConvert.DeserializeObject<Currency>(@"{""Fields"":[],""Case"":""EUR""}");
+            c = JsonConvert.DeserializeObject<Currency>(@"{""Case"":""EUR""}");
             Assert.AreEqual(Currency.EUR, c);
 
             c = JsonConvert.DeserializeObject<Currency>(@"null");
@@ -94,12 +94,6 @@ namespace Newtonsoft.Json.Tests.Converters
         public void DeserializeBasicUnion_NoCaseName()
         {
             ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Currency>(@"{""Fields"":[1]}"), "No 'Case' property with union name found. Path '', line 1, position 14.");
-        }
-
-        [Test]
-        public void DeserializeBasicUnion_NoFields()
-        {
-            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Currency>(@"{""Case"":""AUD""}"), "No 'Fields' property with union fields found. Path '', line 1, position 14.");
         }
 
         [Test]


### PR DESCRIPTION
Thanks @JamesNK for coming out with an excellent support for JSON Serialization & Deserialization of F# Discriminated Union. 

In FSharp, Values are optionals in the [Discriminated Union](http://msdn.microsoft.com/en-us/library/vstudio/dd233226%28v=vs.100%29.aspx). But In JSON.NET library we are forced to have an empty "Fields" array in order to serialize the discriminated unions with empty values.

IMHO, it is redundant and we can relax this requirement. This pull request would solve this by removing this constraint.

_Before Change_
![before change](https://cloud.githubusercontent.com/assets/1128916/4368553/81abca68-42ef-11e4-8087-4cfcd5d134bd.png)
_After Change_
![after change](https://cloud.githubusercontent.com/assets/1128916/4368557/877ec710-42ef-11e4-83f5-d0ab2460b492.png)
