### PR TITLE
Serialize F# DUs in a partial trust environment

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/DiscriminatedUnionConverterTests.cs
@@ -31,6 +31,7 @@ using Microsoft.FSharp.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Permissions;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Tests.TestObjects;
@@ -297,6 +298,15 @@ namespace Newtonsoft.Json.Tests.Converters
 
             Assert.AreEqual(5.0, r.length);
             Assert.AreEqual(10.0, r.width);
+        }
+
+        [Test]
+        [ReflectionPermission(SecurityAction.PermitOnly, Flags = ReflectionPermissionFlag.MemberAccess)]
+        public void SerializeUnionInPartialTrust()
+        {
+            
+
+            SerializeBasicUnion();
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Properties/AssemblyInfo.cs
+++ b/Src/Newtonsoft.Json.Tests/Properties/AssemblyInfo.cs
@@ -33,8 +33,10 @@ using System.Security;
 
 #if PORTABLE40
 [assembly: AssemblyTitle("Json.NET Tests Portable .NET 4.0")]
+[assembly: SecurityRules(SecurityRuleSet.Level1)]
 #elif PORTABLE
 [assembly: AssemblyTitle("Json.NET Tests Portable")]
+[assembly: SecurityRules(SecurityRuleSet.Level1)]
 #elif NETFX_CORE
 [assembly: AssemblyTitle("Json.NET Tests WinRT")]
 #elif NET20
@@ -43,10 +45,13 @@ using System.Security;
 [assembly: AssemblyTitle("Json.NET Tests .NET 3.5")]
 #elif NET40
 [assembly: AssemblyTitle("Json.NET Tests .NET 4.0")]
+[assembly: SecurityRules(SecurityRuleSet.Level1)]
 #else
-
 [assembly: AssemblyTitle("Json.NET Tests")]
+[assembly: SecurityRules(SecurityRuleSet.Level1)]
 #endif
+
+[assembly: AllowPartiallyTrustedCallers]
 
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]

--- a/Src/Newtonsoft.Json/Utilities/FSharpUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/FSharpUtils.cs
@@ -88,15 +88,16 @@ namespace Newtonsoft.Json.Utilities
 
                         Type fsharpType = fsharpCoreAssembly.GetType("Microsoft.FSharp.Reflection.FSharpType");
 
-                        MethodInfo isUnionMethodInfo = fsharpType.GetMethod("IsUnion", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+                        MethodInfo isUnionMethodInfo = fsharpType.GetMethod("IsUnion", BindingFlags.Public | BindingFlags.Static);
                         IsUnion = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(isUnionMethodInfo);
 
-                        MethodInfo getUnionCasesMethodInfo = fsharpType.GetMethod("GetUnionCases", BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+                        MethodInfo getUnionCasesMethodInfo = fsharpType.GetMethod("GetUnionCases", BindingFlags.Public | BindingFlags.Static);
                         GetUnionCases = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(getUnionCasesMethodInfo);
 
                         Type fsharpValue = fsharpCoreAssembly.GetType("Microsoft.FSharp.Reflection.FSharpValue");
 
                         PreComputeUnionTagReader = CreateFSharpFuncCall(fsharpValue, "PreComputeUnionTagReader");
+
                         PreComputeUnionReader = CreateFSharpFuncCall(fsharpValue, "PreComputeUnionReader");
                         PreComputeUnionConstructor = CreateFSharpFuncCall(fsharpValue, "PreComputeUnionConstructor");
 
@@ -111,7 +112,6 @@ namespace Newtonsoft.Json.Utilities
                         _ofSeq = listModule.GetMethod("OfSeq");
 
                         _mapType = fsharpCoreAssembly.GetType("Microsoft.FSharp.Collections.FSharpMap`2");
-
 #if !(DOTNET || PORTABLE)
                         Thread.MemoryBarrier();
 #endif
@@ -123,8 +123,9 @@ namespace Newtonsoft.Json.Utilities
 
         private static MethodCall<object, object> CreateFSharpFuncCall(Type type, string methodName)
         {
-            MethodInfo innerMethodInfo = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
-            MethodInfo invokeFunc = innerMethodInfo.ReturnType.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance);
+            MethodInfo innerMethodInfo = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            MethodInfo invokeFunc = innerMethodInfo.ReturnType.GetMethod("Invoke", BindingFlags.Public)
+                ?? innerMethodInfo.ReturnType.GetMethod("Invoke");
 
             MethodCall<object, object> call = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(innerMethodInfo);
             MethodCall<object, object> invoke = JsonTypeReflector.ReflectionDelegateFactory.CreateMethodCall<object>(invokeFunc);


### PR DESCRIPTION
This fixes #821. I had to decorate the tests assembly to allow partial trust callers; the same will also need to be true for any F# assembly that has DUs that need to be serialized.