### PR TITLE
Move reflection calls until after branches that may mean they're unused

### DIFF
--- a/Src/Newtonsoft.Json/Converters/BinaryConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/BinaryConverter.cs
@@ -99,10 +99,6 @@ namespace Newtonsoft.Json.Converters
         /// <returns>The object value.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            Type t = (ReflectionUtils.IsNullableType(objectType))
-                ? Nullable.GetUnderlyingType(objectType)
-                : objectType;
-
             if (reader.TokenType == JsonToken.Null)
             {
                 if (!ReflectionUtils.IsNullable(objectType))
@@ -130,6 +126,10 @@ namespace Newtonsoft.Json.Converters
             {
                 throw JsonSerializationException.Create(reader, "Unexpected token parsing binary. Expected String or StartArray, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
             }
+
+            Type t = (ReflectionUtils.IsNullableType(objectType))
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
 
 #if !NET20
             if (t.AssignableToTypeName(BinaryTypeName))

--- a/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
@@ -78,12 +78,6 @@ namespace Newtonsoft.Json.Converters
         /// <returns>The object value.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-#if !NET20
-            Type t = (ReflectionUtils.IsNullableType(objectType))
-                ? Nullable.GetUnderlyingType(objectType)
-                : objectType;
-#endif
-
             if (reader.TokenType == JsonToken.Null)
             {
                 if (!ReflectionUtils.IsNullable(objectType))
@@ -118,6 +112,9 @@ namespace Newtonsoft.Json.Converters
             }
 
 #if !NET20
+            Type t = (ReflectionUtils.IsNullableType(objectType))
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
             if (t == typeof(DateTimeOffset))
             {
                 return new DateTimeOffset(d);

--- a/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
@@ -80,17 +80,9 @@ namespace Newtonsoft.Json.Converters
         /// <returns>The object value.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            bool isNullable = ReflectionUtils.IsNullableType(objectType);
-
-            Type t = (isNullable)
-                ? Nullable.GetUnderlyingType(objectType)
-                : objectType;
-
-            ReflectionObject reflectionObject = ReflectionObjectPerType.Get(t);
-
             if (reader.TokenType == JsonToken.Null)
             {
-                if (!isNullable)
+                if (!ReflectionUtils.IsNullableType(objectType))
                 {
                     throw JsonSerializationException.Create(reader, "Cannot convert null value to KeyValuePair.");
                 }
@@ -102,6 +94,12 @@ namespace Newtonsoft.Json.Converters
             object value = null;
 
             ReadAndAssert(reader);
+
+            Type t = ReflectionUtils.IsNullableType(objectType)
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
+
+            ReflectionObject reflectionObject = ReflectionObjectPerType.Get(t);
 
             while (reader.TokenType == JsonToken.PropertyName)
             {

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -106,9 +106,6 @@ namespace Newtonsoft.Json.Converters
         /// <returns>The object value.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            bool isNullable = ReflectionUtils.IsNullableType(objectType);
-            Type t = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
-
             if (reader.TokenType == JsonToken.Null)
             {
                 if (!ReflectionUtils.IsNullableType(objectType))
@@ -118,6 +115,9 @@ namespace Newtonsoft.Json.Converters
 
                 return null;
             }
+
+            bool isNullable = ReflectionUtils.IsNullableType(objectType);
+            Type t = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
 
             try
             {


### PR DESCRIPTION
A handful of cases where reflection calls are made prior to branches that
might lead to the results not being used.