### PR TITLE
Ensure future updates won't break camel casing of property names with numbers

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
@@ -57,6 +57,7 @@ namespace Newtonsoft.Json.Tests.Utilities
             Assert.AreEqual(" IPhone", StringUtils.ToCamelCase(" IPhone"));
             Assert.AreEqual("isCIA", StringUtils.ToCamelCase("IsCIA"));
             Assert.AreEqual("vmQ", StringUtils.ToCamelCase("VmQ"));
+            Assert.AreEqual("xml2Json", StringUtils.ToCamelCase("Xml2Json"));
         }
     }
 }


### PR DESCRIPTION
When we updated to the latest version of Newtonsoft.Json, some of our API broke. The `CamelCasePropertyNamesContractResolver` changed when `StringUtils.ToCamelCase` implementation changed. As an example, the property name `A2B` was resulting with `a2b`, and now it returns `a2B`. The second is correct IMHO, so we changed our code to match with that new serialized name.

To avoid this breaking again in the future, here's a new test (no new code)