### PR TITLE
Allow consumers to disable property type resolution.

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // Copyright (c) 2007 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -124,6 +124,12 @@ namespace Newtonsoft.Json.Serialization
         /// </summary>
         /// <value>Whether this type contract is serialized as a reference.</value>
         public bool? IsReference { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this contract's type is resolved via GetType().
+        /// </summary>
+        /// <value>Whether this contract's type is resolved via GetType().</value>
+        public bool ResolveRealType { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default <see cref="JsonConverter" /> for this contract.

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -533,7 +533,7 @@ namespace Newtonsoft.Json.Serialization
                 }
 
                 memberValue = property.ValueProvider.GetValue(value);
-                memberContract = (property.PropertyContract.IsSealed) ? property.PropertyContract : GetContractSafe(memberValue);
+                memberContract = (property.PropertyContract.IsSealed || !property.PropertyContract.ResolveRealType) ? property.PropertyContract : GetContractSafe(memberValue);
 
                 if (ShouldWriteProperty(memberValue, property))
                 {


### PR DESCRIPTION
**Main question**: http://stackoverflow.com/questions/17123821/serialize-only-interface-properties-to-json-with-json-net

That SO question pretty good answers how to specify the serializer not to serialize more than needed and take properties only specified by an interface. **However** that does not propagate to that interface's properties of type [another] interface and/or classes, which descendants inherit them.

I'll show you an example:

    interface Foo
    {
        Foo2 Bar { get; }
    }

    interface Foo2
    {
        int Bar2 { get; }
    }

    sealed class A : Foo
    {
        public Foo2 Bar { get; } = new B();
    }
    sealed class B : Foo2
    {
        public int Extra { get; } = 2;

        int Foo2.Bar2
        {
            get
            {
                return 1;
            }
        }
    }

If I serialize this by using the **non**-selected (but yet good) [answer](http://stackoverflow.com/a/20929276/558018), the result I get is:

```
{
  "Bar": {
    "Extra": 2
  }
}
```

Which is bad in two ways: it didn't serialize `int Foo2.Bar` and it did serialize `public int Extra`. Now, with the update I propose, we let the uses to manually decide with the following piece of code whether they want to serialize in a different way:


    public class InterfaceContractResolver<TInterface> : DefaultContractResolver where TInterface : class
    {
        public override JsonContract ResolveContract(Type type)
        {
            JsonContract result = base.ResolveContract(type);
            result.ResolveRealType = false;
            return result;
        }
        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
        {
            return base.CreateProperties(typeof(TInterface).IsAssignableFrom(type) ? typeof(TInterface) : type, memberSerialization);
        }
    }

Which produces the following:
```
{
  "Bar": {
    "Bar2": 1
  }
}
```