### PR TITLE
Improve Self referencing loop exceptions on properties by including a recommendation

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -2814,7 +2814,7 @@ keyword such as type of business.""
                 o.ReferenceLoopHandlingErrorProperty = o;
 
                 JsonConvert.SerializeObject(o, Formatting.Indented, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
-            }, "Self referencing loop detected for property 'ReferenceLoopHandlingErrorProperty' with type '" + classRef + "'. Path ''.");
+            }, "Self referencing loop detected in NullValueHandlingIncludeProperty. Consider applying [JsonProperty(ReferenceLoopHandling = ReferenceLoopHandling.Ignore] to property ReferenceLoopHandlingErrorProperty.");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/Serialization/PreserveReferencesHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/PreserveReferencesHandlingTests.cs
@@ -108,7 +108,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             circularList.Add(new CircularList { null });
             circularList.Add(new CircularList { new CircularList { circularList } });
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.SerializeObject(circularList, Formatting.Indented); }, "Self referencing loop detected with type '" + classRef + "'. Path '[2][0]'.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.SerializeObject(circularList, Formatting.Indented); }, "Self referencing loop detected with type " + classRef + ", Path: [2][0]");
         }
 
         [Test]
@@ -261,7 +261,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             circularDictionary.Add("other", new CircularDictionary { { "blah", null } });
             circularDictionary.Add("self", circularDictionary);
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.SerializeObject(circularDictionary, Formatting.Indented); }, @"Self referencing loop detected with type '" + classRef + "'. Path ''.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.SerializeObject(circularDictionary, Formatting.Indented); }, @"Self referencing loop detected with type " + classRef + ", Path: other");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
@@ -190,7 +190,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             var settings =
                 new JsonSerializerSettings();
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(main, settings), "Self referencing loop detected with type 'Newtonsoft.Json.Tests.Serialization.ReferenceLoopHandlingTests+MainClass'. Path 'Child'.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(main, settings), "Self referencing loop detected with type Newtonsoft.Json.Tests.Serialization.ReferenceLoopHandlingTests+MainClass, Path: Child");
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             var settings = new JsonSerializerSettings();
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(parent, settings), "Self referencing loop detected with type 'Newtonsoft.Json.Tests.Serialization.ReferenceLoopHandlingTests+DictionaryDynamicObject'. Path 'child'.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(parent, settings), "Self referencing loop detected with type Newtonsoft.Json.Tests.Serialization.ReferenceLoopHandlingTests+DictionaryDynamicObject, Path: child");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -267,38 +267,38 @@ namespace Newtonsoft.Json.Serialization
 
             if (_serializeStack.IndexOf(value) != -1)
             {
-				var serializerReferenceLoopHandling = referenceLoopHandling.GetValueOrDefault(Serializer._referenceLoopHandling);
+                var serializerReferenceLoopHandling = referenceLoopHandling.GetValueOrDefault(Serializer._referenceLoopHandling);
 
-				if (serializerReferenceLoopHandling == ReferenceLoopHandling.Error)
-				{
-					string message = "Self referencing loop detected in {0}.".FormatWith(CultureInfo.InvariantCulture, writer.Path);
-					if (property != null)
-						message += " Consider applying [JsonProperty(ReferenceLoopHandling = ReferenceLoopHandling.Ignore] to property {0}.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName);
+                if (serializerReferenceLoopHandling == ReferenceLoopHandling.Error)
+                {
+                    string message = "Self referencing loop detected in {0}.".FormatWith(CultureInfo.InvariantCulture, writer.Path);
+                    if (property != null)
+                        message += " Consider applying [JsonProperty(ReferenceLoopHandling = ReferenceLoopHandling.Ignore] to property {0}.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName);
 
-					throw new JsonSerializationException(message);
-				}
-				else
-				{
-					string message = "Self referencing loop detected";
-					if (property != null)
-						message += " for property '{0}'".FormatWith(CultureInfo.InvariantCulture, property.PropertyName);
-					message += " with type '{0}'.".FormatWith(CultureInfo.InvariantCulture, value.GetType());
+                    throw new JsonSerializationException(message);
+                }
+                else
+                {
+                    string message = "Self referencing loop detected";
+                    if (property != null)
+                        message += " for property '{0}'".FormatWith(CultureInfo.InvariantCulture, property.PropertyName);
+                    message += " with type '{0}'.".FormatWith(CultureInfo.InvariantCulture, value.GetType());
 
-					switch (serializerReferenceLoopHandling)
-					{
-						case ReferenceLoopHandling.Error:
-						case ReferenceLoopHandling.Ignore:
-							if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
-								TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, message + ". Skipping serializing self referenced value."), null);
+                    switch (serializerReferenceLoopHandling)
+                    {
+                        case ReferenceLoopHandling.Error:
+                        case ReferenceLoopHandling.Ignore:
+                            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, message + ". Skipping serializing self referenced value."), null);
 
-							return false;
-						case ReferenceLoopHandling.Serialize:
-							if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
-								TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, message + ". Serializing self referenced value."), null);
+                            return false;
+                        case ReferenceLoopHandling.Serialize:
+                            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, message + ". Serializing self referenced value."), null);
 
-							return true;
-					}
-				}
+                            return true;
+                    }
+                }
             }
 
             return true;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -271,9 +271,16 @@ namespace Newtonsoft.Json.Serialization
 
                 if (serializerReferenceLoopHandling == ReferenceLoopHandling.Error)
                 {
-                    string message = "Self referencing loop detected in {0}.".FormatWith(CultureInfo.InvariantCulture, writer.Path);
-                    if (property != null)
-                        message += " Consider applying [JsonProperty(ReferenceLoopHandling = ReferenceLoopHandling.Ignore] to property {0}.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName);
+                    string message;
+                    if (property == null)
+                    {
+                        message = "Self referencing loop detected with type {0}, Path: {1}".FormatWith(CultureInfo.InvariantCulture, value.GetType(), writer.Path);
+                    }
+                    else
+                    {
+                        message = "Self referencing loop detected in {0}. Consider applying [JsonProperty(ReferenceLoopHandling = ReferenceLoopHandling.Ignore] to property {1}."
+                            .FormatWith(CultureInfo.InvariantCulture, writer.Path, property.PropertyName);
+                    }
 
                     throw new JsonSerializationException(message);
                 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -286,7 +286,6 @@ namespace Newtonsoft.Json.Serialization
 
                     switch (serializerReferenceLoopHandling)
                     {
-                        case ReferenceLoopHandling.Error:
                         case ReferenceLoopHandling.Ignore:
                             if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, message + ". Skipping serializing self referenced value."), null);


### PR DESCRIPTION
The solution to a self-referencing loop on most Properties is to add an ignore reference loop attribute, so the Exception may as well be there to tell novices how to most easily resolve it. Most devs running into this for the first time are likely to be surprised at the depth of Json.Net in having ways of handling this, and it may lead them to explore JsonProperty(ReferenceLoopHandling more deeply.