### PR TITLE
* Update JContainer.ValidateToken to remove an old property with the …

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -372,6 +372,10 @@ namespace Newtonsoft.Json.Linq
             JToken next = (index == children.Count) ? null : children[index];
 
             ValidateToken(item, null);
+            // BM : ValidateToken may have removed an already existing duplicate key
+            //      Check index is not off the end.
+            if (index > ChildrenTokens.Count)
+                index = ChildrenTokens.Count;
 
             item.Parent = this;
 
@@ -467,6 +471,10 @@ namespace Newtonsoft.Json.Linq
             item = EnsureParentToken(item, false);
 
             ValidateToken(item, existing);
+            // BM : ValidateToken may have removed an already existing duplicate key
+            //      Check index is not off the end.
+            if (index > ChildrenTokens.Count)
+                index = ChildrenTokens.Count;
 
             JToken previous = (index == 0) ? null : children[index - 1];
             JToken next = (index == children.Count - 1) ? null : children[index + 1];

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -154,7 +154,7 @@ namespace Newtonsoft.Json.Linq
             if (_properties.TryGetValue(newProperty.Name, out existing))
             {
                 // BM : If a property with the same name aready exists, remove it so we can add the incoming one.
-                Console.WriteLine("Overwriting old duplicate property name detected: {0}", newProperty.Name);
+                Console.WriteLine("[Json.NET] Overwriting old duplicate property name detected: {0}", newProperty.Name);
                 _properties.Remove(newProperty.Name);
             }
         }

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -154,7 +154,6 @@ namespace Newtonsoft.Json.Linq
             if (_properties.TryGetValue(newProperty.Name, out existing))
             {
                 // BM : If a property with the same name aready exists, remove it so we can add the incoming one.
-                Console.WriteLine("[Json.NET] Overwriting old duplicate property name detected: {0}", newProperty.Name);
                 _properties.Remove(newProperty.Name);
             }
         }

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -152,7 +152,11 @@ namespace Newtonsoft.Json.Linq
             }
 
             if (_properties.TryGetValue(newProperty.Name, out existing))
-                throw new ArgumentException("Can not add property {0} to {1}. Property with the same name already exists on object.".FormatWith(CultureInfo.InvariantCulture, newProperty.Name, GetType()));
+            {
+                // BM : If a property with the same name aready exists, remove it so we can add the incoming one.
+                Console.WriteLine("Overwriting old duplicate property name detected: {0}", newProperty.Name);
+                _properties.Remove(newProperty.Name);
+            }
         }
 
         internal override void MergeItem(object content, JsonMergeSettings settings)


### PR DESCRIPTION
…same key as the incoming property.

   - Insertion will continue as normal; resulting in the newer property overwriting the older one.
* Handle index going out of range as remove the old property will decrease the size of the Child list.