### PR TITLE
Property names can now be renamed

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
@@ -628,6 +628,35 @@ namespace Newtonsoft.Json.Tests.Linq
         }
 
         [Test]
+        public void Rename()
+        {
+            //Arrange
+            var map = new Dictionary<string, string>
+            {
+                {"FirstName", "fn"},
+                {"LastName", "ln"},
+            };
+            JObject o1 = JObject.Parse(@"{
+              'FirstName': 'John',
+              'LastName': 'Smith',
+              'Enabled': false,
+              'Roles': [ 'User' ]
+            }");
+
+            //Act
+            foreach (var item in map)
+            {
+                o1.SelectToken(item.Key).Rename(item.Value);
+            }
+
+            //Assert
+            foreach (var item in map)
+            {
+                Assert.IsNotNull(o1.SelectToken(item.Value));
+            }
+        }
+
+        [Test]
         public void AfterSelf()
         {
             JArray a =

--- a/Src/Newtonsoft.Json.Tests/Linq/JValueTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JValueTests.cs
@@ -294,6 +294,16 @@ namespace Newtonsoft.Json.Tests.Linq
         }
 
         [Test]
+        public void RenameParentNull()
+        {
+            ExceptionAssert.Throws<InvalidOperationException>(() =>
+            {
+                JValue v = new JValue(true);
+                v.Rename("newPropertyName");
+            }, "The parent is missing.");
+        }
+
+        [Test]
         public void Root()
         {
             JValue v = new JValue(true);

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2345,5 +2345,19 @@ namespace Newtonsoft.Json.Linq
                 }
             }
         }
+
+        /// <summary>
+        /// Renames the property name to given name
+        /// </summary>
+        /// <param name="newName"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void Rename(string newName)
+        {
+            var parent = Parent;
+            if (_parent == null)
+                throw new InvalidOperationException("The parent is missing.");
+            var newToken = new JProperty(newName, this);
+            parent.Replace(newToken);
+        }
     }
 }


### PR DESCRIPTION
Property names can now be renamed using .Rename("newPropertyName") to resolve https://github.com/JamesNK/Newtonsoft.Json/issues/548
- Added unit tests to cover the functionality