### PR TITLE
Adding support for the required array from http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.4.3

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaBuilderTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Schema/JsonSchemaBuilderTests.cs
@@ -140,6 +140,50 @@ namespace Newtonsoft.Json.Tests.Schema
         }
 
         [Test]
+        public void RequiredArray() {
+            string json = @"{
+  ""properties"": {
+    ""firstProperty"": {
+      ""type"" : ""string""
+    },
+    ""secondProperty"": {
+      ""type"" : ""string""
+    },
+    ""thirdProperty"": {
+      ""type"" : ""string""
+    },
+  },
+  ""required"": [ ""firstProperty"", ""thirdProperty"" ]
+}";
+            JsonSchemaBuilder builder = new JsonSchemaBuilder(new JsonSchemaResolver());
+            JsonSchema schema = builder.Read(new JsonTextReader(new StringReader(json)));
+
+            Assert.IsTrue(schema.Properties["firstProperty"].Required.Value);
+            Assert.IsFalse(schema.Properties["secondProperty"].Required.HasValue);
+            Assert.IsTrue(schema.Properties["thirdProperty"].Required.Value);
+        }
+
+        [TestCase(@"{ ""required"": [ 1 ] }", TestName = "Array of incorrect type")]
+        [TestCase(@"{ ""required"": [ ] }", TestName = "Empty array")]
+        [TestCase(@"{ ""properties"" : {
+                        ""firstProperty"": {
+                          ""type"" : ""string""
+                        },
+                      },
+                      ""required"": [ ""firstProperty"", ""firstProperty"" ] }", TestName = "Array with duplicates")]
+        [TestCase(@"{ ""properties"" : {
+                        ""firstProperty"": {
+                          ""type"" : ""string""
+                        },
+                      },
+                      ""required"": [ ""secondProperty"" ] }", TestName = "Array with invalid property name")]
+        public void ShouldRejectInvalidRequiredArrayValues(string json) {
+            JsonSchemaBuilder builder = new JsonSchemaBuilder(new JsonSchemaResolver());
+
+            var exception = Assert.Throws<JsonException>(() => builder.Read(new JsonTextReader(new StringReader(json))));
+        }
+
+        [Test]
         public void ExclusiveMinimum_ExclusiveMaximum()
         {
             string json = @"{


### PR DESCRIPTION
This change will support the Json Schema version 4 meaning of the "required" keyword, where required properties are specified in an array. The previous (version 3) Boolean functionality of "required" is still maintained.