### PR TITLE
Compare BaseDefinition for properties when adding private properties.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -1399,5 +1399,16 @@ namespace Newtonsoft.Json.Tests
                 writer.WriteValue(Math.Round((double)value, _precision, _rounding));
             }
         }
+
+        [Test]
+        public void GenericBaseClassSerialization()
+        {
+            string json = JsonConvert.SerializeObject (new NonGenericChildClass ());
+            Assert.AreEqual ("{\"Data\":null}", json);
+        }
+
+        public class GenericBaseClass<O, T> { public virtual T Data { get; set; } }
+        public class GenericIntermediateClass<O> : GenericBaseClass<O, string> { public override string Data { get; set; } }
+        public class NonGenericChildClass : GenericIntermediateClass<int> { }
     }
 }

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -967,7 +967,7 @@ namespace Newtonsoft.Json.Utilities
                             int index = initialProperties.IndexOf(p => p.Name == subTypeProperty.Name
                                                                        && p.IsVirtual()
                                                                        && p.GetBaseDefinition() != null
-                                                                       && p.GetBaseDefinition().DeclaringType.IsAssignableFrom(subTypeProperty.DeclaringType));
+                                                                       && p.GetBaseDefinition().DeclaringType.IsAssignableFrom(subTypeProperty.GetBaseDefinition().DeclaringType));
 
                             if (index == -1)
                                 initialProperties.Add(subTypeProperty);


### PR DESCRIPTION
Due to difference in mono vs .net (see https://bugzilla.xamarin.com/show_bug.cgi?id=36305),
MethodInfo.GetBaseDefinition() does not actually return base class (it returns partially-instantiated
generic class) in mono when overriding property from generic base class. Because of this, lookup
of matching property in ReflectionUtils.GetChildPrivateProperties() fails to find
already added property and adds the same property multiple times. Comparing GetBaseDefinition()'s
compensates for this: since the same function is applied to both PropertyInfo's, matching property
will be found.

This fixes issue #726.