### PR TITLE
Fix for "inherited" interfaces

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/DependencyInjectionTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/DependencyInjectionTests.cs
@@ -234,7 +234,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.IsNotNull(o);
             Assert.IsNotNull(o.Logger);
             Assert.IsNotNull(o.Repository);
-			Assert.IsNotNull(o.Repository.CreatedOn);
+			Assert.AreEqual(o.Repository.CreatedOn, DateTime.Parse("2015-04-01 20:00"));
 
             Assert.AreEqual(2, count);
 

--- a/Src/Newtonsoft.Json.Tests/Serialization/DependencyInjectionTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/DependencyInjectionTests.cs
@@ -47,7 +47,12 @@ using NUnit.Framework;
 
 namespace Newtonsoft.Json.Tests.Serialization
 {
-    public interface ITaskRepository
+	public interface IBase
+	{
+		DateTime CreatedOn { get; set; }	
+	}
+
+    public interface ITaskRepository : IBase
     {
         string ConnectionString { get; set; }
     }
@@ -58,7 +63,12 @@ namespace Newtonsoft.Json.Tests.Serialization
         string Level { get; set; }
     }
 
-    public class TaskRepository : ITaskRepository
+	public class Base : IBase
+	{
+		public DateTime CreatedOn { get; set; }
+	}
+
+    public class TaskRepository : Base, ITaskRepository
     {
         public string ConnectionString { get; set; }
     }
@@ -202,7 +212,8 @@ namespace Newtonsoft.Json.Tests.Serialization
                     'Level': 'Debug'
                 },
                 'Repository': {
-                    'ConnectionString': 'server=.'
+                    'ConnectionString': 'server=.',
+					'CreatedOn': '2015-04-01 20:00'
                 },
                 'People': [
                     {
@@ -223,6 +234,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.IsNotNull(o);
             Assert.IsNotNull(o.Logger);
             Assert.IsNotNull(o.Repository);
+			Assert.IsNotNull(o.Repository.CreatedOn);
 
             Assert.AreEqual(2, count);
 

--- a/Src/Newtonsoft.Json.sln.DotSettings
+++ b/Src/Newtonsoft.Json.sln.DotSettings
@@ -2,5 +2,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -883,8 +883,20 @@ namespace Newtonsoft.Json.Utilities
         {
             ValidationUtils.ArgumentNotNull(targetType, "targetType");
 
-            List<PropertyInfo> propertyInfos = new List<PropertyInfo>(targetType.GetProperties(bindingAttr));
-            GetChildPrivateProperties(propertyInfos, targetType, bindingAttr);
+	        List<PropertyInfo> propertyInfos;
+
+			if (!targetType.IsInterface())
+			{
+				propertyInfos = new List<PropertyInfo>(targetType.GetProperties(bindingAttr));
+			}
+			else
+			{
+				propertyInfos = (new Type[] { targetType })
+					.Concat(targetType.GetInterfaces())
+					.SelectMany(i => i.GetProperties()).ToList();
+			}
+
+			GetChildPrivateProperties(propertyInfos, targetType, bindingAttr);
 
             // a base class private getter/setter will be inaccessable unless the property was gotten from the base class
             for (int i = 0; i < propertyInfos.Count; i++)

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -893,7 +893,7 @@ namespace Newtonsoft.Json.Utilities
 			{
 				propertyInfos = (new Type[] { targetType })
 					.Concat(targetType.GetInterfaces())
-					.SelectMany(i => i.GetProperties()).ToList();
+					.SelectMany(i => i.GetProperties(bindingAttr)).ToList();
 			}
 
 			GetChildPrivateProperties(propertyInfos, targetType, bindingAttr);


### PR DESCRIPTION
It appears that the current GetProperties methods in the ReflectionUtils class does not handle the scenario were an interface is derived from 1 or more other interfaces.  This is a fix (and a unit test) for that issue