### PR TITLE
Document the meaning of "default settings"

### DIFF
--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -451,11 +451,13 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// Creates a new <see cref="JsonSerializer"/> instance.
-        /// The <see cref="JsonSerializer"/> will not use default settings.
+        /// The <see cref="JsonSerializer"/> will not use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </summary>
         /// <returns>
         /// A new <see cref="JsonSerializer"/> instance.
-        /// The <see cref="JsonSerializer"/> will not use default settings.
+        /// The <see cref="JsonSerializer"/> will not use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </returns>
         public static JsonSerializer Create()
         {
@@ -464,12 +466,14 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// Creates a new <see cref="JsonSerializer"/> instance using the specified <see cref="JsonSerializerSettings"/>.
-        /// The <see cref="JsonSerializer"/> will not use default settings.
+        /// The <see cref="JsonSerializer"/> will not use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </summary>
         /// <param name="settings">The settings to be applied to the <see cref="JsonSerializer"/>.</param>
         /// <returns>
         /// A new <see cref="JsonSerializer"/> instance using the specified <see cref="JsonSerializerSettings"/>.
-        /// The <see cref="JsonSerializer"/> will not use default settings.
+        /// The <see cref="JsonSerializer"/> will not use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </returns>
         public static JsonSerializer Create(JsonSerializerSettings settings)
         {
@@ -483,11 +487,13 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// Creates a new <see cref="JsonSerializer"/> instance.
-        /// The <see cref="JsonSerializer"/> will use default settings.
+        /// The <see cref="JsonSerializer"/> will use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </summary>
         /// <returns>
         /// A new <see cref="JsonSerializer"/> instance.
-        /// The <see cref="JsonSerializer"/> will use default settings.
+        /// The <see cref="JsonSerializer"/> will use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </returns>
         public static JsonSerializer CreateDefault()
         {
@@ -500,12 +506,14 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// Creates a new <see cref="JsonSerializer"/> instance using the specified <see cref="JsonSerializerSettings"/>.
-        /// The <see cref="JsonSerializer"/> will use default settings.
+        /// The <see cref="JsonSerializer"/> will use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </summary>
         /// <param name="settings">The settings to be applied to the <see cref="JsonSerializer"/>.</param>
         /// <returns>
         /// A new <see cref="JsonSerializer"/> instance using the specified <see cref="JsonSerializerSettings"/>.
-        /// The <see cref="JsonSerializer"/> will use default settings.
+        /// The <see cref="JsonSerializer"/> will use default settings 
+        /// from <see cref="JsonConvert.DefaultSettings"/>.
         /// </returns>
         public static JsonSerializer CreateDefault(JsonSerializerSettings settings)
         {


### PR DESCRIPTION
The term "default settings" did not obviously reference the `JsonConvert.DefaultSettings` global variable (especially to those who were not aware of its existence), and so the actual difference between `Create()` and `CreateDefault()` was unclear. By referencing it explicitly, the code, and therefore its generated documentation, will be clearer.