### PR TITLE
Encode XML localName when converting to XML and decode when converting back

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
@@ -2554,6 +2554,19 @@ namespace Newtonsoft.Json.Tests.Converters
             Assert.AreEqual(@"{""DocumentId"":""13779965364495889899""}", json2);
         }
 #endif
+        [Test]
+        public void DeserializeXmlIncompatibleCharsInPropertyName()
+        {
+            var json = "{\"%name\":\"value\"}";
+
+            XmlDocument node = JsonConvert.DeserializeXmlNode(json);
+
+            Assert.AreEqual("<_x0025_name>value</_x0025_name>", node.OuterXml);
+
+            string json2 = JsonConvert.SerializeXmlNode(node);
+
+            Assert.AreEqual(json, json2);
+        }
 
         [Test]
         public void SerializeEmptyNodeAndOmitRoot()

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -99,7 +99,7 @@ namespace Newtonsoft.Json.Converters
 
         public IXmlElement CreateElement(string elementName)
         {
-            return new XmlElementWrapper(_document.CreateElement(elementName));
+            return new XmlElementWrapper(_document.CreateElement(XmlConvert.EncodeName(elementName)));
         }
 
         public IXmlElement CreateElement(string qualifiedName, string namespaceUri)
@@ -977,9 +977,9 @@ namespace Newtonsoft.Json.Converters
                 : manager.LookupPrefix(node.NamespaceUri);
 
             if (!string.IsNullOrEmpty(prefix))
-                return prefix + ":" + node.LocalName;
+                return prefix + ":" + XmlConvert.DecodeName(node.LocalName);
             else
-                return node.LocalName;
+                return XmlConvert.DecodeName(node.LocalName);
         }
 
         private string GetPropertyName(IXmlNode node, XmlNamespaceManager manager)


### PR DESCRIPTION
If JSON contains characters not allowed in XML local names (such as percent sign, for example) `JsonConvert.DeserializeXmlNode()` throws exception. To prevent this property name should be encoded with [XmlConver.EncodeName](https://msdn.microsoft.com/en-us/library/system.xml.xmlconvert.encodename%28v=vs.110%29.aspx) and decoded with [XmlConvert.DecodeName](https://msdn.microsoft.com/en-us/library/system.xml.xmlconvert.decodename%28v=vs.110%29.aspx).