### PR TITLE
A way to simplify customized serialization usage

### DIFF
--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -565,7 +565,7 @@ namespace Newtonsoft.Json
         /// Serializes the specified object to a JSON string using a collection of <see cref="JsonConverter"/>.
         /// </summary>
         /// <param name="value">The object to serialize.</param>
-        /// <param name="converters">A collection converters used while serializing.</param>
+        /// <param name="converters">A collection of converters used while serializing. This will override the pre-registered converters.</param>
         /// <returns>A JSON string representation of the object.</returns>
         public static string SerializeObject(object value, params JsonConverter[] converters)
         {
@@ -581,7 +581,7 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="value">The object to serialize.</param>
         /// <param name="formatting">Indicates how the output is formatted.</param>
-        /// <param name="converters">A collection converters used while serializing.</param>
+        /// <param name="converters">A collection of converters used while serializing. This will override the pre-registered converters.</param>
         /// <returns>A JSON string representation of the object.</returns>
         public static string SerializeObject(object value, Formatting formatting, params JsonConverter[] converters)
         {
@@ -824,7 +824,7 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
         /// <param name="value">The JSON to deserialize.</param>
-        /// <param name="converters">Converters to use while deserializing.</param>
+        /// <param name="converters">Converters to use while deserializing. This will override the pre-registered converters.</param>
         /// <returns>The deserialized object from the JSON string.</returns>
         public static T DeserializeObject<T>(string value, params JsonConverter[] converters)
         {
@@ -851,7 +851,7 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="value">The JSON to deserialize.</param>
         /// <param name="type">The type of the object to deserialize.</param>
-        /// <param name="converters">Converters to use while deserializing.</param>
+        /// <param name="converters">Converters to use while deserializing. This will override the pre-registered converters.</param>
         /// <returns>The deserialized object from the JSON string.</returns>
         public static object DeserializeObject(string value, Type type, params JsonConverter[] converters)
         {

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -53,12 +53,12 @@ namespace Newtonsoft.Json
     /// </example>
     public static class JsonConvert
     {
-        private static readonly Dictionary<Type, JsonConverter> _registeredJsonConverters = new Dictionary<Type, JsonConverter>();
+        private static readonly Dictionary<Type, JsonConverter[]> _registeredJsonConverters = new Dictionary<Type, JsonConverter[]>();
         /// <summary>
         /// Gets or sets pre-registered JsonConverters that automatically used by
         /// serialization and deserialization methods.
         /// </summary>
-        public static Dictionary<Type, JsonConverter> RegisteredJsonConverters { get { return _registeredJsonConverters; } }
+        public static Dictionary<Type, JsonConverter[]> RegisteredJsonConverters { get { return _registeredJsonConverters; } }
 
         /// <summary>
         /// Gets or sets a function that creates default <see cref="JsonSerializerSettings"/>.

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -688,7 +688,7 @@ namespace Newtonsoft.Json
 
         private static string SerializeObjectInternal(object value, Type type, JsonSerializer jsonSerializer)
         {
-            if (0 == jsonSerializer.Converters.Count)
+            if (null != value && 0 == jsonSerializer.Converters.Count)
             {
                 JsonConverter[] jsonConverters;
                 if (_registeredJsonConverters.TryGetValue(value.GetType(), out jsonConverters))

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -130,6 +130,27 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Unregister JsonConverter[] for type T.
+        /// </summary>
+        /// <typeparam name="T">Type to unregister JsonConverters for.</typeparam>
+        public static void UnregisterJsonConverters<T>()
+        {
+            UnregisterJsonConverters(typeof(T));
+        }
+
+        /// <summary>
+        /// Unregister JsonConverter[] for specified type.
+        /// </summary>
+        /// <param name="type">Type to unregister JsonConverters for.</param>
+        /// <exception cref="ArgumentException">The pre-registered type cannot be null.</exception>
+        private static void UnregisterJsonConverters(Type type)
+        {
+            if (null == type)
+                throw new ArgumentException("The pre-registered type cannot be null.", "type");
+            _registeredJsonConverters.Remove(type);
+        }
+
+        /// <summary>
         /// Converts the <see cref="DateTime"/> to its JSON string representation.
         /// </summary>
         /// <param name="value">The value to convert.</param>

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -688,10 +688,10 @@ namespace Newtonsoft.Json
 
         private static string SerializeObjectInternal(object value, Type type, JsonSerializer jsonSerializer)
         {
-            if (null != type && 0 == jsonSerializer.Converters.Count)
+            if (0 == jsonSerializer.Converters.Count)
             {
                 JsonConverter[] jsonConverters;
-                if (_registeredJsonConverters.TryGetValue(type, out jsonConverters))
+                if (_registeredJsonConverters.TryGetValue(value.GetType(), out jsonConverters))
                     for (int i = 0; i < jsonConverters.Length; i++)
                         jsonSerializer.Converters.Insert(i, jsonConverters[i]);
             }

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -105,6 +105,31 @@ namespace Newtonsoft.Json
         public static readonly string NaN = "NaN";
 
         /// <summary>
+        /// Register customized JsonConverters in advance, which can be automatically
+        /// used by serialization and deserialization methods.
+        /// </summary>
+        /// <param name="jsonConverters">The customized JsonConverters.</param>
+        /// <typeparam name="T">Type to register JsonConverters for.</typeparam>
+        public static void RegisterJsonConverters<T>(params JsonConverter[] jsonConverters)
+        {
+            RegisterJsonConverters(typeof (T), jsonConverters);
+        }
+
+        /// <summary>
+        /// Register customized JsonConverters in advance, which can be automatically
+        /// used by serialization and deserialization methods.
+        /// </summary>
+        /// <param name="type">Type to register JsonConverters for.</param>
+        /// <param name="jsonConverters">The customized JsonConverters.</param>
+        /// <exception cref="ArgumentException">The pre-registered type cannot be null.</exception>
+        public static void RegisterJsonConverters(Type type, params JsonConverter[] jsonConverters)
+        {
+            if(null == type)
+                throw new ArgumentException("The pre-registered type cannot be null.", "type");
+            _registeredJsonConverters[type] = jsonConverters;
+        }
+
+        /// <summary>
         /// Converts the <see cref="DateTime"/> to its JSON string representation.
         /// </summary>
         /// <param name="value">The value to convert.</param>

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -642,9 +642,13 @@ namespace Newtonsoft.Json
 
         private static string SerializeObjectInternal(object value, Type type, JsonSerializer jsonSerializer)
         {
-            JsonConverter jsonConverter;
-            if (_registeredJsonConverters.TryGetValue(type, out jsonConverter) && !jsonSerializer.Converters.Contains(jsonConverter))
-                jsonSerializer.Converters.Add(jsonConverter);
+            if (null != type && 0 == jsonSerializer.Converters.Count)
+            {
+                JsonConverter[] jsonConverters;
+                if (_registeredJsonConverters.TryGetValue(type, out jsonConverters))
+                    for (int i = 0; i < jsonConverters.Length; i++)
+                        jsonSerializer.Converters.Insert(i, jsonConverters[i]);
+            }
 
             StringBuilder sb = new StringBuilder(256);
             StringWriter sw = new StringWriter(sb, CultureInfo.InvariantCulture);
@@ -849,9 +853,13 @@ namespace Newtonsoft.Json
 
             JsonSerializer jsonSerializer = JsonSerializer.CreateDefault(settings);
 
-            JsonConverter jsonConverter;
-            if (_registeredJsonConverters.TryGetValue(type, out jsonConverter) && !jsonSerializer.Converters.Contains(jsonConverter))
-                jsonSerializer.Converters.Add(jsonConverter);
+            if (null != type && 0 == jsonSerializer.Converters.Count)
+            {
+                JsonConverter[] jsonConverters;
+                if (_registeredJsonConverters.TryGetValue(type, out jsonConverters))
+                    for (int i = 0; i < jsonConverters.Length; i++)
+                        jsonSerializer.Converters.Insert(i, jsonConverters[i]);
+            }
 
             // by default DeserializeObject should check for additional content
             if (!jsonSerializer.IsCheckAdditionalContentSet())


### PR DESCRIPTION
A **static Dictionary\<Type, JsonConverter[]\>** was added to JsonConvert class, which the "final" **SerializeObjectInternal** and **DeserializeObject** method will automaticlly get the right **JsonConverter[]** from, if any.

So, by registering a **custom JsonConverter[]** in advance, the serialization/deserialization code need **not** to pass **JsonConverter[]** everytime any more.

But, if **JsonConverter[]** was passed explicitly, the passed **JsonConverter[]** will override the registered ones. So that the behavior of existing code will not change.

This idea comes from MongoDB serialization mechanism, which is very convenient.