### PR TITLE
Add support for reading json from stream without buffering

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
@@ -3358,7 +3358,7 @@ null//comment
             if (disposing)
             {
                 if (own)
-                    r.Dispose();
+                    r.Close();
             }
             disposed = true;
         }

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
@@ -3192,6 +3192,25 @@ null//comment
                 },
                 "Unexpected character encountered while parsing value: !. Path 'frameworks.dnxcore50.dependencies.['System.Xml.ReaderWriter'].source', line 6, position 21.");
         }
+
+        [Test]
+        public void UnbufferedReader()
+        {
+            var ms = new MemoryStream();
+            var w = new StreamWriter(ms, Encoding.Default);
+            var objStr = @"{'key':'value'}";
+            w.Write(objStr);
+            w.Flush();
+            var testPos = ms.Position;
+            w.Write(objStr);
+            w.Flush();
+            ms.Seek(0, SeekOrigin.Begin);
+            var r = new JsonTextReader(new UnbufferedStreamReader(ms, Encoding.Default, false));
+            r.SupportMultipleContent = true;
+            r.Unbuffered = true;
+            var obj = JObject.Load(r);
+            Assert.AreEqual(ms.Position, testPos);
+        }
     }
 
     public class ToggleReaderError : TextReader
@@ -3288,6 +3307,65 @@ null//comment
         public override void Write(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException();
+        }
+    }
+
+    public class UnbufferedStreamReader : TextReader
+    {
+        private Stream stream;
+        private BinaryReader r;
+        private bool own;
+        private bool disposed = false;
+
+        public UnbufferedStreamReader(Stream stream, Encoding encoding, bool own)
+        {
+            this.stream = stream;
+            this.own = own;
+            r = new BinaryReader(stream, encoding);
+        }
+
+        public UnbufferedStreamReader(Stream stream) :
+            this(stream, Encoding.Default, true)
+        {
+        }
+
+        public bool EndOfStream
+        {
+            get
+            {
+                if (disposed)
+                    throw new ObjectDisposedException("stream");
+                if (stream.Position < stream.Length)
+                    return false;
+                return true;
+            }
+        }
+
+        public override int Read()
+        {
+            return EndOfStream ? -1 : r.ReadChar();
+        }
+
+        public override int Peek()
+        {
+            return r.PeekChar();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+                if (own)
+                    r.Dispose();
+            }
+            disposed = true;
+        }
+
+        ~UnbufferedStreamReader()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Src/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonReader.cs
@@ -304,6 +304,15 @@ namespace Newtonsoft.Json.Bson
 #endif
         }
 
+        /// <summary>
+        /// This property is not currently supported. This property always returns true.
+        /// </summary>
+        public override bool Unbuffered
+        {
+            get { return true; }
+            set { }
+        }
+
         private bool ReadCodeWScope()
         {
             switch (_bsonReaderState)

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -307,7 +307,7 @@ namespace Newtonsoft.Json
             _dateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
             _dateParseHandling = DateParseHandling.DateTime;
             _floatParseHandling = FloatParseHandling.Double;
-
+            
             CloseInput = true;
         }
 
@@ -1005,5 +1005,10 @@ namespace Newtonsoft.Json
             _tokenType = JsonToken.None;
             _value = null;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether JsonReader shouldn't cache data from the input stream.
+        /// </summary>
+        public virtual bool Unbuffered { get; set; }
     }
 }

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -192,7 +192,7 @@ namespace Newtonsoft.Json
 
         private int ReadData(bool append)
         {
-            return ReadData(append, 0);
+            return ReadData(append, 1);
         }
 
         private int ReadData(bool append, int charsRequired)
@@ -241,8 +241,8 @@ namespace Newtonsoft.Json
                     _charsUsed = remainingCharCount;
                 }
             }
-
-            int attemptCharReadCount = _chars.Length - _charsUsed - 1;
+            
+            int attemptCharReadCount = Unbuffered ? charsRequired : _chars.Length - _charsUsed - 1;
 
             int charsRead = _reader.Read(_chars, _charsUsed, attemptCharReadCount);
 
@@ -1633,7 +1633,7 @@ namespace Newtonsoft.Json
         /// Gets a value indicating whether the class can return line information.
         /// </summary>
         /// <returns>
-        /// 	<c>true</c> if LineNumber and LinePosition can be provided; otherwise, <c>false</c>.
+        ///     <c>true</c> if LineNumber and LinePosition can be provided; otherwise, <c>false</c>.
         /// </returns>
         public bool HasLineInfo()
         {

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -917,5 +917,14 @@ namespace Newtonsoft.Json
                 return (lineInfo != null) ? lineInfo.LinePosition : 0;
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether JsonReader shouldn't cache data from the input stream.
+        /// </summary>
+        public override bool Unbuffered
+        {
+            get { return _reader.Unbuffered; }
+            set { _reader.Unbuffered = value; }
+        }
     }
 }

--- a/Src/Newtonsoft.Json/Serialization/TraceJsonReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/TraceJsonReader.cs
@@ -136,5 +136,11 @@ namespace Newtonsoft.Json.Serialization
                 return (lineInfo != null) ? lineInfo.LinePosition : 0;
             }
         }
+
+        public override bool Unbuffered
+        {
+            get { return _innerReader.Unbuffered; }
+            set { _innerReader.Unbuffered = value; }
+        }
     }
 }


### PR DESCRIPTION
Consider a stream that is being read by a two different entities. Let's say, stream contains a small json 'header' object followed by a large json 'data' object. We want the first entity to read header (that contains data size) and the second entity to read the data. Current `JsonReader` implementation doesn't allow to implement this task, because it caches data from stream, consuming beginning of 'data' object and so making impossible for the second entity to read that object from the stream.

My solution introduces `JsonReader.Unbuffered` property (false by default) that allows to disable caching so `JsonReader` will read as many chars as it actually needs.
