### PR TITLE
Set EnableNuGetPackageRestore true for the process, to enable nuget rest...

### DIFF
--- a/Build/build.ps1
+++ b/Build/build.ps1
@@ -70,6 +70,8 @@ task Build -depends Clean {
 
       Write-Host
       Write-Host "Restoring"
+      [Environment]::SetEnvironmentVariable("EnableNuGetPackageRestore", "true", "Process")
+      exec { .\Tools\NuGet\NuGet.exe update -self }
       exec { .\Tools\NuGet\NuGet.exe restore ".\Src\$name.sln" | Out-Default } "Error restoring $name"
 
       Write-Host


### PR DESCRIPTION
1. added Nuget.exe update -self to update itself to the latest.
2. set EnableNuGetPackageRestore to true to enable package restore. It only sets the value to the process, so that it doesn't overwrite the user machine's settings