### PR TITLE
Handles "null" and "undefined" value for JObject.Merge

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
@@ -569,5 +569,57 @@ namespace Newtonsoft.Json.Tests.Linq
             Assert.AreEqual("name1", p.Name);
             Assert.AreEqual(0, p.Count);
         }
+
+        [Test]
+        public void MergeNullValue()
+        {
+            var source = new JObject
+            {
+                {"Property1", "value"},
+                {"Property2", new JObject()},
+                {"Property3", JValue.CreateNull()},
+                {"Property4", JValue.CreateUndefined()},
+            };
+
+            var patch = JObject.Parse("{Property1:null, Property2:null, Property3:null, Property4:null}");
+
+            source.Merge(patch, new JsonMergeSettings
+            {
+                MergetObjectHandling = MergeObjectHandling.Null,
+            });
+
+            Assert.IsNotNull(source["Property1"]);
+            Assert.AreEqual(JTokenType.Null, source["Property1"].Type);
+            Assert.IsNotNull(source["Property2"]);
+            Assert.AreEqual(JTokenType.Null, source["Property2"].Type);
+            Assert.IsNotNull(source["Property3"]);
+            Assert.AreEqual(JTokenType.Null, source["Property3"].Type);
+            Assert.IsNotNull(source["Property4"]);
+            Assert.AreEqual(JTokenType.Null, source["Property4"].Type);
+        }
+
+        [Test]
+        public void MergeUndefinedlValue()
+        {
+            var source = new JObject
+            {
+                {"Property1", "value"},
+                {"Property2", new JObject()},
+                {"Property3", JValue.CreateNull()},
+                {"Property4", JValue.CreateUndefined()},
+            };
+
+            var patch = JObject.Parse("{Property1:undefined, Property2:undefined, Property3:undefined, Property4:undefined}");
+
+            source.Merge(patch, new JsonMergeSettings
+            {
+                MergetObjectHandling = MergeObjectHandling.Undefined,
+            });
+
+            Assert.IsNull(source.Property("Property1"));
+            Assert.IsNull(source.Property("Property2"));
+            Assert.IsNull(source.Property("Property3"));
+            Assert.IsNull(source.Property("Property4"));
+        }
     }
 }

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -171,11 +171,31 @@ namespace Newtonsoft.Json.Linq
                 }
                 else if (contentItem.Value != null)
                 {
+                    if (settings != null)
+                    {
+                        if (contentItem.Value.Type == JTokenType.Null)
+                        {
+                            if ((settings.MergetObjectHandling & MergeObjectHandling.Null) != 0)
+                            {
+                                existingProperty.Value = contentItem.Value;
+                            }
+                            continue;
+                        }
+
+                        if (contentItem.Value.Type == JTokenType.Undefined)
+                        {
+                            if ((settings.MergetObjectHandling & MergeObjectHandling.Undefined) != 0)
+                            {
+                                existingProperty.Remove();
+                            }
+                            continue;
+                        }
+                    }
+
                     JContainer existingContainer = existingProperty.Value as JContainer;
                     if (existingContainer == null)
                     {
-                        if (contentItem.Value.Type != JTokenType.Null)
-                            existingProperty.Value = contentItem.Value;
+                        existingProperty.Value = contentItem.Value;
                     }
                     else if (existingContainer.Type != contentItem.Value.Type)
                     {

--- a/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
@@ -9,6 +9,8 @@ namespace Newtonsoft.Json.Linq
     {
         private MergeArrayHandling _mergeArrayHandling;
 
+        private MergeObjectHandling _mergeObjectHandling;
+
         /// <summary>
         /// Gets or sets the method used when merging JSON arrays.
         /// </summary>
@@ -22,6 +24,22 @@ namespace Newtonsoft.Json.Linq
                     throw new ArgumentOutOfRangeException("value");
                 
                 _mergeArrayHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the method used when merging JSON objects.
+        /// </summary>
+        /// <value>The method used when merging JSON objects.</value>
+        public MergeObjectHandling MergetObjectHandling
+        {
+            get { return _mergeObjectHandling; }
+            set
+            {
+                if ((value | MergeObjectHandling.All) != MergeObjectHandling.All)
+                    throw new ArgumentOutOfRangeException("value");
+
+                _mergeObjectHandling = value;
             }
         }
     }

--- a/Src/Newtonsoft.Json/Linq/MergeObjectHandling.cs
+++ b/Src/Newtonsoft.Json/Linq/MergeObjectHandling.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Newtonsoft.Json.Linq
+{
+    /// <summary>
+    /// Specifies how JSON objects are merged together.
+    /// </summary>
+    [Flags]
+    public enum MergeObjectHandling
+    {
+        /// <summary>
+        /// Uses default behaviour (ignore null and undefined) to merge the objects.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The target object's null value will be set to the source object.
+        /// </summary>
+        Null = 1,
+
+        /// <summary>
+        /// The target objects's explicit <code>undefined</code> value will remove the source object's property.
+        /// </summary>
+        Undefined = 2,
+
+        /// <summary>
+        /// Merge objects uses <see cref="Null"/> and <see cref="Undefined"/> policy.
+        /// </summary>
+        All = Null | Undefined,
+    }
+}

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net20.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net20.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Linq\JsonPath\QueryFilter.cs" />
     <Compile Include="Linq\JsonPath\ScanFilter.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="SerializationBinder.cs" />
     <Compile Include="Serialization\DiagnosticsTraceWriter.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net35.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net35.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Linq\JsonPath\QueryFilter.cs" />
     <Compile Include="Linq\JsonPath\ScanFilter.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="SerializationBinder.cs" />
     <Compile Include="Serialization\DiagnosticsTraceWriter.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Net40.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Net40.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Linq\JsonPath\QueryFilter.cs" />
     <Compile Include="Linq\JsonPath\ScanFilter.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="Serialization\DiagnosticsTraceWriter.cs" />
     <Compile Include="Serialization\ExpressionValueProvider.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Portable.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Portable.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Linq\JTokenWriter.cs" />
     <Compile Include="Linq\JValue.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MemberSerialization.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="MissingMemberHandling.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Portable40.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Portable40.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Linq\JTokenWriter.cs" />
     <Compile Include="Linq\JValue.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MemberSerialization.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="MissingMemberHandling.cs" />

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Linq\JTokenWriter.cs" />
     <Compile Include="Linq\JValue.cs" />
     <Compile Include="Linq\MergeArrayHandling.cs" />
+    <Compile Include="Linq\MergeObjectHandling.cs" />
     <Compile Include="MemberSerialization.cs" />
     <Compile Include="MetadataPropertyHandling.cs" />
     <Compile Include="MissingMemberHandling.cs" />


### PR DESCRIPTION
Optional handles the "null" and "undefined" value for JObject.Merge by setting MergeObjectHandling flag in JsonMergeSettings.

Details in #531 .