### PR TITLE
Enable string type schemas for enums.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
@@ -763,7 +763,7 @@ namespace Newtonsoft.Json.Tests.Schema
 }", json);
         }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(StringEnumConverter), true)]
         public enum SortTypeFlagAsString
         {
             No = 0,
@@ -778,7 +778,6 @@ namespace Newtonsoft.Json.Tests.Schema
 
 #if !ASPNETCORE50
         [Test]
-        [Ignore]
         public void GenerateSchemaWithStringEnum()
         {
             JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator();
@@ -788,7 +787,7 @@ namespace Newtonsoft.Json.Tests.Schema
 
             // NOTE: This fails because the enum is serialized as an integer and not a string.
             // NOTE: There should exist a way to serialize the enum as lowercase strings.
-            Assert.AreEqual(@"{
+            StringAssert.AreEqual(@"{
   ""type"": ""object"",
   ""properties"": {
     ""y"": {

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -33,6 +33,8 @@ using Newtonsoft.Json.Utilities;
 using Newtonsoft.Json.Utilities.LinqBridge;
 #else
 using System.Linq;
+using Newtonsoft.Json.Schema;
+using Newtonsoft.Json.Linq;
 
 #endif
 
@@ -63,6 +65,15 @@ namespace Newtonsoft.Json.Converters
         public StringEnumConverter()
         {
             AllowIntegerValues = true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringEnumConverter"/> class.
+        /// </summary>
+        /// <param name="camelCaseText"><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</param>
+        public StringEnumConverter(bool camelCaseText) : this()
+        {
+            CamelCaseText = camelCaseText;
         }
 
         /// <summary>
@@ -234,6 +245,45 @@ namespace Newtonsoft.Json.Converters
             }
 
             return map;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonSchema"/> of the JSON produced by the JsonConverter.
+        /// </summary>
+        /// <param name="objectType">The type of the object.</param>
+        /// <returns>The <see cref="JsonSchema"/> of the JSON produced by the JsonConverter.</returns>
+        public override JsonSchema GetSchema(Type objectType)
+        {
+            bool isNullable = ReflectionUtils.IsNullableType(objectType);
+            Type t = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
+
+            if (!t.IsEnum())
+                return null;
+
+            JsonSchema schema = new JsonSchema();
+            schema.Type = JsonSchemaType.String;
+            if(isNullable)
+            {
+                schema.Type |= JsonSchemaType.Null; 
+            }
+
+            schema.Required = !isNullable;
+            schema.Enum = new List<JToken>();
+
+            BidirectionalDictionary<string, string> map = EnumMemberNamesPerType.Get(t);
+            string[] names = Enum.GetNames(t);
+
+            foreach(string name in names)
+            {
+                string resolvedName = ResolvedEnumName(map, name);
+                if (CamelCaseText)
+                    resolvedName = StringUtils.ToCamelCase(resolvedName);
+
+                schema.Enum.Add(JValue.CreateString(resolvedName));
+            }
+
+            return schema;
+
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonConverter.cs
+++ b/Src/Newtonsoft.Json/JsonConverter.cs
@@ -66,8 +66,9 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Gets the <see cref="JsonSchema"/> of the JSON produced by the JsonConverter.
         /// </summary>
+        /// <param name="objectType">The type of the object.</param>
         /// <returns>The <see cref="JsonSchema"/> of the JSON produced by the JsonConverter.</returns>
-        public virtual JsonSchema GetSchema()
+        public virtual JsonSchema GetSchema(Type objectType)
         {
             return null;
         }

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
@@ -244,7 +244,7 @@ namespace Newtonsoft.Json.Schema
             JsonConverter converter;
             if ((converter = contract.Converter) != null || (converter = contract.InternalConverter) != null)
             {
-                JsonSchema converterSchema = converter.GetSchema();
+                JsonSchema converterSchema = converter.GetSchema(type);
                 if (converterSchema != null)
                     return converterSchema;
             }


### PR DESCRIPTION
This code allows the generation of schemas for enums rendered as strings. I modified the existing GetSchema method in JsonConverter, adding a type parameter in order to enumerate the available enum names. This change to the interface of JsonConverter does not appear to cause any problems, as GetSchema was only called in one place: the JsonSchemaGenerator class.

This fixes the GenerateSchemaWithEnumString test, and so the Ignore attribute on that test has been removed.
