### PR TITLE
Let json support "Dollar-Quoted String".

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A dollar-quoted string that follows a keyword or identifier must be separated fr
       {
         "IntervalSecondsForCheck": "60",
         "Start": "2014-09-21T05:00:00+08:00",
-        "LastActiveTime": "2014-09-25T06:12:58.8958167+08:00",
+   property     "LastActiveTime": "2014-09-25T06:12:58.8958167+08:00",
         "Interval": "1.00:00:00",
         "Message": $tag$
 hi, !@#$%^&*()_+{}:"|<>?,./;'[]\-=
@@ -61,3 +61,20 @@ $tag$
   }   
 }
 ```
+
+###A example of serialize a property by "Dollar-Quoted String"
+```c
+    public class Test1
+    {
+        [JsonProperty(DollarTag="aa")]
+        public string Name { get; set; }
+    }
+```
+
+###A example of write all string by "Dollar-Quoted String"
+```c
+    jsonTextWriter.DollarTag = null;   //don't use "Dollar-Quoted String"
+    jsonTextWriter.DollarTag = "";     //use "Dollar-Quoted String" by $$
+	jsonTextWriter.DollarTag = "tag";  //use "Dollar-Quoted String" by $tag$
+```
+	

--- a/README.md
+++ b/README.md
@@ -1,8 +1,63 @@
-#![Logo](Doc/icons/logo.jpg) Json.NET#
+##Let json support "Dollar-Quoted String". 
 
-- [Homepage](http://www.newtonsoft.com/json)
-- [Documentation](http://www.newtonsoft.com/json/help)
-- [NuGet Package](https://www.nuget.org/packages/Newtonsoft.Json)
-- [Contributing Guidelines](CONTRIBUTING.md)
-- [License](LICENSE.md)
-- [Stack Overflow](http://stackoverflow.com/questions/tagged/json.net)
+Dollar-Quoted string is introduced by PostgreSQL. But it not about database. It's a very good idea to express string in source code.
+It's has similar effect with xml's CDATA. But Dollar-Quoted string is more powerfull and easier. 
+
+This project can read json with Dollar-Quoted string, write json with Dollar-Quoted string, serialize object to  json with Dollar-Quoted string according C# attributes.
+
+###Dollar-Quoted String:
+
+While the standard syntax for specifying string constants is usually convenient, it can be difficult to understand when the desired string contains many single quotes or backslashes, since each of those must be doubled. To allow more readable queries in such situations, PostgreSQL provides another way, called "dollar quoting", to write string constants. A dollar-quoted string constant consists of a dollar sign ($), an optional "tag" of zero or more characters, another dollar sign, an arbitrary sequence of characters that makes up the string content, a dollar sign, the same tag that began this dollar quote, and a dollar sign. For example, here are two different ways to specify the string "Dianne's horse" using dollar quoting:
+
+```c
+$$Dianne's horse$$
+$SomeTag$Dianne's horse$SomeTag$
+```
+
+Notice that inside the dollar-quoted string, single quotes can be used without needing to be escaped. Indeed, no characters inside a dollar-quoted string are ever escaped: the string content is always written literally. Backslashes are not special, and neither are dollar signs, unless they are part of a sequence matching the opening tag.
+
+It is possible to nest dollar-quoted string constants by choosing different tags at each nesting level. This is most commonly used in writing function definitions. For example:
+
+```c
+$function$
+BEGIN
+    RETURN ($1 ~ $q$[\t\r\n\v\\]$q$);
+END;
+$function$
+```
+
+Here, the sequence $q$[\t\r\n\v\\]$q$ represents a dollar-quoted literal string [\t\r\n\v\\], which will be recognized when the function body is executed by PostgreSQL. But since the sequence does not match the outer dollar quoting delimiter $function$, it is just some more characters within the constant so far as the outer string is concerned.
+
+The tag, if any, of a dollar-quoted string follows the same rules as an unquoted identifier, except that it cannot contain a dollar sign. Tags are case sensitive, so $tag$String content$tag$ is correct, but $TAG$String content$tag$ is not.
+
+A dollar-quoted string that follows a keyword or identifier must be separated from it by whitespace; otherwise the dollar quoting delimiter would be taken as part of the preceding identifier.
+
+###A example of json with "Dollar-Quoted String"
+
+```c
+{
+  "Config": {
+    "Tasks": {
+      "Task": [ 
+      {
+        "IntervalSecondsForCheck": "60",
+        "Start": "2014-09-21T05:00:00+08:00",
+        "LastActiveTime": "2014-09-25T06:12:58.8958167+08:00",
+        "Interval": "1.00:00:00",
+        "Message": $tag$
+hi, !@#$%^&*()_+{}:"|<>?,./;'[]\-=
+abc"abc"abc\abc/abc$abc
+hi
+$tag$
+      },
+      {
+        "IntervalSecondsForCheck": "60",
+        "Start": "2014-11-21T05:00:00+08:00",
+        $aa$LastActiveTime$aa$: $bb$2013-11-22T07:19:44.5380022+08:00$bb$,
+        "Interval": "1.00:00:00",
+        "Message": "teset"
+      }]
+    }
+  }   
+}
+```

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
@@ -122,6 +122,46 @@ namespace Newtonsoft.Json.Tests
         }
 
         [Test]
+        public void ReadDollarQuoteString()
+        {
+            string json = @"{""NameOfStore"":$$Forest's Bakery And Cafe$$}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+            jsonTextReader.Read();
+            jsonTextReader.Read();
+            jsonTextReader.Read();
+
+            Assert.AreEqual(@"Forest's Bakery And Cafe", jsonTextReader.Value);
+        }
+
+        [Test]
+        public void ReadDollarQuoteStringWithTag()
+        {
+            string json = @"{""NameOfStore"":$tag$Forest's Bakery And Cafe$tag$}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+            jsonTextReader.Read();
+            jsonTextReader.Read();
+            jsonTextReader.Read();
+
+            Assert.AreEqual(@"Forest's Bakery And Cafe", jsonTextReader.Value);
+        } 
+
+        [Test]
+        public void ReadDollarQuotePropertyWithTag()
+        {
+            string json = @"{$pp$Name'Of""Store$pp$:$tag$Forest's Bakery And Cafe$tag$}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+            jsonTextReader.Read();           
+            jsonTextReader.Read();
+            Assert.AreEqual(@"Name'Of""Store", jsonTextReader.Value );
+            jsonTextReader.Read();
+
+            Assert.AreEqual(@"Forest's Bakery And Cafe", jsonTextReader.Value);
+        }
+
+        [Test]
         public void ReadMultilineString()
         {
             string json = @"""first line

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
@@ -296,9 +296,7 @@
     <Compile Include="TestObjects\ContentBaseClass.cs" />
     <Compile Include="TestObjects\ContentSubClass.cs" />
     <Compile Include="TestObjects\Currency.cs" />
-    <Compile Include="TestObjects\CustomerDataSet.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="TestObjects\CustomerDataSet.cs" />
     <Compile Include="TestObjects\DataContractSerializationAttributesClass.cs" />
     <Compile Include="TestObjects\DateTimeWrapper.cs" />
     <Compile Include="TestObjects\DecimalTestClass.cs" />

--- a/Src/Newtonsoft.Json.Tests/project.json
+++ b/Src/Newtonsoft.Json.Tests/project.json
@@ -3,7 +3,7 @@
   "exclude": [
   ],
   "dependencies": {
-    "Newtonsoft.Json": ""
+    "Newtonsoft.Json": "*"
   },
   "commands": {
     "test": "xunit.runner.dnx -parallel none"

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -32,7 +32,7 @@ namespace Newtonsoft.Json
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class JsonPropertyAttribute : Attribute
-    {
+    { 
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state
         internal NullValueHandling? _nullValueHandling;
@@ -46,6 +46,7 @@ namespace Newtonsoft.Json
         internal bool? _itemIsReference;
         internal ReferenceLoopHandling? _itemReferenceLoopHandling;
         internal TypeNameHandling? _itemTypeNameHandling;
+        internal string _dollarTag;
 
         /// <summary>
         /// Gets or sets the converter used when serializing the property's collection items.
@@ -182,7 +183,20 @@ namespace Newtonsoft.Json
             set { _itemIsReference = value; }
         }
 
-        public string DollarTag { get;  set; }
+        /// <summary>
+        /// DollarTag
+        /// </summary>
+        public string DollarTag
+        {
+            get { return _dollarTag; }
+            set
+            {
+                if (value.Contains("$"))
+                    throw new ArgumentException(@"Invalid DollarTag. Can't contain $.");
+
+                _dollarTag = value;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonPropertyAttribute"/> class.

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -182,6 +182,8 @@ namespace Newtonsoft.Json
             set { _itemIsReference = value; }
         }
 
+        public string DollarTag { get;  set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonPropertyAttribute"/> class.
         /// </summary>

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -377,7 +377,25 @@ namespace Newtonsoft.Json
                 WriteValueInternal(JsonConvert.Null, JsonToken.Null);
             else if (this.DollarTag != null)
             {
-                _writer.Write("$" + this.DollarTag + "$" + value + "$" + this.DollarTag + "$");
+                var fullTag = "$" + this.DollarTag + "$";
+                int maxTry = 10;
+                for (int i = 0; i < maxTry; i++)
+                {
+                    if (!value.Contains(fullTag))
+                    {
+                        break;
+                    }
+
+                    if (i < maxTry - 1)
+                    {
+                        fullTag = "$" + this.DollarTag + i + "$";
+                    }
+                    else
+                    {
+                        fullTag = "$" + Guid.NewGuid().ToString("N") + "$";
+                    }
+                }
+                _writer.Write(fullTag + value + fullTag);
                 this.DollarTag = null;
             }
             else

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -51,6 +51,8 @@ namespace Newtonsoft.Json
         private char[] _writeBuffer;
         private char[] _indentChars;
 
+        public string DollarTag;
+
         private Base64Encoder Base64Encoder
         {
             get
@@ -373,6 +375,11 @@ namespace Newtonsoft.Json
 
             if (value == null)
                 WriteValueInternal(JsonConvert.Null, JsonToken.Null);
+            else if (this.DollarTag != null)
+            {
+                _writer.Write("$" + this.DollarTag + "$" + value + "$" + this.DollarTag + "$");
+                this.DollarTag = null;
+            }
             else
                 WriteEscapedString(value, true);
         }

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1241,6 +1241,7 @@ namespace Newtonsoft.Json.Serialization
                 property._required = propertyAttribute._required;
                 property.Order = propertyAttribute._order;
                 property.DefaultValueHandling = propertyAttribute._defaultValueHandling;
+                property.DollarTag = propertyAttribute.DollarTag;
                 hasMemberAttribute = true;
             }
 #if !NET20

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -283,6 +283,11 @@ namespace Newtonsoft.Json.Serialization
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }
 
+        /// <summary>
+        /// DollarTag
+        /// </summary>
+        public string DollarTag { get; set; }
+
         internal void WritePropertyName(JsonWriter writer)
         {
             if (_skipPropertyNameEscape)

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -136,6 +136,15 @@ namespace Newtonsoft.Json.Serialization
                 }
             }
 
+
+            if (member.DollarTag != null)
+            {
+                var jtw = writer as JsonTextWriter;
+                if (jtw != null)
+                {
+                    jtw.DollarTag = member.DollarTag;
+                }
+            }
             JsonWriter.WriteValue(writer, contract.TypeCode, value);
         }
 
@@ -147,7 +156,7 @@ namespace Newtonsoft.Json.Serialization
                 return;
             }
 
-            JsonConverter converter = 
+            JsonConverter converter =
                 ((member != null) ? member.Converter : null) ??
                 ((containerProperty != null) ? containerProperty.ItemConverter : null) ??
                 ((containerContract != null) ? containerContract.ItemConverter : null) ??

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -137,7 +137,7 @@ namespace Newtonsoft.Json.Serialization
             }
 
 
-            if (member.DollarTag != null)
+            if (member!=null && member.DollarTag != null)
             {
                 var jtw = writer as JsonTextWriter;
                 if (jtw != null)

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -142,7 +142,7 @@ namespace Newtonsoft.Json.Serialization
                 var jtw = writer as JsonTextWriter;
                 if (jtw != null)
                 {
-                    jtw.DollarTag = member.DollarTag;
+                    jtw.TempDollarTag = member.DollarTag;
                 }
             }
             JsonWriter.WriteValue(writer, contract.TypeCode, value);

--- a/Src/NuGet.Config
+++ b/Src/NuGet.Config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
     <add key="AspNet VNext (CI Builds)" value="https://www.myget.org/F/aspnetvnext/" />
     <add key="xunit (CI Builds)" value="https://www.myget.org/F/xunit/" />
     <add key="NuGet.org (v2)" value="https://www.nuget.org/api/v2/" />


### PR DESCRIPTION
Let json support "Dollar-Quoted String". 

Dollar-Quoted string is introduced by PostgreSQL. But it not about database. It's a very good idea to express string in source code.
It's has similar effect with xml's CDATA. But Dollar-Quoted string is more powerfull and easier. 