### PR TITLE
JValue.ToString() uses IFormattable if possible to produce InvariantCulture string.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JValueTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JValueTests.cs
@@ -45,6 +45,7 @@ using NUnit.Framework;
 #endif
 using Newtonsoft.Json.Linq;
 using System.Globalization;
+using System.Threading;
 #if NET20
 using Newtonsoft.Json.Utilities.LinqBridge;
 #else
@@ -745,6 +746,26 @@ namespace Newtonsoft.Json.Tests.Linq
   ""http://james.newtonking.com"",
   ""http://james.newtonking.com/install?v=7.0.1""
 ]", a.ToString());
+        }
+
+        [Test]
+        public void ToStringInvariantCulture()
+        {
+            var a = new JValue(5.6m);
+
+            var savedCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-Gb", true)
+            {
+                NumberFormat = new NumberFormatInfo
+                {
+                    NumberDecimalSeparator = ">>>"
+                }
+            };
+
+            string json = a.ToString();
+            Thread.CurrentThread.CurrentCulture = savedCulture;
+
+            StringAssert.AreEqual("5.6", json);
         }
 
 #if !NET20

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -915,7 +915,8 @@ namespace Newtonsoft.Json.Linq
                 return string.Empty;
             }
 
-            return _value.ToString();
+            var formattable = _value as IFormattable;
+            return formattable == null ? _value.ToString() : formattable.ToString(null, CultureInfo.InvariantCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
This is fixes #874.

JValue will try to use IFormattable to produce InvariantCulture string.