### PR TITLE
Correct ParamName in exception for invalid JsonToken on ‎WriteToken

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -898,6 +898,19 @@ Parameter name: value");
         }
 
         [Test]
+        public void TokenTypeOutOfRange()
+        {
+            using (JsonWriter jsonWriter = new JsonTextWriter(new StringWriter()))
+            {
+                ArgumentOutOfRangeException ex = ExceptionAssert.Throws<ArgumentOutOfRangeException>(() => jsonWriter.WriteToken((JsonToken)int.MinValue));
+                Assert.AreEqual("token", ex.ParamName);
+
+                ex = ExceptionAssert.Throws<ArgumentOutOfRangeException>(() => jsonWriter.WriteToken((JsonToken)int.MinValue, "test"));
+                Assert.AreEqual("token", ex.ParamName);
+            }
+        }
+
+        [Test]
         public void BadWriteEndArray()
         {
             ExceptionAssert.Throws<JsonWriterException>(() =>

--- a/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
+++ b/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
@@ -367,7 +367,7 @@ namespace Newtonsoft.Json.Tests
 
     public static class ExceptionAssert
     {
-        public static void Throws<TException>(Action action, params string[] possibleMessages)
+        public static TException Throws<TException>(Action action, params string[] possibleMessages)
             where TException : Exception
         {
             try
@@ -375,26 +375,23 @@ namespace Newtonsoft.Json.Tests
                 action();
 
                 Assert.Fail("Exception of type {0} expected. No exception thrown.", typeof(TException).Name);
+                return null;
             }
             catch (TException ex)
             {
-                if (possibleMessages != null && possibleMessages.Length > 0)
+                if (possibleMessages == null || possibleMessages.Length == 0)
                 {
-                    bool match = false;
-                    foreach (string possibleMessage in possibleMessages)
+                    return ex;
+                }
+                foreach (string possibleMessage in possibleMessages)
+                {
+                    if (StringAssert.Equals(possibleMessage, ex.Message))
                     {
-                        if (StringAssert.Equals(possibleMessage, ex.Message))
-                        {
-                            match = true;
-                            break;
-                        }
-                    }
-
-                    if (!match)
-                    {
-                        throw new Exception("Unexpected exception message." + Environment.NewLine + "Expected one of: " + string.Join(Environment.NewLine, possibleMessages) + Environment.NewLine + "Got: " + ex.Message + Environment.NewLine + Environment.NewLine + ex);
+                        return ex;
                     }
                 }
+
+                throw new Exception("Unexpected exception message." + Environment.NewLine + "Expected one of: " + string.Join(Environment.NewLine, possibleMessages) + Environment.NewLine + "Got: " + ex.Message + Environment.NewLine + Environment.NewLine + ex);
             }
             catch (Exception ex)
             {

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -508,64 +508,7 @@ namespace Newtonsoft.Json
         /// A null value can be passed to the method for token's that don't have a value, e.g. <see cref="JsonToken.StartObject"/>.</param>
         public void WriteToken(JsonToken token, object value)
         {
-            WriteTokenInternal(token, value);
-        }
-
-        /// <summary>
-        /// Writes the <see cref="JsonToken"/> token.
-        /// </summary>
-        /// <param name="token">The <see cref="JsonToken"/> to write.</param>
-        public void WriteToken(JsonToken token)
-        {
-            WriteTokenInternal(token, null);
-        }
-
-        internal void WriteToken(JsonReader reader, bool writeChildren, bool writeDateConstructorAsDate, bool writeComments)
-        {
-            int initialDepth;
-
-            if (reader.TokenType == JsonToken.None)
-            {
-                initialDepth = -1;
-            }
-            else if (!JsonTokenUtils.IsStartToken(reader.TokenType))
-            {
-                initialDepth = reader.Depth + 1;
-            }
-            else
-            {
-                initialDepth = reader.Depth;
-            }
-
-            WriteToken(reader, initialDepth, writeChildren, writeDateConstructorAsDate, writeComments);
-        }
-
-        internal void WriteToken(JsonReader reader, int initialDepth, bool writeChildren, bool writeDateConstructorAsDate, bool writeComments)
-        {
-            do
-            {
-                // write a JValue date when the constructor is for a date
-                if (writeDateConstructorAsDate && reader.TokenType == JsonToken.StartConstructor && string.Equals(reader.Value.ToString(), "Date", StringComparison.Ordinal))
-                {
-                    WriteConstructorDate(reader);
-                }
-                else
-                {
-                    if (reader.TokenType != JsonToken.Comment || writeComments)
-                    {
-                        WriteTokenInternal(reader.TokenType, reader.Value);
-                    }
-                }
-            } while (
-                // stop if we have reached the end of the token being read
-                initialDepth - 1 < reader.Depth - (JsonTokenUtils.IsEndToken(reader.TokenType) ? 1 : 0)
-                && writeChildren
-                && reader.Read());
-        }
-
-        private void WriteTokenInternal(JsonToken tokenType, object value)
-        {
-            switch (tokenType)
+            switch (token)
             {
                 case JsonToken.None:
                     // read to next
@@ -670,8 +613,60 @@ namespace Newtonsoft.Json
                     }
                     break;
                 default:
-                    throw MiscellaneousUtils.CreateArgumentOutOfRangeException("TokenType", tokenType, "Unexpected token type.");
+                    throw MiscellaneousUtils.CreateArgumentOutOfRangeException(nameof(token), token, "Unexpected token type.");
             }
+        }
+
+        /// <summary>
+        /// Writes the <see cref="JsonToken"/> token.
+        /// </summary>
+        /// <param name="token">The <see cref="JsonToken"/> to write.</param>
+        public void WriteToken(JsonToken token)
+        {
+            WriteToken(token, null);
+        }
+
+        internal void WriteToken(JsonReader reader, bool writeChildren, bool writeDateConstructorAsDate, bool writeComments)
+        {
+            int initialDepth;
+
+            if (reader.TokenType == JsonToken.None)
+            {
+                initialDepth = -1;
+            }
+            else if (!JsonTokenUtils.IsStartToken(reader.TokenType))
+            {
+                initialDepth = reader.Depth + 1;
+            }
+            else
+            {
+                initialDepth = reader.Depth;
+            }
+
+            WriteToken(reader, initialDepth, writeChildren, writeDateConstructorAsDate, writeComments);
+        }
+
+        internal void WriteToken(JsonReader reader, int initialDepth, bool writeChildren, bool writeDateConstructorAsDate, bool writeComments)
+        {
+            do
+            {
+                // write a JValue date when the constructor is for a date
+                if (writeDateConstructorAsDate && reader.TokenType == JsonToken.StartConstructor && string.Equals(reader.Value.ToString(), "Date", StringComparison.Ordinal))
+                {
+                    WriteConstructorDate(reader);
+                }
+                else
+                {
+                    if (reader.TokenType != JsonToken.Comment || writeComments)
+                    {
+                        WriteToken(reader.TokenType, reader.Value);
+                    }
+                }
+            } while (
+                // stop if we have reached the end of the token being read
+                initialDepth - 1 < reader.Depth - (JsonTokenUtils.IsEndToken(reader.TokenType) ? 1 : 0)
+                && writeChildren
+                && reader.Read());
         }
 
         private void WriteConstructorDate(JsonReader reader)


### PR DESCRIPTION
Fixes #755

Also consolidates WriteTokenInternal into matching WriteToken (slightly reduce
assembly size).

Also extend ExceptionAssert.Throws to return exception for further examination.