### PR TITLE
Unit test for Issue #457

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -334,6 +334,7 @@
     </Compile>
     <Compile Include="TestObjects\DataContractSerializationAttributesClass.cs" />
     <Compile Include="TestObjects\DateTimeErrorObjectCollection.cs" />
+    <Compile Include="TestObjects\DateTimeOffsetWrapper.cs" />
     <Compile Include="TestObjects\DateTimeTestClass.cs" />
     <Compile Include="TestObjects\DateTimeWrapper.cs" />
     <Compile Include="TestObjects\DecimalTestClass.cs" />

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -6606,6 +6606,20 @@ Path '', line 1, position 1.");
             Assert.AreEqual(DateTimeKind.Local, c.Value.Kind);
         }
 
+        [Test]
+        public void DeserializeDateTimeOffsetAndDateTime()
+        {
+            string jsonIsoText =
+                @"{""DateTimeOffsetValue"":""2012-02-25T19:55:50.6095676+00:00"", ""DateTimeValue"":""2012-02-25T19:55:50.6095676+00:00""}";
+
+            DateTimeOffsetWrapper c = JsonConvert.DeserializeObject<DateTimeOffsetWrapper>(jsonIsoText);
+            DateTimeOffsetWrapper cISO = JsonConvert.DeserializeObject<DateTimeOffsetWrapper>(jsonIsoText, new IsoDateTimeConverter());
+            Assert.AreEqual(c.DateTimeOffsetValue, cISO.DateTimeOffsetValue); // Why would the iso date time converter change the offset? 
+            Assert.AreEqual(c.DateTimeValue, cISO.DateTimeValue);
+            Assert.AreEqual(c.DateTimeOffsetValue.DateTime, c.DateTimeValue);
+            Assert.AreEqual(DateTimeKind.Utc, c.DateTimeValue.Kind); // If the timezone is +00:00 why is the kind not set to utc?
+        }
+
 #if !NET20
         [Test]
         public void DeserializeUTC()

--- a/Src/Newtonsoft.Json.Tests/TestObjects/DateTimeOffsetWrapper.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/DateTimeOffsetWrapper.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Newtonsoft.Json.Tests.TestObjects {
+    public class DateTimeOffsetWrapper {
+        public DateTimeOffset DateTimeOffsetValue { get; set; }
+
+        public DateTime DateTimeValue { get; set; }
+    }
+}


### PR DESCRIPTION
This test shows off that in some cases the offset is not preserved when deserializing a DateTimeOffset. 

Also, If your time is set to +00:00 then the DateTimeKind should be set to utc? You could say that it should also be set to local kind if the offset matches the users local time.