### PR TITLE
DiscriminatedUnionConverter can deserialize fields from object

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
@@ -172,6 +172,22 @@ namespace Newtonsoft.Json.Tests.Converters
             Assert.AreEqual(10.0, r.width);
         }
 
+        [Test]
+        public void DeserializeUnionWithFieldsWithTypeNameHandlingAll()
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All
+            };
+            Shape c = JsonConvert.DeserializeObject<Shape>(@"{""Case"":""Rectangle"",""Fields"":{""$type"":""System.Object[], mscorlib"",""$values"":[10.0,5.0]}}", settings);
+            Assert.AreEqual(true, c.IsRectangle);
+
+            Shape.Rectangle r = (Shape.Rectangle)c;
+
+            Assert.AreEqual(5.0, r.length);
+            Assert.AreEqual(10.0, r.width);
+        }
+
         public class Union
         {
             public List<UnionCase> Cases;
@@ -270,12 +286,6 @@ namespace Newtonsoft.Json.Tests.Converters
         public void DeserializeBasicUnion_UnexpectedEnd()
         {
             ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Currency>(@"{""Case"":"), "Unexpected end when reading union. Path 'Case', line 1, position 8.");
-        }
-
-        [Test]
-        public void DeserializeBasicUnion_FieldsObject()
-        {
-            ExceptionAssert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Currency>(@"{""Case"":""AUD"",""Fields"":{}}"), "Union fields must been an array. Path 'Fields', line 1, position 24.");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
@@ -174,10 +174,27 @@ namespace Newtonsoft.Json.Converters
                 else if (string.Equals(propertyName, FieldsPropertyName, StringComparison.OrdinalIgnoreCase))
                 {
                     ReadAndAssert(reader);
-                    if (reader.TokenType != JsonToken.StartArray)
-                        throw JsonSerializationException.Create(reader, "Union fields must been an array.");
 
-                    fields = (JArray)JToken.ReadFrom(reader);
+                    if (reader.TokenType == JsonToken.StartArray)
+                    {
+                        fields = (JArray)JToken.ReadFrom(reader);
+                    }
+                    else if (reader.TokenType == JsonToken.StartObject)
+                    {
+                        JObject current = (JObject)JToken.ReadFrom(reader);
+                        JToken valuesToken = current[JsonTypeReflector.ArrayValuesPropertyName];
+                        if (valuesToken != null)
+                        {
+                            JsonReader listReader = valuesToken.CreateReader();
+                            if (!listReader.Read())
+                                throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
+
+                            fields = (JArray)JToken.ReadFrom(listReader);
+                            listReader.Skip();
+                        }
+                        else throw JsonSerializationException.Create(reader, "Union fields must expose {0} property".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.ArrayValuesPropertyName));
+                    }
+                    else throw JsonSerializationException.Create(reader, "Union fields must been an array or object.");
                 }
                 else
                 {


### PR DESCRIPTION
This pull solves the problem described in issue #512. It gives a `DiscriminatedUnionConverter` ability to deserialize union fields from JSON serialized in `{ Fields: { $type: ..., $values: [] } }` notation (which is an array JSON format when serialization setting `TypeNameHandling` is set to `All`).

Changes have been reflected in test cases (one new added to confirm proper deserialization, one removed because it's not an error anymore).