### PR TITLE
Support reference preservation for ISerializable objects.

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonFormatterConverter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonFormatterConverter.cs
@@ -34,13 +34,18 @@ namespace Newtonsoft.Json.Serialization
 {
     internal class JsonFormatterConverter : IFormatterConverter
     {
-        private readonly JsonSerializer _serializer;
+        private readonly JsonSerializerInternalReader _reader;
+        private readonly JsonISerializableContract _contract;
+        private readonly JsonProperty _member;
 
-        public JsonFormatterConverter(JsonSerializer serializer)
+        public JsonFormatterConverter(JsonSerializerInternalReader reader, JsonISerializableContract contract, JsonProperty member)
         {
-            ValidationUtils.ArgumentNotNull(serializer, "serializer");
+            ValidationUtils.ArgumentNotNull(reader, "serializer");
+            ValidationUtils.ArgumentNotNull(contract, "contract");
 
-            _serializer = serializer;
+            _reader = reader;
+            _contract = contract;
+            _member = member;
         }
 
         private T GetTokenValue<T>(object value)
@@ -59,7 +64,7 @@ namespace Newtonsoft.Json.Serialization
             if (token == null)
                 throw new ArgumentException("Value is not a JToken.", "value");
 
-            return _serializer.Deserialize(token.CreateReader(), type);
+            return _reader.CreateISerializableItem(token, type, _contract, _member);
         }
 
         public object Convert(object value, TypeCode typeCode)

--- a/Src/Newtonsoft.Json/Serialization/JsonISerializableContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonISerializableContract.cs
@@ -25,6 +25,7 @@
 
 #if !(NETFX_CORE || PORTABLE || PORTABLE40)
 using System;
+using System.Runtime.Serialization;
 
 namespace Newtonsoft.Json.Serialization
 {
@@ -40,6 +41,12 @@ namespace Newtonsoft.Json.Serialization
         public ObjectConstructor<object> ISerializableCreator { get; set; }
 
         /// <summary>
+        /// Gets whether the type implements IDeserializationCallback.
+        /// </summary>
+        /// <value>True if the type implements IDeserialiationCallback, otherwise false.</value>
+        public bool HasDeserializationCallback { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JsonISerializableContract"/> class.
         /// </summary>
         /// <param name="underlyingType">The underlying type for the contract.</param>
@@ -47,6 +54,7 @@ namespace Newtonsoft.Json.Serialization
             : base(underlyingType)
         {
             ContractType = JsonContractType.Serializable;
+            HasDeserializationCallback = typeof(IDeserializationCallback).IsAssignableFrom(underlyingType);
         }
     }
 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -749,7 +749,12 @@ To fix this error either change the environment to be fully trusted, change the 
             {
                 JsonContract valueContract = GetContractSafe(serializationEntry.Value);
 
-                if (CheckForCircularReference(writer, serializationEntry.Value, null, valueContract, contract, member))
+                if (ShouldWriteReference(serializationEntry.Value, null, valueContract, contract, member))
+                {
+                    writer.WritePropertyName(serializationEntry.Name);
+                    WriteReference(writer, serializationEntry.Value);
+                }
+                else if (CheckForCircularReference(writer, serializationEntry.Value, null, valueContract, contract, member))
                 {
                     writer.WritePropertyName(serializationEntry.Name);
                     SerializeValue(writer, serializationEntry.Value, valueContract, null, contract, member);


### PR DESCRIPTION
Makes it possible to serialize references with ISerializable objects by adhering to the IDeserializationCallback pattern used in the .NET Framework.
