### PR TITLE
Use GetValueOrDefault() over Value when Nullable<T> known non-null

### DIFF
--- a/Src/Newtonsoft.Json/Bson/BsonBinaryWriter.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonBinaryWriter.cs
@@ -198,7 +198,7 @@ namespace Newtonsoft.Json.Bson
         {
             if (calculatedlengthPrefix != null)
             {
-                _writer.Write(calculatedlengthPrefix.Value);
+                _writer.Write(calculatedlengthPrefix.GetValueOrDefault());
             }
 
             WriteUtf8Bytes(s, byteCount);

--- a/Src/Newtonsoft.Json/JsonPosition.cs
+++ b/Src/Newtonsoft.Json/JsonPosition.cs
@@ -118,7 +118,7 @@ namespace Newtonsoft.Json
             }
             if (currentPosition != null)
             {
-                capacity += currentPosition.Value.CalculateLength();
+                capacity += currentPosition.GetValueOrDefault().CalculateLength();
             }
 
             StringBuilder sb = new StringBuilder(capacity);
@@ -131,7 +131,7 @@ namespace Newtonsoft.Json
             }
             if (currentPosition != null)
             {
-                currentPosition.Value.WriteTo(sb);
+                currentPosition.GetValueOrDefault().WriteTo(sb);
             }
 
             return sb.ToString();

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -847,7 +847,7 @@ namespace Newtonsoft.Json
             if (_dateTimeZoneHandling != null && reader.DateTimeZoneHandling != _dateTimeZoneHandling)
             {
                 previousDateTimeZoneHandling = reader.DateTimeZoneHandling;
-                reader.DateTimeZoneHandling = _dateTimeZoneHandling.Value;
+                reader.DateTimeZoneHandling = _dateTimeZoneHandling.GetValueOrDefault();
             }
             else
             {
@@ -857,7 +857,7 @@ namespace Newtonsoft.Json
             if (_dateParseHandling != null && reader.DateParseHandling != _dateParseHandling)
             {
                 previousDateParseHandling = reader.DateParseHandling;
-                reader.DateParseHandling = _dateParseHandling.Value;
+                reader.DateParseHandling = _dateParseHandling.GetValueOrDefault();
             }
             else
             {
@@ -867,7 +867,7 @@ namespace Newtonsoft.Json
             if (_floatParseHandling != null && reader.FloatParseHandling != _floatParseHandling)
             {
                 previousFloatParseHandling = reader.FloatParseHandling;
-                reader.FloatParseHandling = _floatParseHandling.Value;
+                reader.FloatParseHandling = _floatParseHandling.GetValueOrDefault();
             }
             else
             {
@@ -914,15 +914,15 @@ namespace Newtonsoft.Json
             }
             if (previousDateTimeZoneHandling != null)
             {
-                reader.DateTimeZoneHandling = previousDateTimeZoneHandling.Value;
+                reader.DateTimeZoneHandling = previousDateTimeZoneHandling.GetValueOrDefault();
             }
             if (previousDateParseHandling != null)
             {
-                reader.DateParseHandling = previousDateParseHandling.Value;
+                reader.DateParseHandling = previousDateParseHandling.GetValueOrDefault();
             }
             if (previousFloatParseHandling != null)
             {
-                reader.FloatParseHandling = previousFloatParseHandling.Value;
+                reader.FloatParseHandling = previousFloatParseHandling.GetValueOrDefault();
             }
             if (_maxDepthSet)
             {
@@ -1003,35 +1003,35 @@ namespace Newtonsoft.Json
             if (_formatting != null && jsonWriter.Formatting != _formatting)
             {
                 previousFormatting = jsonWriter.Formatting;
-                jsonWriter.Formatting = _formatting.Value;
+                jsonWriter.Formatting = _formatting.GetValueOrDefault();
             }
 
             DateFormatHandling? previousDateFormatHandling = null;
             if (_dateFormatHandling != null && jsonWriter.DateFormatHandling != _dateFormatHandling)
             {
                 previousDateFormatHandling = jsonWriter.DateFormatHandling;
-                jsonWriter.DateFormatHandling = _dateFormatHandling.Value;
+                jsonWriter.DateFormatHandling = _dateFormatHandling.GetValueOrDefault();
             }
 
             DateTimeZoneHandling? previousDateTimeZoneHandling = null;
             if (_dateTimeZoneHandling != null && jsonWriter.DateTimeZoneHandling != _dateTimeZoneHandling)
             {
                 previousDateTimeZoneHandling = jsonWriter.DateTimeZoneHandling;
-                jsonWriter.DateTimeZoneHandling = _dateTimeZoneHandling.Value;
+                jsonWriter.DateTimeZoneHandling = _dateTimeZoneHandling.GetValueOrDefault();
             }
 
             FloatFormatHandling? previousFloatFormatHandling = null;
             if (_floatFormatHandling != null && jsonWriter.FloatFormatHandling != _floatFormatHandling)
             {
                 previousFloatFormatHandling = jsonWriter.FloatFormatHandling;
-                jsonWriter.FloatFormatHandling = _floatFormatHandling.Value;
+                jsonWriter.FloatFormatHandling = _floatFormatHandling.GetValueOrDefault();
             }
 
             StringEscapeHandling? previousStringEscapeHandling = null;
             if (_stringEscapeHandling != null && jsonWriter.StringEscapeHandling != _stringEscapeHandling)
             {
                 previousStringEscapeHandling = jsonWriter.StringEscapeHandling;
-                jsonWriter.StringEscapeHandling = _stringEscapeHandling.Value;
+                jsonWriter.StringEscapeHandling = _stringEscapeHandling.GetValueOrDefault();
             }
 
             CultureInfo previousCulture = null;
@@ -1063,23 +1063,23 @@ namespace Newtonsoft.Json
             // reset writer back to previous options
             if (previousFormatting != null)
             {
-                jsonWriter.Formatting = previousFormatting.Value;
+                jsonWriter.Formatting = previousFormatting.GetValueOrDefault();
             }
             if (previousDateFormatHandling != null)
             {
-                jsonWriter.DateFormatHandling = previousDateFormatHandling.Value;
+                jsonWriter.DateFormatHandling = previousDateFormatHandling.GetValueOrDefault();
             }
             if (previousDateTimeZoneHandling != null)
             {
-                jsonWriter.DateTimeZoneHandling = previousDateTimeZoneHandling.Value;
+                jsonWriter.DateTimeZoneHandling = previousDateTimeZoneHandling.GetValueOrDefault();
             }
             if (previousFloatFormatHandling != null)
             {
-                jsonWriter.FloatFormatHandling = previousFloatFormatHandling.Value;
+                jsonWriter.FloatFormatHandling = previousFloatFormatHandling.GetValueOrDefault();
             }
             if (previousStringEscapeHandling != null)
             {
-                jsonWriter.StringEscapeHandling = previousStringEscapeHandling.Value;
+                jsonWriter.StringEscapeHandling = previousStringEscapeHandling.GetValueOrDefault();
             }
             if (_dateFormatStringSet)
             {

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -490,7 +490,7 @@ namespace Newtonsoft.Json
             else
             {
                 InternalWriteValue(JsonToken.Float);
-                WriteValueInternal(JsonConvert.ToString(value.Value, FloatFormatHandling, QuoteChar, true), JsonToken.Float);
+                WriteValueInternal(JsonConvert.ToString(value.GetValueOrDefault(), FloatFormatHandling, QuoteChar, true), JsonToken.Float);
             }
         }
 
@@ -517,7 +517,7 @@ namespace Newtonsoft.Json
             else
             {
                 InternalWriteValue(JsonToken.Float);
-                WriteValueInternal(JsonConvert.ToString(value.Value, FloatFormatHandling, QuoteChar, true), JsonToken.Float);
+                WriteValueInternal(JsonConvert.ToString(value.GetValueOrDefault(), FloatFormatHandling, QuoteChar, true), JsonToken.Float);
             }
         }
 

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -361,7 +361,7 @@ namespace Newtonsoft.Json
             JsonSchemaType? currentNodeType = GetCurrentNodeSchemaType();
             if (currentNodeType != null)
             {
-                if (JsonSchemaGenerator.HasFlag(schema.Disallow, currentNodeType.Value))
+                if (JsonSchemaGenerator.HasFlag(schema.Disallow, currentNodeType.GetValueOrDefault()))
                 {
                     RaiseError("Type {0} is disallowed.".FormatWith(CultureInfo.InvariantCulture, currentNodeType), schema);
                 }
@@ -835,7 +835,7 @@ namespace Newtonsoft.Json
                 else
 #endif
                 {
-                    notDivisible = !IsZero(Convert.ToInt64(value, CultureInfo.InvariantCulture) % schema.DivisibleBy.Value);
+                    notDivisible = !IsZero(Convert.ToInt64(value, CultureInfo.InvariantCulture) % schema.DivisibleBy.GetValueOrDefault());
                 }
 
                 if (notDivisible)
@@ -907,7 +907,7 @@ namespace Newtonsoft.Json
 
             if (schema.DivisibleBy != null)
             {
-                double remainder = FloatingPointRemainder(value, schema.DivisibleBy.Value);
+                double remainder = FloatingPointRemainder(value, schema.DivisibleBy.GetValueOrDefault());
 
                 if (!IsZero(remainder))
                 {

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -1091,7 +1091,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1108,7 +1108,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1124,7 +1124,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1141,7 +1141,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1157,7 +1157,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1173,7 +1173,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1189,7 +1189,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1205,7 +1205,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1222,7 +1222,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1238,7 +1238,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1254,7 +1254,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1271,7 +1271,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1287,7 +1287,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1303,7 +1303,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1320,7 +1320,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 #endif
@@ -1337,7 +1337,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 
@@ -1353,7 +1353,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                WriteValue(value.Value);
+                WriteValue(value.GetValueOrDefault());
             }
         }
 

--- a/Src/Newtonsoft.Json/Linq/JTokenReader.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenReader.cs
@@ -229,7 +229,7 @@ namespace Newtonsoft.Json.Linq
             JsonToken? endToken = GetEndToken(c);
             if (endToken != null)
             {
-                SetToken(endToken.Value);
+                SetToken(endToken.GetValueOrDefault());
                 _current = c;
                 _parent = c;
                 return true;

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -683,12 +683,12 @@ namespace Newtonsoft.Json.Linq
                 return JTokenType.String;
             }
 
-            switch (current.Value)
+            switch (current.GetValueOrDefault())
             {
                 case JTokenType.Comment:
                 case JTokenType.String:
                 case JTokenType.Raw:
-                    return current.Value;
+                    return current.GetValueOrDefault();
                 default:
                     return JTokenType.String;
             }

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
@@ -14,7 +14,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
             {
                 if (Index != null)
                 {
-                    JToken v = GetTokenIndex(t, errorWhenNoMatch, Index.Value);
+                    JToken v = GetTokenIndex(t, errorWhenNoMatch, Index.GetValueOrDefault());
 
                     if (v != null)
                     {

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
@@ -60,8 +60,8 @@ namespace Newtonsoft.Json.Linq.JsonPath
                         if (errorWhenNoMatch)
                         {
                             throw new JsonException("Array slice of {0} to {1} returned no results.".FormatWith(CultureInfo.InvariantCulture,
-                                Start != null ? Start.Value.ToString(CultureInfo.InvariantCulture) : "*",
-                                End != null ? End.Value.ToString(CultureInfo.InvariantCulture) : "*"));
+                                Start != null ? Start.GetValueOrDefault().ToString(CultureInfo.InvariantCulture) : "*",
+                                End != null ? End.GetValueOrDefault().ToString(CultureInfo.InvariantCulture) : "*"));
                         }
                     }
                 }

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaWriter.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaWriter.cs
@@ -84,7 +84,7 @@ namespace Newtonsoft.Json.Schema
             WritePropertyIfNotNull(_writer, JsonSchemaConstants.TransientPropertyName, schema.Transient);
             if (schema.Type != null)
             {
-                WriteType(JsonSchemaConstants.TypePropertyName, _writer, schema.Type.Value);
+                WriteType(JsonSchemaConstants.TypePropertyName, _writer, schema.Type.GetValueOrDefault());
             }
             if (!schema.AllowAdditionalProperties)
             {
@@ -143,7 +143,7 @@ namespace Newtonsoft.Json.Schema
             }
             if (schema.Disallow != null)
             {
-                WriteType(JsonSchemaConstants.DisallowPropertyName, _writer, schema.Disallow.Value);
+                WriteType(JsonSchemaConstants.DisallowPropertyName, _writer, schema.Disallow.GetValueOrDefault());
             }
             if (schema.Extends != null && schema.Extends.Count > 0)
             {

--- a/Src/Newtonsoft.Json/Serialization/JsonObjectContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonObjectContract.cs
@@ -192,7 +192,7 @@ namespace Newtonsoft.Json.Serialization
                     }
                 }
 
-                return _hasRequiredOrDefaultValueProperties.Value;
+                return _hasRequiredOrDefaultValueProperties.GetValueOrDefault();
             }
         }
 

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -2096,7 +2096,7 @@ namespace Newtonsoft.Json.Serialization
                         contract,
                         reader.Depth,
                         context.Property,
-                        context.Presence.Value,
+                        context.Presence.GetValueOrDefault(),
                         !context.Used);
                 }
             }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -262,7 +262,7 @@ namespace Newtonsoft.Json.Serialization
                 }
             }
 
-            if (!isReference.Value)
+            if (!isReference.GetValueOrDefault())
             {
                 return false;
             }

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -408,7 +408,7 @@ namespace Newtonsoft.Json.Serialization
 #endif
                 }
 
-                return _dynamicCodeGeneration.Value;
+                return _dynamicCodeGeneration.GetValueOrDefault();
             }
         }
 
@@ -437,7 +437,7 @@ namespace Newtonsoft.Json.Serialization
 #endif
                 }
 
-                return _fullyTrusted.Value;
+                return _fullyTrusted.GetValueOrDefault();
             }
         }
 

--- a/Src/Newtonsoft.Json/Utilities/MathUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/MathUtils.cs
@@ -138,7 +138,7 @@ namespace Newtonsoft.Json.Utilities
                 return val1;
             }
 
-            return Math.Min(val1.Value, val2.Value);
+            return Math.Min(val1.GetValueOrDefault(), val2.GetValueOrDefault());
         }
 
         public static int? Max(int? val1, int? val2)
@@ -152,7 +152,7 @@ namespace Newtonsoft.Json.Utilities
                 return val1;
             }
 
-            return Math.Max(val1.Value, val2.Value);
+            return Math.Max(val1.GetValueOrDefault(), val2.GetValueOrDefault());
         }
 
         public static double? Max(double? val1, double? val2)
@@ -166,7 +166,7 @@ namespace Newtonsoft.Json.Utilities
                 return val1;
             }
 
-            return Math.Max(val1.Value, val2.Value);
+            return Math.Max(val1.GetValueOrDefault(), val2.GetValueOrDefault());
         }
 
         public static bool ApproxEquals(double d1, double d2)

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -862,8 +862,8 @@ namespace Newtonsoft.Json.Utilities
 
             if (assemblyDelimiterIndex != null)
             {
-                typeName = fullyQualifiedTypeName.Substring(0, assemblyDelimiterIndex.Value).Trim();
-                assemblyName = fullyQualifiedTypeName.Substring(assemblyDelimiterIndex.Value + 1, fullyQualifiedTypeName.Length - assemblyDelimiterIndex.Value - 1).Trim();
+                typeName = fullyQualifiedTypeName.Substring(0, assemblyDelimiterIndex.GetValueOrDefault()).Trim();
+                assemblyName = fullyQualifiedTypeName.Substring(assemblyDelimiterIndex.GetValueOrDefault() + 1, fullyQualifiedTypeName.Length - assemblyDelimiterIndex.GetValueOrDefault() - 1).Trim();
             }
             else
             {


### PR DESCRIPTION
`GetValueOrDefault()` is an easily-inlined access to a field as this will hold the correct value for both `HasValue` and `!HasValue` cases.

The `Value` property in comparison contains a branch on a check that the `Nullable<T>` has its internal `hasValue` flag to decide whether to throw `InvalidOperationException` or not.

Hence when a nullable type is known to have a value (not be `null`) and one wants the value, rather than to possibly trigger the exception-throw, `GetValueOrDefault()` has a slight performance benefit over `Value`.
 
Accordingly, replace calls to the `Value` property with calls to `GetValueOrDefault()` when previous checks or assignments guarantee the value is not `null`.