### PR TITLE
Revert from expressions to reflection in Portable40

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Utilities/ExpressionReflectionDelegateFactoryTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/ExpressionReflectionDelegateFactoryTests.cs
@@ -24,7 +24,7 @@
 #endregion
 
 using System.Collections.Generic;
-#if !(NET20 || NET35)
+#if !(PORTABLE40 || NET20 || NET35)
 using System.Linq;
 using System;
 using System.Diagnostics;

--- a/Src/Newtonsoft.Json/Serialization/ExpressionValueProvider.cs
+++ b/Src/Newtonsoft.Json/Serialization/ExpressionValueProvider.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35)
+#if !(PORTABLE40 || NET20 || NET35)
 using System;
 using System.Collections.Generic;
 #if NET20

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -411,9 +411,11 @@ namespace Newtonsoft.Json.Serialization
         {
             get
             {
-#if !(PORTABLE40 || PORTABLE || NETFX_CORE)
+#if !(PORTABLE || NETFX_CORE)
+#if !PORTABLE40
                 if (DynamicCodeGeneration)
                     return DynamicReflectionDelegateFactory.Instance;
+#endif
 
                 return LateBoundReflectionDelegateFactory.Instance;
 #else

--- a/Src/Newtonsoft.Json/Utilities/ExpressionReflectionDelegateFactory.cs
+++ b/Src/Newtonsoft.Json/Utilities/ExpressionReflectionDelegateFactory.cs
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if !(NET20 || NET35)
+#if !(PORTABLE40 || NET20 || NET35)
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
The change to using expressions for reflection in portable builds (57ccaf0) requires the use of dynamic code generation. This adds a size overhead of ~2MB per architecture to Xamarin.iOS apps because it requires Mono.Dynamic.Interpreter to be included.

This PR reverts the change to expressions for the Portable40 build. Xamarin projects can use either the Portable or Portable40 assemblies and thereby choose whether to optimize for speed or size.