### PR TITLE
Enables XmlElement object type support in XmlNodeConverter

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
@@ -906,6 +906,23 @@ namespace Newtonsoft.Json.Tests.Converters
             return sw.ToString();
         }
 
+        public class Foo2
+        {
+            public XmlElement Bar { get; set; }
+        }
+
+        [Test]
+        public void SerializeAndDeserializeXmlElement()
+        {
+            Foo2 foo = new Foo2 { Bar = null };
+            string json = JsonConvert.SerializeObject(foo);
+
+            Assert.AreEqual(@"{""Bar"":null}", json);
+            Foo2 foo2 = JsonConvert.DeserializeObject<Foo2>(json);
+
+            Assert.IsNull(foo2.Bar);
+        }
+
         [Test]
         public void SingleTextNode()
         {

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1476,12 +1476,13 @@ namespace Newtonsoft.Json.Converters
                 return element;
             }
 #endif
-
+#if !(DOTNET || PORTABLE)
             if (objectType == typeof(XmlElement))
             {
                 return document.DocumentElement.WrappedNode;
             }
-            
+#endif
+
             return document.WrappedNode;
         }
 

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1433,7 +1433,7 @@ namespace Newtonsoft.Json.Converters
             {
                 if (objectType != typeof(XmlDocument) && objectType != typeof(XmlElement))
                 {
-                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XmlDocuments or XmlElement");
+                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XmlDocument or XmlElement");
                 }
 
                 XmlDocument d = new XmlDocument();

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1431,9 +1431,9 @@ namespace Newtonsoft.Json.Converters
 #if !(DOTNET || PORTABLE)
             if (typeof(XmlNode).IsAssignableFrom(objectType))
             {
-                if (objectType != typeof(XmlDocument))
+                if (objectType != typeof(XmlDocument) && objectType != typeof(XmlElement))
                 {
-                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XmlDocuments");
+                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XmlDocuments or XmlElement");
                 }
 
                 XmlDocument d = new XmlDocument();
@@ -1477,6 +1477,11 @@ namespace Newtonsoft.Json.Converters
             }
 #endif
 
+            if (objectType == typeof(XmlElement))
+            {
+                return document.DocumentElement.WrappedNode;
+            }
+            
             return document.WrappedNode;
         }
 


### PR DESCRIPTION
Hey James, any particular reason why not supporting `XmlElement` **deserialization** in `XmlNodeConverter`? In one of the projects I'm working on we do have a type which has an XmlElement type field. It can be serialized perfectly by Json.NET, however, always fails during de-serialization with the error "XmlNodeConverter only supports deserializing XmlDocuments".

I'm sending this PR in advance to see if you are fine with it. I have tested it in my own project and it works. The build also passes entirely.

Thanks,
-Jack
