### PR TITLE
Issue with deserialization of read-only property

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Serialization\ImmutableCollectionsTests.cs" />
     <Compile Include="Serialization\JsonSerializerCollectionsTests.cs" />
     <Compile Include="Serialization\MetadataPropertyHandlingTests.cs" />
+    <Compile Include="Serialization\ReadOnlyPropertyDeserializationTests.cs" />
     <Compile Include="Serialization\ReferenceLoopHandlingTests.cs" />
     <Compile Include="Serialization\ReflectionAttributeProviderTests.cs" />
     <Compile Include="Serialization\ShouldSerializeTests.cs" />

--- a/Src/Newtonsoft.Json.Tests/Serialization/ReadOnlyPropertyDeserializationTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ReadOnlyPropertyDeserializationTests.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using NUnit.Framework;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+	[TestFixture]
+	public class ReadOnlyPropertyDeserializationTests
+	{
+		[Test]
+		public void Read_only_property_is_accessed_during_deserialization()
+		{
+			var serializer = new JsonSerializer {ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor};
+
+			var stringWriter = new StringWriter();
+			serializer.Serialize(new JsonTextWriter(stringWriter), new DomainClass {IntVal = 1});
+
+			var json = stringWriter.ToString();
+
+			serializer.Deserialize<DomainClass>(new JsonTextReader(new StringReader(json)));
+		}
+
+		private class DomainClass
+		{
+			// We have a read-only property that relies on a writable property.
+			// This property should be serialized; but should not be referenced 
+			// during the deserialization process. Because the object is in an 
+			// invalid state, 
+			public ValueClass ReadOnlyVal
+			{
+				get { return 100/IntVal > 0 ? new ValueClass() : null; }
+			}
+
+			public int IntVal { get; set; }
+		}
+
+		private class ValueClass
+		{
+		}
+	}
+}


### PR DESCRIPTION
Added a unit test to demonstrate a read-only property being accessed during the deserialization process. This is causing issues for us because it is causing code to run when the object is in an invalid state.