### PR TITLE
Added support for \v char with tests

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -1757,6 +1757,33 @@ keyword such as type of business.""
         }
 
         [Test]
+        public void ValidBackslashChars()
+        {
+            //According to https://www.json.com/json-object#object-with-strings
+            var validBackslashEscapedChars = new Dictionary<char, string>()
+            {
+                {'v', "\v"}, 
+                {'b', "\b"}, 
+                {'f', "\f"}, 
+                {'n', "\n"}, 
+                {'r', "\r"}, 
+                {'t', "\t"}, 
+                {'\\', "\\"}
+            };
+
+            const string jsonTemplate = @"[""\{0}""]";
+            foreach (var escapedChar in validBackslashEscapedChars)
+            {
+                var json = string.Format(jsonTemplate, escapedChar.Key);
+                var obj = JsonConvert.DeserializeObject<List<string>>(json);
+                Assert.AreEqual(obj[0], escapedChar.Value);
+            }
+
+
+            
+        }
+
+        [Test]
         public void DateTimeTest()
         {
             List<DateTime> testDates = new List<DateTime>

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -472,6 +472,10 @@ namespace Newtonsoft.Json
                                 charPos++;
                                 writeChar = '\r';
                                 break;
+                            case 'v':
+                                charPos++;
+                                writeChar = '\v';
+                                break;
                             case '\\':
                                 charPos++;
                                 writeChar = '\\';


### PR DESCRIPTION
According to https://www.json.com/json-object#object-with-strings valid json can contains '\v' char. It was discussed on SO on link: http://stackoverflow.com/questions/19176024/how-to-escape-special-characters-in-building-a-json-string

That is why I added support for this char :)

I hope You will agree with me
