### PR TITLE
Adding Support for Writing String values from Streams

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -86,6 +86,25 @@ namespace Newtonsoft.Json.Tests
         }
 
         [Test]
+        public void WriteValueForStreams()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw) { QuoteName = false };
+
+            TextReader inputStream = new StringReader("value");
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("name");
+            writer.WriteValue(inputStream);
+
+            writer.WriteEndObject();
+            writer.Flush();
+
+            Assert.AreEqual(@"{name:""value""}", sw.ToString());
+        }
+
+        [Test]
         public void QuoteNameAndStrings()
         {
             StringBuilder sb = new StringBuilder();
@@ -253,6 +272,31 @@ namespace Newtonsoft.Json.Tests
                     jsonWriter.WriteEndArray();
                 }
             }, @"Unsupported type: System.Version. Use the JsonSerializer class to get the object's JSON representation. Path ''.");
+        }
+
+        [Test]
+        public void StreamEscaping()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.WriteStartArray();
+                jsonWriter.WriteValue(new StringReader(@"""These pretzels are making me thirsty!"""));
+                jsonWriter.WriteValue(new StringReader("Jeff's house was burninated."));
+                jsonWriter.WriteValue(new StringReader("1. You don't talk about fight club.\r\n2. You don't talk about fight club."));
+                jsonWriter.WriteValue(new StringReader("35% of\t statistics\n are made\r up."));
+                jsonWriter.WriteEndArray();
+            }
+
+            string expected = @"[""\""These pretzels are making me thirsty!\"""",""Jeff's house was burninated."",""1. You don't talk about fight club.\r\n2. You don't talk about fight club."",""35% of\t statistics\n are made\r up.""]";
+            string result = sb.ToString();
+
+            Console.WriteLine("StringEscaping");
+            Console.WriteLine(result);
+
+            Assert.AreEqual(expected, result);
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -823,6 +823,15 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Streams a <see cref="TextReader"/> into a JSON string.
+        /// </summary>
+        /// <param name="value">The <see cref="TextReader"/> value to read from.</param>
+        public virtual void WriteValue(TextReader value)
+        {
+            InternalWriteValue(JsonToken.String);
+        }
+
+        /// <summary>
         /// Writes a <see cref="Int32"/> value.
         /// </summary>
         /// <param name="value">The <see cref="Int32"/> value to write.</param>

--- a/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
@@ -100,17 +100,25 @@ namespace Newtonsoft.Json.Utilities
         public static void WriteEscapedJavaScriptString(TextWriter writer, string s, char delimiter, bool appendDelimiters,
             bool[] charEscapeFlags, StringEscapeHandling stringEscapeHandling, ref char[] writeBuffer)
         {
+            var chars = s.ToCharArray();
+            WriteEscapedJavaScriptCharArray(writer, ref chars, chars.Length, delimiter, appendDelimiters,
+                charEscapeFlags, stringEscapeHandling, ref writeBuffer);
+        }
+
+        public static void WriteEscapedJavaScriptCharArray(TextWriter writer, ref char[] stringBuffer, int sChars, char delimiter, bool appendDelimiters,
+            bool[] charEscapeFlags, StringEscapeHandling stringEscapeHandling, ref char[] writeBuffer)
+        {
             // leading delimiter
             if (appendDelimiters)
                 writer.Write(delimiter);
 
-            if (s != null)
+            if (stringBuffer != null)
             {
                 int lastWritePosition = 0;
 
-                for (int i = 0; i < s.Length; i++)
+                for (int i = 0; i < sChars; i++)
                 {
-                    var c = s[i];
+                    var c = stringBuffer[i];
 
                     if (c < charEscapeFlags.Length && !charEscapeFlags[c])
                         continue;
@@ -197,7 +205,7 @@ namespace Newtonsoft.Json.Utilities
                             writeBuffer = newBuffer;
                         }
 
-                        s.CopyTo(lastWritePosition, writeBuffer, start, length - start);
+                        Array.Copy(stringBuffer, lastWritePosition, writeBuffer, start, length - start);
 
                         // write unchanged chars before writing escaped text
                         writer.Write(writeBuffer, start, length - start);
@@ -213,16 +221,16 @@ namespace Newtonsoft.Json.Utilities
                 if (lastWritePosition == 0)
                 {
                     // no escaped text, write entire string
-                    writer.Write(s);
+                    writer.Write(stringBuffer, 0, sChars);
                 }
                 else
                 {
-                    int length = s.Length - lastWritePosition;
+                    int length = sChars - lastWritePosition;
 
                     if (writeBuffer == null || writeBuffer.Length < length)
                         writeBuffer = new char[length];
 
-                    s.CopyTo(lastWritePosition, writeBuffer, 0, length);
+                    Array.Copy(stringBuffer, lastWritePosition, writeBuffer, 0, length);
 
                     // write remaining text
                     writer.Write(writeBuffer, 0, length);


### PR DESCRIPTION
I have a need to write very large JSON strings (100MB+), and storing the entire string in memory before writing it to the JSON output stream is causing my agents to go OOM.

This change allows me to stream into a large string.

NOTE:

* In order to keep the new Streaming method in line with the String method, I made them quickly converge to the same code path. This causes writing String values to become a bit slower.
* This change extends the core JsonWriter interface. If you don't want to do this, an alternate implementation can be found here: https://github.com/elarkin/Newtonsoft.Json/tree/no-new-interface-method