### PR TITLE
Renamed EqualityComparer property to ReferenceLoopEqualityComparer

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -932,8 +932,8 @@ namespace Newtonsoft.Json.Tests.Serialization
             settings.Culture = new CultureInfo("en-nz");
             Assert.AreEqual("en-NZ", settings.Culture.ToString());
 
-            settings.EqualityComparer = EqualityComparer<object>.Default;
-            Assert.AreEqual(EqualityComparer<object>.Default, settings.EqualityComparer);
+            settings.ReferenceLoopEqualityComparer = EqualityComparer<object>.Default;
+            Assert.AreEqual(EqualityComparer<object>.Default, settings.ReferenceLoopEqualityComparer);
 
             settings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
             Assert.AreEqual(DateFormatHandling.MicrosoftDateFormat, settings.DateFormatHandling);

--- a/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ReferenceLoopHandlingTests.cs
@@ -290,7 +290,7 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             string json = JsonConvert.SerializeObject(account, new JsonSerializerSettings
             {
-                EqualityComparer = new ReferenceEqualsEqualityComparer(),
+                ReferenceLoopEqualityComparer = new ReferenceEqualsEqualityComparer(),
                 Formatting = Formatting.Indented
             });
 

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -575,8 +575,8 @@ namespace Newtonsoft.Json
                 serializer.ReferenceResolver = settings.ReferenceResolverProvider();
             if (settings.TraceWriter != null)
                 serializer.TraceWriter = settings.TraceWriter;
-            if (settings.EqualityComparer != null)
-                serializer.EqualityComparer = settings.EqualityComparer;
+            if (settings.ReferenceLoopEqualityComparer != null)
+                serializer.EqualityComparer = settings.ReferenceLoopEqualityComparer;
             if (settings.Binder != null)
                 serializer.Binder = settings.Binder;
 

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -201,10 +201,10 @@ namespace Newtonsoft.Json
         public IContractResolver ContractResolver { get; set; }
 
         /// <summary>
-        /// Gets or sets the equality comparer used by the serializer when comparing references.
+        /// Gets or sets the equality comparer used by the serializer when comparing references during loop detection.
         /// </summary>
         /// <value>The equality comparer.</value>
-        public IEqualityComparer EqualityComparer { get; set; }
+        public IEqualityComparer ReferenceLoopEqualityComparer { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IReferenceResolver"/> used by the serializer when resolving references.


### PR DESCRIPTION
Minor tweak, but renaming it, I feel, better communicates how the serializer is going to use the EqualityComparer. Thoughts?