### PR TITLE
Update JToken.cs (JObject.ToString throws OutofMemory exception)

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -421,15 +421,24 @@ namespace Newtonsoft.Json.Linq
         /// <returns>The JSON for this token using the given formatting and converters.</returns>
         public string ToString(Formatting formatting, params JsonConverter[] converters)
         {
-            using (StringWriter sw = new StringWriter(CultureInfo.InvariantCulture))
+            string path = System.IO.Path.GetTempFileName();
+            FileInfo fileInfo = new FileInfo(path);
+            fileInfo.Attributes = FileAttributes.Temporary;
+            string t;
+            using (FileStream stream = File.OpenWrite(path))
             {
-                JsonTextWriter jw = new JsonTextWriter(sw);
-                jw.Formatting = formatting;
+                using (StreamWriter sw = new StreamWriter(stream))
+                {
+                    JsonTextWriter jw = new JsonTextWriter(sw);
+                    jw.Formatting = formatting;
 
-                WriteTo(jw, converters);
+                    WriteTo(jw, converters);
 
-                return sw.ToString();
+                    t = sw.ToString();
+                }
             }
+            System.IO.File.Delete(path);
+            return t;
         }
 
         private static JValue EnsureValue(JToken value)


### PR DESCRIPTION
JObject.ToString throws OutofMemory exception, when JToken uses StringWriter to generate string and this string is quite large. If the StringWriter.length is larger than 120MB, exception occurs very often. The reason is that StringBulder uses StringBuilder as its base data structure and StringBuilder requires a continuous memory. If the StringBuilder cannot get such a continuous memory it will throw OutofMemory exception.