### PR TITLE
JSONPath query for fields in the root document seem to not work.

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
@@ -34,6 +34,15 @@ namespace Newtonsoft.Json.Linq.JsonPath
                 }
                 else
                 {
+                    var prop = t as JProperty;
+
+                    if (prop != null && prop.Name == Name)
+                    {
+                        var v = prop.Value as JValue;
+
+                        yield return v;
+                    }
+
                     if (errorWhenNoMatch)
                         throw new JsonException("Property '{0}' not valid on {1}.".FormatWith(CultureInfo.InvariantCulture, Name ?? "*", t.GetType().Name));
                 }


### PR DESCRIPTION
Given a JSON document of:
{
  "EventTypeID": 5,
  "DataTimeStamp": "2015-03-17T18:44:08.387Z"
}

A JSONPath of $[?(@.EventTypeID > 1)] would never return a match.  This is a minor change to the implementation but it has not been well tested.