### PR TITLE
added support for multiple deserialization aliases

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -1338,5 +1338,32 @@ namespace Newtonsoft.Json.Tests
                 writer.WriteValue(Math.Round((double)value, _precision, _rounding));
             }
         }
+
+        class ForAliasTesting
+        {
+            [JsonProperty(Aliases=new[]{"V1", "V2", "Value2"})]
+            public int Value { get; set; }
+
+            public int Value2 { get; set; }
+        }
+
+        [Test]
+        public void AliasTest()
+        {
+            const string json1 = @"{""Value"":""42""}";
+            Assert.AreEqual(42, JsonConvert.DeserializeObject<ForAliasTesting>(json1).Value);
+
+            const string json2 = @"{""V1"":""42""}";
+            Assert.AreEqual(42, JsonConvert.DeserializeObject<ForAliasTesting>(json2).Value);
+
+            const string json3 = @"{""V2"":""42""}";
+            Assert.AreEqual(42, JsonConvert.DeserializeObject<ForAliasTesting>(json3).Value);
+
+            const string json4 = @"{""value"":""42""}";
+            Assert.AreEqual(42, JsonConvert.DeserializeObject<ForAliasTesting>(json4).Value);
+
+            const string json5 = @"{""Value2"":""42""}";
+            Assert.AreNotEqual(42, JsonConvert.DeserializeObject<ForAliasTesting>(json5).Value);
+        }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaGeneratorTests.cs
@@ -363,7 +363,7 @@ namespace Newtonsoft.Json.Tests.Schema
                 JsonPropertyCollection c = new JsonPropertyCollection(type);
                 c.AddRange(properties.Where(m => m.PropertyName != "Root"));
 
-                return c;
+                return c.ToList();
             }
         }
 

--- a/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
@@ -162,7 +162,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             var resolver = new DefaultContractResolver();
             var contract = (JsonObjectContract)resolver.ResolveContract(typeof(Invoice));
 
-            JsonProperty property = contract.Properties["FollowUpDays"];
+            JsonProperty property = contract.Properties.GetClosestMatchProperty("FollowUpDays");
             Assert.AreEqual(1, property.AttributeProvider.GetAttributes(false).Count);
             Assert.AreEqual(typeof(DefaultValueAttribute), property.AttributeProvider.GetAttributes(false)[0].GetType());
         }
@@ -419,7 +419,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             var resolver = new DefaultContractResolver();
             var contract = (JsonObjectContract)resolver.ResolveContract(typeof(AddressWithDataMember));
 
-            Assert.AreEqual("AddressLine1", contract.Properties[0].PropertyName);
+            Assert.AreEqual("AddressLine1", contract.Properties.First().PropertyName);
         }
 #endif
 
@@ -444,7 +444,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.AreEqual(contract.ParametrizedConstructor, typeof(PublicParametizedConstructorWithPropertyNameConflictWithAttribute).GetConstructor(new[] { typeof(string) }));
 #pragma warning restore 618
             Assert.AreEqual(1, contract.CreatorParameters.Count);
-            Assert.AreEqual("name", contract.CreatorParameters[0].PropertyName);
+            Assert.AreEqual("name", contract.CreatorParameters.First().PropertyName);
 
 #pragma warning disable 618
             contract.ParametrizedConstructor = null;
@@ -464,8 +464,8 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.AreEqual(contract.OverrideConstructor, typeof(MultipleParamatrizedConstructorsJsonConstructor).GetConstructor(new[] { typeof(string), typeof(int) }));
 #pragma warning restore 618
             Assert.AreEqual(2, contract.CreatorParameters.Count);
-            Assert.AreEqual("Value", contract.CreatorParameters[0].PropertyName);
-            Assert.AreEqual("Age", contract.CreatorParameters[1].PropertyName);
+            Assert.AreEqual("Value", contract.CreatorParameters.First().PropertyName);
+            Assert.AreEqual("Age", contract.CreatorParameters.Skip(1).First().PropertyName);
 
 #pragma warning disable 618
             contract.OverrideConstructor = null;

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonPropertyCollectionTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonPropertyCollectionTests.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System.Linq;
 #if NETFX_CORE
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using TestFixture = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
@@ -56,9 +57,9 @@ namespace Newtonsoft.Json.Tests.Serialization
             var contract = (JsonObjectContract)resolver.ResolveContract(value.GetType());
 
             Assert.AreEqual(3, contract.Properties.Count);
-            Assert.IsTrue(contract.Properties.Contains("OverriddenProperty"), "Contract is missing property 'OverriddenProperty'");
-            Assert.IsTrue(contract.Properties.Contains("PropertyA"), "Contract is missing property 'PropertyA'");
-            Assert.IsTrue(contract.Properties.Contains("PropertyB"), "Contract is missing property 'PropertyB'");
+            Assert.IsTrue(contract.Properties.Any(x => x.PropertyName == "OverriddenProperty"), "Contract is missing property 'OverriddenProperty'");
+            Assert.IsTrue(contract.Properties.Any(x => x.PropertyName == "PropertyA"), "Contract is missing property 'PropertyA'");
+            Assert.IsTrue(contract.Properties.Any(x => x.PropertyName == "PropertyB"), "Contract is missing property 'PropertyB'");
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -173,6 +173,12 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Aliases for property names to be used during deserialization.
+        /// This is valuable for renaming properties.
+        /// </summary>
+        public string[] Aliases { get; set; }
+
+        /// <summary>
         /// Gets or sets whether this property's collection items are serialized as a reference.
         /// </summary>
         /// <value>Whether this property's collection items are serialized as a reference.</value>

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -598,7 +598,7 @@ namespace Newtonsoft.Json.Serialization
         /// <param name="constructor">The constructor to create properties for.</param>
         /// <param name="memberProperties">The type's member properties.</param>
         /// <returns>Properties for the given <see cref="ConstructorInfo"/>.</returns>
-        protected virtual IList<JsonProperty> CreateConstructorParameters(ConstructorInfo constructor, JsonPropertyCollection memberProperties)
+        protected virtual IEnumerable<JsonProperty> CreateConstructorParameters(ConstructorInfo constructor, JsonPropertyCollection memberProperties)
         {
             var constructorParameters = constructor.GetParameters();
 
@@ -1228,6 +1228,7 @@ namespace Newtonsoft.Json.Serialization
                 property._required = propertyAttribute._required;
                 property.Order = propertyAttribute._order;
                 property.DefaultValueHandling = propertyAttribute._defaultValueHandling;
+                property.AddAliases(propertyAttribute.Aliases);
                 hasMemberAttribute = true;
             }
 #if !NET20

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -24,6 +24,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Newtonsoft.Json.Utilities;
 
@@ -289,6 +290,23 @@ namespace Newtonsoft.Json.Serialization
                 writer.WritePropertyName(PropertyName, false);
             else
                 writer.WritePropertyName(PropertyName);
+        }
+
+        private HashSet<string> _aliases;
+        public void AddAliases(IEnumerable<string> aliases)
+        {
+            if (aliases == null) 
+                return;
+            if (_aliases == null)
+                _aliases = new HashSet<string>(aliases);
+            else
+                foreach (var alias in aliases)
+                    _aliases.Add(alias);
+        }
+
+        public bool HasAlias(string propertyName)
+        {
+            return _aliases != null && _aliases.Contains(propertyName);
         }
     }
 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1645,7 +1645,7 @@ namespace Newtonsoft.Json.Serialization
 
                 if (matchingCreatorParameter != null)
                 {
-                    int i = contract.CreatorParameters.IndexOf(matchingCreatorParameter);
+                    int i = contract.CreatorParameters.IndexOf(x => x == matchingCreatorParameter);
                     creatorParameterValues[i] = propertyValue.Value;
                 }
                 else

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -392,9 +392,8 @@ namespace Newtonsoft.Json.Serialization
 
             int initialDepth = writer.Top;
 
-            for (int index = 0; index < contract.Properties.Count; index++)
+            foreach(var property in contract.Properties)
             {
-                JsonProperty property = contract.Properties[index];
                 try
                 {
                     object memberValue;
@@ -781,10 +780,8 @@ namespace Newtonsoft.Json.Serialization
 
             int initialDepth = writer.Top;
 
-            for (int index = 0; index < contract.Properties.Count; index++)
+            foreach(var property in contract.Properties)
             {
-                JsonProperty property = contract.Properties[index];
-
                 // only write non-dynamic properties that have an explicit attribute
                 if (property.HasMemberAttribute)
                 {


### PR DESCRIPTION
I was looking for ways to make it easier to rename properties. I don't like having to keep both the old and new properties on my objects. For that reason, I added some code to allow me to specify multiple property aliases with a new property on the `JsonPropertyAttribute`. It required me to significantly change the `JsonPropertyCollection` as well. I could not see any way to accomplish what I wanted using hooks in the existing system. 