### PR TITLE
JsonTextReader auto supports decimal precision (28 significant figure…

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTest.cs
@@ -93,6 +93,36 @@ namespace Newtonsoft.Json.Tests
         }
 
         [Test]
+        public void FloatParseHandling_TestPrecision()
+        {
+            string json = "[9223372036854775807, 1.7976931348623157E+308, 792281625142643375935439503.35]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = Json.FloatParseHandling.Auto;
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.IsTrue(reader.Value is long);
+            Assert.AreEqual(long.MaxValue, reader.Value); // long
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.IsTrue(reader.Value is double);
+            Assert.AreEqual(double.MaxValue, reader.Value); // double
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.IsTrue(reader.Value is decimal);
+            Assert.AreEqual(decimal.MaxValue / 100, reader.Value); // decimal
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
         public void LineInfoAndNewLines()
         {
             string json = "{}";

--- a/Src/Newtonsoft.Json/FloatParseHandling.cs
+++ b/Src/Newtonsoft.Json/FloatParseHandling.cs
@@ -38,6 +38,11 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Floating point numbers are parsed to <see cref="Decimal"/>.
         /// </summary>
-        Decimal = 1
+        Decimal = 1,
+
+        /// <summary>
+        /// Floating point numbers are parsed to <see cref="Decimal"/>, if failed then they are parsed to <see cref="Double"/>.
+        /// </summary>
+        Auto = 2,
     }
 }

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -216,7 +216,7 @@ namespace Newtonsoft.Json
             get { return _floatParseHandling; }
             set
             {
-                if (value < FloatParseHandling.Double || value > FloatParseHandling.Decimal)
+                if (value < FloatParseHandling.Double || value > FloatParseHandling.Auto)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -2014,7 +2014,24 @@ namespace Newtonsoft.Json
                     {
                         string number = _stringReference.ToString();
 
-                        if (_floatParseHandling == FloatParseHandling.Decimal)
+                        if (_floatParseHandling == FloatParseHandling.Auto)
+                        {
+                            decimal d;
+                            double d2;
+                            if (decimal.TryParse(number, NumberStyles.Number | NumberStyles.AllowExponent, NumberFormatInfo.InvariantInfo, out d))
+                            {
+                                numberValue = d;
+                            }
+                            else if (double.TryParse(number, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out d2))
+                            {
+                                numberValue = d2;
+                            }
+                            else
+                            {
+                                throw JsonReaderException.Create(this, "Input string '{0}' is not a valid decimal/double.".FormatWith(CultureInfo.InvariantCulture, number));
+                            }
+                        }
+                        else if (_floatParseHandling == FloatParseHandling.Decimal)
                         {
                             decimal d;
                             if (decimal.TryParse(number, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out d))


### PR DESCRIPTION
JsonTextReader auto supports decimal precision (28 significant figures) &
double range (10e324).
