### PR TITLE
Fix null reference in Json.NET with F# and WinRT

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/FSharpUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/FSharpUtils.cs
@@ -88,10 +88,10 @@ namespace Newtonsoft.Json.Utilities
 
                         Type fsharpType = fsharpCoreAssembly.GetType("Microsoft.FSharp.Reflection.FSharpType");
 
-                        MethodInfo isUnionMethodInfo = fsharpType.GetMethod("IsUnion", BindingFlags.Public | BindingFlags.Static);
+                        MethodInfo isUnionMethodInfo = fsharpType.GetMethod("IsUnion", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
                         IsUnion = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(isUnionMethodInfo);
 
-                        MethodInfo getUnionCasesMethodInfo = fsharpType.GetMethod("GetUnionCases", BindingFlags.Public | BindingFlags.Static);
+                        MethodInfo getUnionCasesMethodInfo = fsharpType.GetMethod("GetUnionCases", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
                         GetUnionCases = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(getUnionCasesMethodInfo);
 
                         Type fsharpValue = fsharpCoreAssembly.GetType("Microsoft.FSharp.Reflection.FSharpValue");
@@ -123,7 +123,7 @@ namespace Newtonsoft.Json.Utilities
 
         private static MethodCall<object, object> CreateFSharpFuncCall(Type type, string methodName)
         {
-            MethodInfo innerMethodInfo = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            MethodInfo innerMethodInfo = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic );
             MethodInfo invokeFunc = innerMethodInfo.ReturnType.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance);
 
             MethodCall<object, object> call = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(innerMethodInfo);


### PR DESCRIPTION
F# class libraries built for various WinRT class library types aren't able to use Json.NET at the moment.

I've set up a tiny repo to demonstrate the crash, which you can find at https://github.com/alexhardwicke/NewtonsoftRTBug

The exception and call stack:

    System.ArgumentNullException: Value cannot be null.
    Parameter name: method
    at Newtonsoft.Json.Utilities.ExpressionReflectionDelegateFactory.CreateMethodCall[T](MethodBase method)
    at Newtonsoft.Json.Utilities.FSharpUtils.EnsureInitialized(Assembly fsharpCoreAssembly)
    at Newtonsoft.Json.Converters.DiscriminatedUnionConverter.CanConvert(Type objectType)
    at Newtonsoft.Json.JsonSerializer.GetMatchingConverter(IList`1 converters, Type objectType)
    at Newtonsoft.Json.Serialization.DefaultContractResolver.InitializeContract(JsonContract contract)
    at Newtonsoft.Json.Serialization.DefaultContractResolver.CreateObjectContract(Type objectType)
    at Newtonsoft.Json.Serialization.DefaultContractResolver.CreateContract(Type objectType)
    at Newtonsoft.Json.Serialization.DefaultContractResolver.ResolveContract(Type type)
    at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonWriter jsonWriter, Object value, Type objectType)
    at Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Object value, Type objectType)
    at Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type type, JsonSerializer jsonSerializer)
    at Newtonsoft.Json.JsonConvert.SerializeObject(Object value)
    at FSharpLibrary.Serialise.get_X()
    at NewtonsoftRTBug.MainPage.<>c.<<-ctor>b__0_0>d.MoveNext()

The problem seems to be that the methods that Json.NET wants in FSharpUtils.cs are NonPublic in the versions of FSharp.Core that are available to F# Portable40 class libraries (3.259.4.0, 3.259.3.1 and 3.7.4.0 have the problem - I haven't tested further).


Adding the NonPublic BindingFlag where appropriate resolves the problem.

I've not created new tests because it'd be a bit involved - I'd have to add an F# Portable40 project that tries to serialise/deserialise and I thought I'd wait for some input before going that far.