### PR TITLE
Use "Indented" for DefaultFormatting when debugging.

### DIFF
--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -50,7 +50,11 @@ namespace Newtonsoft.Json
         internal const FormatterAssemblyStyle DefaultTypeNameAssemblyFormat = FormatterAssemblyStyle.Simple;
         internal static readonly StreamingContext DefaultContext;
 
+#if DEBUG
+        internal const Formatting DefaultFormatting = Formatting.Indented;
+#else
         internal const Formatting DefaultFormatting = Formatting.None;
+#endif
         internal const DateFormatHandling DefaultDateFormatHandling = DateFormatHandling.IsoDateFormat;
         internal const DateTimeZoneHandling DefaultDateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
         internal const DateParseHandling DefaultDateParseHandling = DateParseHandling.DateTime;


### PR DESCRIPTION
DefaultFormatting should remain "None" for RELEASE builds, but it's easier to read "Indented" JSON for the purposes of DEBUG builds.