### PR TITLE
Fix InvalidCastException when deserializing a GUID from BSON.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Bson/BsonReaderTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Bson/BsonReaderTests.cs
@@ -1708,6 +1708,26 @@ namespace Newtonsoft.Json.Tests.Bson
             CollectionAssert.AreEquivalent(g.ToByteArray(), b.TheGuid);
         }
 
+        [Test]
+        public void DeserializeBsonDocumentWithString()
+        {
+            byte[] data = HexToBytes("10-00-00-00-02-62-00-04-00-00-00-61-62-63-00-00");
+            JsonSerializer serializer = new JsonSerializer();
+            JObject jObj = (JObject)serializer.Deserialize(new BsonReader(new MemoryStream(data)));
+            string stringValue = jObj.Value<string>("b");
+            Assert.AreEqual("abc", stringValue);
+        }
+
+        [Test]
+        public void DeserializeBsonDocumentWithGuid()
+        {
+            byte[] data = HexToBytes("1D-00-00-00-05-62-00-10-00-00-00-04-DF-41-E3-E2-39-EE-BB-4C-86-C0-06-A7-64-33-61-E1-00");
+            JsonSerializer serializer = new JsonSerializer();
+            JObject jObj = (JObject)serializer.Deserialize(new BsonReader(new MemoryStream(data)));
+            Guid guidValue = jObj.Value<Guid>("b");
+            Assert.AreEqual(new Guid("e2e341df-ee39-4cbb-86c0-06a7643361e1"), guidValue);
+        }
+
         public class BytesTestClass
         {
             public byte[] TheGuid { get; set; }

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -549,7 +549,10 @@ namespace Newtonsoft.Json
                         WriteRawValue((reader.Value != null) ? reader.Value.ToString() : null);
                         break;
                     case JsonToken.Bytes:
-                        WriteValue((byte[])reader.Value);
+                        if (reader.Value is Guid)
+                            WriteValue((Guid)reader.Value);
+                        else
+                            WriteValue((byte[])reader.Value);
                         break;
                     default:
                         throw MiscellaneousUtils.CreateArgumentOutOfRangeException("TokenType", reader.TokenType, "Unexpected token type.");


### PR DESCRIPTION
Issue: When attempting to deserialize a GUID from BSON, an exception is thrown by the JsonWriter class.

```
System.InvalidCastException : Unable to cast object of type 'System.Guid' to type 'System.Byte[]'.
   at Newtonsoft.Json.JsonWriter.WriteToken(JsonReader reader, Int32 initialDepth, Boolean writeChildren, Boolean writeDateConstructorAsDate) in JsonWriter.cs: line 555
   at Newtonsoft.Json.JsonWriter.WriteToken(JsonReader reader, Boolean writeChildren, Boolean writeDateConstructorAsDate) in JsonWriter.cs: line 463
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateJObject(JsonReader reader) in JsonSerializerInternalReader.cs: line 251
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue) in JsonSerializerInternalReader.cs: line 426
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue) in JsonSerializerInternalReader.cs: line 280
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent) in JsonSerializerInternalReader.cs: line 186
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType) in JsonSerializer.cs: line 710
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType) in JsonSerializer.cs: line 689
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader) in JsonSerializer.cs: line 653
   at Newtonsoft.Json.Tests.Bson.BsonReaderTests.DeserializeBsonDocumentWithGuid() in BsonReaderTests.cs: line 1727
```

To reproduce:

```
var stream = new MemoryStream();
serializer.Serialize(new BsonWriter(stream), new[] { Guid.NewGuid() });
stream.Position = 0;
serializer.Deserialize(new BsonReader(stream));
```

All unit tests still pass.
