### PR TITLE
Updated StringEnumConverter to correctly handle integers when passed as Strings and Integers are not allowed

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
@@ -413,6 +413,41 @@ namespace Newtonsoft.Json.Tests.Converters
             Assert.Fail();
         }
 
+        [Test]
+        public void DeserializeInvalidStringWhenNotAllowIntegers()
+        {
+            string json = "{ \"Value\" : \"Three\" }";
+
+            ExceptionAssert.Throws<JsonSerializationException>(() =>
+            {
+                var serializer = new JsonSerializer();
+                serializer.Converters.Add(new StringEnumConverter() { AllowIntegerValues = false });
+                serializer.Deserialize<Bucket>(new JsonTextReader(new StringReader(json)));
+            }, @"Error converting value ""Three"" to type 'Newtonsoft.Json.Tests.Converters.StringEnumConverterTests+MyEnum'. Path 'Value', line 1, position 19.");
+        }
+
+        [Test]
+        public void DeserializeIntegerPassedAsStringButNotAllowed()
+        {
+            string json = "{ \"Value\" : \"123\" }";
+
+            try
+            {
+                var serializer = new JsonSerializer();
+                serializer.Converters.Add(new StringEnumConverter { AllowIntegerValues = false });
+                serializer.Deserialize<Bucket>(new JsonTextReader(new StringReader(json)));
+            }
+            catch (JsonSerializationException ex)
+            {
+                Assert.AreEqual("Error converting value \"123\" to type 'Newtonsoft.Json.Tests.Converters.StringEnumConverterTests+MyEnum'. Path 'Value', line 1, position 17.", ex.Message);
+                Assert.AreEqual(@"Integer value 123 is not allowed. Path 'Value', line 1, position 17.", ex.InnerException.Message);
+
+                return;
+            }
+
+            Assert.Fail();
+        }
+
 #if !NET20
         [Test]
         public void EnumMemberPlusFlags()

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -134,6 +134,14 @@ namespace Newtonsoft.Json.Converters
                 if (reader.TokenType == JsonToken.String)
                 {
                     string enumText = reader.Value.ToString();
+
+                    if (!AllowIntegerValues)
+                    {
+                        int newValue;
+                        if (int.TryParse(enumText, out newValue))
+                            throw JsonSerializationException.Create(reader, "Integer value {0} is not allowed.".FormatWith(CultureInfo.InvariantCulture, reader.Value));
+                    }
+
                     return EnumUtils.ParseEnumName(enumText, isNullable, t);
                 }
 


### PR DESCRIPTION
The problem was initially posted here:
http://stackoverflow.com/questions/35479669/stringenumconverter-invalid-int-values/35484440#35484440

StringEnumConverter works as expected when it tries to convert an int value like
{  "MyEnumProperty": 99999} 
but if I specify the value as string it ,
{  "MyEnumProperty": "99999"}
maybe correctly, it tries to parse it

It could have been smarter and if AllowIntegerValues is set to false could check if the value is an integer and throw an error.
I believe this have help users ,like me ,avoid strange bugs
This is a breaking change but since Integers are not valid identifiers for an enum I cannot think of a case where that affects anyone (You may can though)

I added a few lines that fix the issue and created 2 unit tests.
I seems I haven't broken anything.

Review it and if you find it useful ,and correct,accept the pull request


