### PR TITLE
Adding support to use XML schemas for XML to JSON conversion

### DIFF
--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -26,6 +26,7 @@
 using System;
 using System.IO;
 using System.Globalization;
+using System.Xml.Schema;
 #if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
 using System.Numerics;
 #endif
@@ -1003,6 +1004,27 @@ namespace Newtonsoft.Json
         public static string SerializeXmlNode(XmlNode node, Formatting formatting, bool omitRootObject)
         {
             XmlNodeConverter converter = new XmlNodeConverter { OmitRootObject = omitRootObject };
+
+            return SerializeObject(node, formatting, converter);
+        }
+
+        /// <summary>
+        /// Serializes the XML node to a JSON string using formatting and omits the root object if <paramref name="omitRootObject"/> is <c>true</c>.
+        /// </summary>
+        /// <param name="node">The node to serialize.</param>
+        /// <param name="formatting">Indicates how the output is formatted.</param>
+        /// <param name="omitRootObject">Omits writing the root object.</param>
+        /// <param name="schemaSet">Schemas to be used for serilization.</param>
+        /// <returns>A JSON string of the XmlNode.</returns>
+        public static string SerializeXmlNode(XmlNode node, Formatting formatting, bool omitRootObject, XmlSchemaSet schemaSet)
+        {
+            SchemaInformation schemaInformation = SchemaInformationFactory.CreateOrGet(schemaSet);
+
+            XmlNodeConverter converter = new XmlNodeConverter 
+            {
+                OmitRootObject = omitRootObject,
+                SchemaInfo = schemaInformation
+            };
 
             return SerializeObject(node, formatting, converter);
         }

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Utilities\MiscellaneousUtils.cs" />
     <Compile Include="Utilities\ReflectionDelegateFactory.cs" />
     <Compile Include="Utilities\ReflectionUtils.cs" />
+    <Compile Include="Utilities\SchemaInformation.cs" />
     <Compile Include="Utilities\StringBuffer.cs" />
     <Compile Include="Utilities\StringReference.cs" />
     <Compile Include="Utilities\StringUtils.cs" />

--- a/Src/Newtonsoft.Json/Utilities/SchemaInformation.cs
+++ b/Src/Newtonsoft.Json/Utilities/SchemaInformation.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Schema;
+
+namespace Newtonsoft.Json.Utilities
+{
+    /// <summary>
+    /// Create object of SchemaInformation class
+    /// </summary>
+    public static class SchemaInformationFactory
+    {
+        private static Dictionary<string, SchemaInformation> schemaInformationObjects = new Dictionary<string, SchemaInformation>();
+
+        /// <summary>
+        /// Create a new object of SchemaInformation class or returns an exting one if already present
+        /// </summary>
+        /// <value>namespace uri string</value>
+        public static SchemaInformation CreateOrGet(XmlSchemaSet schemaSet)
+        {
+            if (null == schemaSet || schemaSet.Count == 0)
+            {
+                SchemaInformation nullSchemaInformation = new SchemaInformation(schemaSet);
+                return nullSchemaInformation;
+            }
+
+            if (!schemaSet.IsCompiled)
+            {
+                schemaSet.Compile();
+            }
+
+            string schemaId = null;
+
+            foreach (XmlSchema firstSchema in schemaSet.Schemas())
+            {
+                IEnumerator elementEnumerator = firstSchema.Elements.Values.GetEnumerator();
+                elementEnumerator.MoveNext();
+                XmlSchemaElement rootElement = (XmlSchemaElement)elementEnumerator.Current;
+
+                schemaId = firstSchema.TargetNamespace + "/" + rootElement.Name;
+                break;              
+            }
+            
+            SchemaInformation schemaInformation;
+
+            if (schemaInformationObjects.TryGetValue(schemaId, out schemaInformation))
+            {
+                return schemaInformation;
+            }
+            else
+            {
+                lock (schemaInformationObjects)
+                {
+                    if (schemaInformationObjects.TryGetValue(schemaId, out schemaInformation))
+                    {
+                        return schemaInformation;
+                    }
+                    else
+                    {
+                        schemaInformation = new SchemaInformation(schemaSet);
+                        schemaInformationObjects.Add(schemaId, schemaInformation);
+                        return schemaInformation;
+                    }
+                }
+            }
+
+        }
+    }
+
+    /// <summary>
+    /// Stores serialization properties, data type and array information from an xsd to a dictionary
+    /// </summary>
+    public class SchemaInformation : Dictionary<string, ElementInformation>
+    {
+        public SchemaInformation(XmlSchemaSet schemaSet)
+        {
+            if (null != schemaSet && schemaSet.Count > 0)
+            {
+                this.TraverseSchema(schemaSet);
+            }
+        }
+
+        private void TraverseSchema(XmlSchemaSet schemaSet)
+        {
+            foreach (XmlSchema schema in schemaSet.Schemas())
+            {
+                foreach (XmlSchemaElement element in schema.Elements.Values)
+                {
+                    this.ProcessElement(element);
+                }
+
+                foreach (XmlSchemaComplexType type in schema.SchemaTypes.Values)
+                {
+                    ProcessSchemaObject(type.ContentTypeParticle);
+                }
+            }
+        }
+
+        private void ProcessElement(XmlSchemaElement element)
+        {
+            ElementInformation elementInformation = new ElementInformation();
+
+            if (element.MaxOccurs > 1)
+            {
+                elementInformation.IsArray = true;
+            }
+
+            if (element.ElementSchemaType is XmlSchemaSimpleType && null != element.ElementSchemaType.Datatype)
+            {
+                elementInformation.DataType = element.ElementSchemaType.Datatype.ValueType;
+            }
+
+            if (!this.ContainsKey(element.Name.ToString()))
+            {
+                this.Add(element.Name.ToString(), elementInformation);
+            }
+
+            if (element.ElementSchemaType is XmlSchemaComplexType)
+            {
+                XmlSchemaComplexType complexType = element.ElementSchemaType as XmlSchemaComplexType;
+
+                this.ProcessSchemaObject(complexType.ContentTypeParticle);
+            }
+        }
+
+        private void ProcessSequence(XmlSchemaSequence sequence)
+        {
+            this.ProcessItemCollection(sequence.Items);
+        }
+
+        private void ProcessChoice(XmlSchemaChoice choice)
+        {
+            this.ProcessItemCollection(choice.Items);
+        }
+
+        private void ProcessItemCollection(XmlSchemaObjectCollection objs)
+        {
+            foreach (XmlSchemaObject obj in objs)
+                this.ProcessSchemaObject(obj);
+        }
+
+        private void ProcessSchemaObject(XmlSchemaObject obj)
+        {
+            if (obj is XmlSchemaElement)
+                this.ProcessElement(obj as XmlSchemaElement);
+            if (obj is XmlSchemaChoice)
+                this.ProcessChoice(obj as XmlSchemaChoice);
+            if (obj is XmlSchemaSequence)
+                this.ProcessSequence(obj as XmlSchemaSequence);
+        }
+    }
+
+    /// <summary>
+    /// Class to store Data type and Array information for an xml element
+    /// </summary>
+    public class ElementInformation
+    {
+        /// <summary>
+        /// Stores Data type information for an xml element
+        /// </summary>
+        public Type DataType { get; set; }
+
+        /// <summary>
+        /// Stores Array information for an xml element
+        /// </summary>
+        public bool IsArray { get; set; }
+    }
+}


### PR DESCRIPTION
As we know xml only contains data it doesn't have data type information. While converting from XML to JSON we need to identify data type of each xml node, So We have modified the library to take a xml schema and read the data type from the schema. 
There exist a similar problem to identify a json array of single element. the current version of this library rely on a "ns:Array" attribute to identify single element array in json, but we can not expect a xml coming from any arbitrary system to have this kind of attribute present. this problem can also we solved by using xml schemas. 