### PR TITLE
JsonTextReader supports parsing large numeric value by using custom handler

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
@@ -409,6 +409,59 @@ third line", jsonTextReader.Value);
             ExceptionAssert.Throws<JsonReaderException>(() => { reader.Read(); }, "Unexpected content while parsing JSON. Path 'u', line 1, position 29.");
         }
 
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+        /// <summary>
+        /// By default large number is parsed to BigInteger but not supporting .Net Framework 3.5.
+        /// </summary>
+        [Test]
+        public void NumberOverflowParsingAsBigInteger()
+        {
+            string json = "{\"StandardPrice\":79228162514264337593543950335}"; // decimal.MaxValue
+            using (JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json)))
+            {
+                jsonTextReader.Read();
+                jsonTextReader.Read();
+                jsonTextReader.Read();
+                Assert.IsTrue(decimal.MaxValue == (decimal)((BigInteger)jsonTextReader.Value));
+                Assert.AreEqual(JsonToken.Integer, jsonTextReader.TokenType);
+            }
+        }
+#endif
+
+        /// <summary>
+        /// By setting a parser handler, large number can be parsed to decimal, supporting all .Net Framework versions.
+        /// </summary>
+        [Test]
+        public void NumberOverflowParsingAsDecimal()
+        {
+            string json = "{\"StandardPrice\":79228162514264337593543950335}"; // decimal.MaxValue
+            using (JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json)))
+            {
+                jsonTextReader.NumberOverflowTryParseHandler = delegate (string valueToParse, out object parsedResult, out JsonToken jsonToken)
+                {
+                    decimal tmp;
+                    if (decimal.TryParse(valueToParse, out tmp))
+                    {
+                        parsedResult = tmp;
+                        jsonToken = JsonToken.Float;
+                        return true;
+                    }
+                    else
+                    {
+                        parsedResult = null;
+                        jsonToken = JsonToken.None;
+                        return false;
+                    }
+                };
+
+                jsonTextReader.Read();
+                jsonTextReader.Read();
+                jsonTextReader.Read(); // should read the big number
+                Assert.AreEqual(decimal.MaxValue, (decimal)jsonTextReader.Value);
+                Assert.AreEqual(JsonToken.Float, jsonTextReader.TokenType);
+            }
+        }
+
         [Test]
         public void FloatParseHandling()
         {

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -41,6 +41,15 @@ using System.Linq;
 namespace Newtonsoft.Json
 {
     /// <summary>
+    /// The delegate of a plugin parser to JsonReader.
+    /// </summary>
+    /// <param name="valueToParse">The string value to parse.</param>
+    /// <param name="parsedResult">The parsed result object.</param>
+    /// <param name="jsonToken">JsonToken type.</param>
+    /// <returns>True if the value is parsed.</returns>
+    public delegate bool TryParseHandler(string valueToParse, out object parsedResult, out JsonToken jsonToken);
+
+    /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to serialized JSON data.
     /// </summary>
     public abstract class JsonReader : IDisposable
@@ -167,6 +176,11 @@ namespace Newtonsoft.Json
             get { return _quoteChar; }
             protected internal set { _quoteChar = value; }
         }
+
+        /// <summary>
+        /// The handler to parse the large numeric string found to be overflow.
+        /// </summary>
+        public TryParseHandler NumberOverflowTryParseHandler { get; set; }
 
         /// <summary>
         /// Get or set how <see cref="DateTime"/> time zones are handling when reading JSON.

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -1963,19 +1963,22 @@ namespace Newtonsoft.Json
                     }
                     else if (parseResult == ParseResult.Overflow)
                     {
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
                         string number = _stringReference.ToString();
-
-                        if (number.Length > MaximumJavascriptIntegerCharacterLength)
+                        if (this.NumberOverflowTryParseHandler == null
+                            || (!this.NumberOverflowTryParseHandler(number, out numberValue, out numberType)))
                         {
-                            throw JsonReaderException.Create(this, "JSON integer {0} is too large to parse.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
-                        }
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+                            if (number.Length > MaximumJavascriptIntegerCharacterLength)
+                            {
+                                throw JsonReaderException.Create(this, "JSON integer {0} is too large to parse.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                            }
 
-                        numberValue = BigIntegerParse(number, CultureInfo.InvariantCulture);
-                        numberType = JsonToken.Integer;
+                            numberValue = BigIntegerParse(number, CultureInfo.InvariantCulture);
+                            numberType = JsonToken.Integer;
 #else
                         throw JsonReaderException.Create(this, "JSON integer {0} is too large or small for an Int64.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
 #endif
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
 Should be able to deserialize big number in .net 3.5 #841.