### PR TITLE
Constructor should respect DefaultValue for params set in Contract

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/ConstructorHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ConstructorHandlingTests.cs
@@ -25,7 +25,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Tests.TestObjects;
@@ -39,6 +38,11 @@ using Test = Xunit.FactAttribute;
 using Assert = Newtonsoft.Json.Tests.XUnitAssert;
 #else
 using NUnit.Framework;
+#endif
+#if NET20
+using Newtonsoft.Json.Utilities.LinqBridge;
+#else
+using System.Linq;
 #endif
 
 namespace Newtonsoft.Json.Tests.Serialization

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1662,6 +1662,16 @@ namespace Newtonsoft.Json.Serialization
                 }
             }
 
+            // if the contract's CreatorParameters have a default value and populate flag, then use the default value in the constructor if no property is avalable.
+            foreach (var creatorParameter in contract.CreatorParameters.Where(p => p.DefaultValueHandling.HasValue && HasFlag(p.DefaultValueHandling.Value, DefaultValueHandling.Populate)))
+            {
+                int i = contract.CreatorParameters.IndexOf(creatorParameter);
+                if (creatorParameterValues[i] == null)
+                {
+                    creatorParameterValues[i] = creatorParameter.DefaultValue;
+                }
+            }
+
             object createdObject = creator(creatorParameterValues);
 
             if (id != null)


### PR DESCRIPTION
If a default value and `Populate` handling flag is set for a constructor parameter in a contract's `CreateConstructorParameters` method, then the constructor parameters array should be populated with the default if no matching property is available.

This allows the constructor params to be populated with values at deserialization via the contract. It is a minor code change, with many potential use-cases. 
- All existing tests pass.
- Added test for default param value handling.
