### PR TITLE
Customize type attribute

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
@@ -226,7 +226,7 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
-        public void SerializeRootTypeNameWithCustomTypeAttributeIfDerivedWithAuto()
+        public void SerializeRootTypeNameWithCustomTypeNamePropertyIfDerivedWithAuto()
         {
             var serializer = new JsonSerializer()
             {
@@ -359,7 +359,7 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
-        public void DeserializeTypeNameWithCustomTypeAttribute()
+        public void DeserializeTypeNameWithCustomTypeNameProperty()
         {
             string employeeRef = ReflectionUtils.GetTypeName(typeof(EmployeeReference), FormatterAssemblyStyle.Simple, null);
 

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -129,6 +129,7 @@ namespace Newtonsoft.Json
         internal FloatParseHandling _floatParseHandling;
         private string _dateFormatString;
         private readonly List<JsonPosition> _stack;
+        private string _typeNameProperty;
 
         /// <summary>
         /// Gets the current reader state.
@@ -201,6 +202,15 @@ namespace Newtonsoft.Json
         {
             get { return _dateFormatString; }
             set { _dateFormatString = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the metadata property containing the type name.
+        /// </summary>
+        public string TypeNameProperty
+        {
+            get { return _typeNameProperty ?? JsonSerializerSettings.DefaultTypeNameProperty; }
+            set { _typeNameProperty = value; }
         }
 
         /// <summary>
@@ -796,7 +806,7 @@ namespace Newtonsoft.Json
                 if (!ReadInternal())
                     throw JsonReaderException.Create(this, "Unexpected end when reading bytes.");
 
-                if (Value.ToString() == JsonTypeReflector.TypePropertyName)
+                if (Value.ToString() == TypeNameProperty)
                 {
                     ReadInternal();
                     if (Value != null && Value.ToString().StartsWith("System.Byte[]", StringComparison.Ordinal))

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -44,6 +44,7 @@ namespace Newtonsoft.Json
     public class JsonSerializer
     {
         internal TypeNameHandling _typeNameHandling;
+        internal string _typeNameProperty;
         internal FormatterAssemblyStyle _typeNameAssemblyFormat;
         internal PreserveReferencesHandling _preserveReferencesHandling;
         internal ReferenceLoopHandling _referenceLoopHandling;
@@ -131,6 +132,21 @@ namespace Newtonsoft.Json
                     throw new ArgumentOutOfRangeException("value");
 
                 _typeNameHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the metadata property containing the type name.
+        /// </summary>
+        public string TypeNameProperty
+        {
+            get { return _typeNameProperty; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    throw new ArgumentOutOfRangeException("value");
+
+                _typeNameProperty = value;
             }
         }
 
@@ -531,6 +547,8 @@ namespace Newtonsoft.Json
             // serializer specific
             if (settings._typeNameHandling != null)
                 serializer.TypeNameHandling = settings.TypeNameHandling;
+            if (settings._typeNameProperty != null)
+                serializer.TypeNameProperty = settings.TypeNameProperty;
             if (settings._metadataPropertyHandling != null)
                 serializer.MetadataPropertyHandling = settings.MetadataPropertyHandling;
             if (settings._typeNameAssemblyFormat != null)

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -140,7 +140,7 @@ namespace Newtonsoft.Json
         /// </summary>
         public string TypeNameProperty
         {
-            get { return _typeNameProperty; }
+            get { return _typeNameProperty ?? JsonSerializerSettings.DefaultTypeNameProperty; }
             set
             {
                 if (string.IsNullOrEmpty(value))
@@ -646,7 +646,8 @@ namespace Newtonsoft.Json
             FloatParseHandling? previousFloatParseHandling;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            string previousTypeNameProperty;
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString, out previousTypeNameProperty);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? new TraceJsonReader(reader)
@@ -658,7 +659,7 @@ namespace Newtonsoft.Json
             if (traceJsonReader != null)
                 TraceWriter.Trace(TraceLevel.Verbose, "Deserialized JSON: " + Environment.NewLine + traceJsonReader.GetJson(), null);
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString, previousTypeNameProperty);
         }
 
         /// <summary>
@@ -718,7 +719,8 @@ namespace Newtonsoft.Json
             FloatParseHandling? previousFloatParseHandling;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            string previousTypeNameProperty;
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString, out previousTypeNameProperty);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? new TraceJsonReader(reader)
@@ -730,12 +732,12 @@ namespace Newtonsoft.Json
             if (traceJsonReader != null)
                 TraceWriter.Trace(TraceLevel.Verbose, "Deserialized JSON: " + Environment.NewLine + traceJsonReader.GetJson(), null);
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString, previousTypeNameProperty);
 
             return value;
         }
 
-        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out int? previousMaxDepth, out string previousDateFormatString)
+        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out int? previousMaxDepth, out string previousDateFormatString, out string previousTypeNameProperty)
         {
             if (_culture != null && !_culture.Equals(reader.Culture))
             {
@@ -797,6 +799,16 @@ namespace Newtonsoft.Json
                 previousDateFormatString = null;
             }
 
+            if (_typeNameProperty != null && reader.TypeNameProperty != _typeNameProperty)
+            {
+                previousTypeNameProperty = reader.TypeNameProperty;
+                reader.TypeNameProperty = _typeNameProperty;
+            }
+            else
+            {
+                previousTypeNameProperty = null;
+            }
+
             JsonTextReader textReader = reader as JsonTextReader;
             if (textReader != null)
             {
@@ -806,7 +818,7 @@ namespace Newtonsoft.Json
             }
         }
 
-        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, int? previousMaxDepth, string previousDateFormatString)
+        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, int? previousMaxDepth, string previousDateFormatString, string previousTypeNameProperty)
         {
             // reset reader back to previous options
             if (previousCulture != null)
@@ -817,6 +829,8 @@ namespace Newtonsoft.Json
                 reader.DateParseHandling = previousDateParseHandling.Value;
             if (previousFloatParseHandling != null)
                 reader.FloatParseHandling = previousFloatParseHandling.Value;
+            if (previousTypeNameProperty != null)
+                reader.TypeNameProperty = previousTypeNameProperty;
             if (_maxDepthSet)
                 reader.MaxDepth = previousMaxDepth;
             if (_dateFormatStringSet)

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -45,6 +45,7 @@ namespace Newtonsoft.Json
         internal const PreserveReferencesHandling DefaultPreserveReferencesHandling = PreserveReferencesHandling.None;
         internal const ConstructorHandling DefaultConstructorHandling = ConstructorHandling.Default;
         internal const TypeNameHandling DefaultTypeNameHandling = TypeNameHandling.None;
+        internal const string DefaultTypeNameProperty = "$type";
         internal const MetadataPropertyHandling DefaultMetadataPropertyHandling = MetadataPropertyHandling.Default;
         internal const FormatterAssemblyStyle DefaultTypeNameAssemblyFormat = FormatterAssemblyStyle.Simple;
         internal static readonly StreamingContext DefaultContext;
@@ -84,6 +85,7 @@ namespace Newtonsoft.Json
         internal StreamingContext? _context;
         internal ConstructorHandling? _constructorHandling;
         internal TypeNameHandling? _typeNameHandling;
+        internal string _typeNameProperty;
         internal MetadataPropertyHandling? _metadataPropertyHandling;
 
         /// <summary>
@@ -160,6 +162,16 @@ namespace Newtonsoft.Json
         {
             get { return _typeNameHandling ?? DefaultTypeNameHandling; }
             set { _typeNameHandling = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the metadata property containing the type name.
+        /// </summary>
+        /// <value>The type name attribute.</value>
+        public string TypeNameProperty
+        {
+            get { return _typeNameProperty ?? DefaultTypeNameProperty; }
+            set { _typeNameProperty = value; }
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -557,7 +557,7 @@ namespace Newtonsoft.Json.Serialization
                         return true;
                     }
                 }
-                JToken typeToken = current[JsonTypeReflector.TypePropertyName];
+                JToken typeToken = current[Serializer.TypeNameProperty];
                 if (typeToken != null)
                 {
                     string qualifiedTypeName = (string)typeToken;
@@ -612,7 +612,7 @@ namespace Newtonsoft.Json.Serialization
             {
                 string propertyName = reader.Value.ToString();
 
-                if (propertyName.Length > 0 && propertyName[0] == '$')
+                if (propertyName.Length > 0 && propertyName[0] == '$' || propertyName == Serializer.TypeNameProperty)
                 {
                     // read metadata properties
                     // $type, $id, $ref, etc
@@ -649,7 +649,7 @@ namespace Newtonsoft.Json.Serialization
                                 metadataProperty = true;
                             }
                         }
-                        else if (string.Equals(propertyName, JsonTypeReflector.TypePropertyName, StringComparison.Ordinal))
+                        else if (string.Equals(propertyName, Serializer.TypeNameProperty, StringComparison.Ordinal))
                         {
                             CheckedRead(reader);
                             string qualifiedTypeName = reader.Value.ToString();
@@ -2002,14 +2002,13 @@ namespace Newtonsoft.Json.Serialization
         {
             if (Serializer.MetadataPropertyHandling == MetadataPropertyHandling.ReadAhead)
             {
-                switch (memberName)
+                if (memberName == Serializer.TypeNameProperty ||
+                    memberName == JsonTypeReflector.IdPropertyName ||
+                    memberName == JsonTypeReflector.RefPropertyName ||
+                    memberName == JsonTypeReflector.ArrayValuesPropertyName)
                 {
-                    case JsonTypeReflector.IdPropertyName:
-                    case JsonTypeReflector.RefPropertyName:
-                    case JsonTypeReflector.TypePropertyName:
-                    case JsonTypeReflector.ArrayValuesPropertyName:
-                        reader.Skip();
-                        return true;
+                    reader.Skip();
+                    return true;
                 }
             }
             return false;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -525,7 +525,7 @@ namespace Newtonsoft.Json.Serialization
             if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
 
-            writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
+            writer.WritePropertyName(Serializer.TypeNameProperty, false);
             writer.WriteValue(typeName);
         }
 

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -49,7 +49,6 @@ namespace Newtonsoft.Json.Serialization
 
         public const string IdPropertyName = "$id";
         public const string RefPropertyName = "$ref";
-        public const string TypePropertyName = "$type";
         public const string ValuePropertyName = "$value";
         public const string ArrayValuesPropertyName = "$values";
 


### PR DESCRIPTION
The Json.Net library, when using a setting other than ```TypeNamingHandling.None```, emits and interprets ```$type```properties to support polymorphism. The name ```$type``` is hardcoded.

This PR adds the capability for clients to customize the name of the  ```$type``` property, which allows them to leverage the existing polymorphism-mechanisms for consuming REST APIs that also rely on polymorphism, yet use disscriminating properties named other than ```$type``` (such as ```_type```).