### PR TITLE
Fixes deserializing with type name handling on assemblies loaded with Assembly.LoadFrom

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
@@ -68,7 +68,7 @@ namespace Newtonsoft.Json.Serialization
                     Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
                     foreach (Assembly a in loadedAssemblies)
                     {
-                        if (a.FullName == assemblyName)
+                        if (a.GetName().Name == assemblyName)
                         {
                             assembly = a;
                             break;


### PR DESCRIPTION
The assemblyName should not be compared to the Assembly.FullName as Json.NET only serializes a partial name.