### PR TITLE
Fix documentation for 'JValue.CreateUndefined()'

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -599,9 +599,9 @@ namespace Newtonsoft.Json.Linq
         }
 
         /// <summary>
-        /// Creates a <see cref="JValue"/> null value.
+        /// Creates a <see cref="JValue"/> undefined value.
         /// </summary>
-        /// <returns>A <see cref="JValue"/> null value.</returns>
+        /// <returns>A <see cref="JValue"/> undefined value.</returns>
         public static JValue CreateUndefined()
         {
             return new JValue(null, JTokenType.Undefined);


### PR DESCRIPTION
The documentation mentions returning a 'null' value, when an 'undefined' value is returned.