### PR TITLE
Expose JsonWriter.Dispose(bool) to derived classes.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -1552,6 +1552,46 @@ null//comment
   ]/*comment*/
 }/*comment *//*comment 1 */", sw.ToString());
         }
+
+        [Test]
+        public void DisposeSupressesFinalization()
+        {
+            UnmanagedResourceFakingJsonWriter.CreateAndDispose();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Assert.AreEqual(1, UnmanagedResourceFakingJsonWriter.DisposalCalls);
+        }
+    }
+
+    public class UnmanagedResourceFakingJsonWriter : JsonWriter
+    {
+        public static int DisposalCalls;
+
+        public static void CreateAndDispose()
+        {
+            ((IDisposable)new UnmanagedResourceFakingJsonWriter()).Dispose();
+        }
+
+        public UnmanagedResourceFakingJsonWriter()
+        {
+            DisposalCalls = 0;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            ++DisposalCalls;
+        }
+
+        ~UnmanagedResourceFakingJsonWriter()
+        {
+            Dispose(false);
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class CustomJsonTextWriter : JsonTextWriter

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -1094,7 +1094,7 @@ namespace Newtonsoft.Json
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (_currentState != State.Closed && disposing)
+            if (_currentState != State.Closed & disposing)
             {
                 Close();
             }

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -1437,9 +1437,14 @@ namespace Newtonsoft.Json
         void IDisposable.Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool disposing)
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
         {
             if (_currentState != State.Closed)
             {


### PR DESCRIPTION
Change to protected and virtual. Add GC.SuppressFinalize to IDisposable.Dispose().

See discussion on #746.

Also a micro-opt on JsonReader.Dispose(bool), changing a && to a & as the right-hand operand is fast to access and for most calls both will be true anyway, so removing the branch is a slight win on short-circuiting in that branch.