### PR TITLE
ulong.MaxValue parsing on .NET core

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -2582,6 +2582,20 @@ keyword such as type of business.""
             Assert.AreEqual(3, wibbleOut.Bar[4]);
         }
 
+        [JsonObject]
+        public class ULongClass
+        {
+            public ulong ULong { get; set; } = ulong.MaxValue;
+        }
+
+        [Test]
+        public void SerializeULongMax()
+        {
+            string json = JsonConvert.SerializeObject(new ULongClass(), Formatting.Indented);
+            ULongClass c = JsonConvert.DeserializeObject<ULongClass>(json);
+            Assert.AreEqual((ulong) ulong.MaxValue, c.ULong);
+        }
+
         [Test]
         public void SerializeConverableObjects()
         {

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -30,7 +30,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.IO;
 using System.Globalization;
-#if !(PORTABLE || PORTABLE40 || NET35 || NET20)
+#if !(PORTABLE || PORTABLE40 || NET35 || NET20) || NETSTANDARD10
 using System.Numerics;
 #endif
 using Newtonsoft.Json.Utilities;
@@ -734,7 +734,7 @@ namespace Newtonsoft.Json
                             case '9':
                                 ParseNumber(ReadType.Read);
                                 bool b;
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD10
                                 if (Value is BigInteger)
                                 {
                                     b = (BigInteger)Value != 0;
@@ -1996,7 +1996,7 @@ namespace Newtonsoft.Json
                     }
                     else if (parseResult == ParseResult.Overflow)
                     {
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD10
                         string number = _stringReference.ToString();
 
                         if (number.Length > MaximumJavascriptIntegerCharacterLength)
@@ -2050,7 +2050,7 @@ namespace Newtonsoft.Json
             SetToken(numberType, numberValue, false);
         }
 
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD10
         // By using the BigInteger type in a separate method,
         // the runtime can execute the ParseNumber even if 
         // the System.Numerics.BigInteger.Parse method is

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -33,7 +33,7 @@ using System.Dynamic;
 #endif
 using System.Diagnostics;
 using System.Globalization;
-#if !(PORTABLE || PORTABLE40 || NET35 || NET20)
+#if !(PORTABLE || PORTABLE40 || NET35 || NET20) || NETSTANDARD10
 using System.Numerics;
 #endif
 using System.Reflection;
@@ -968,7 +968,7 @@ namespace Newtonsoft.Json.Serialization
                             }
                         }
 
-#if !(PORTABLE || PORTABLE40 || NET35 || NET20)
+#if !(PORTABLE || PORTABLE40 || NET35 || NET20) || NETSTANDARD10
                         if (value is BigInteger)
                         {
                             return ConvertUtils.FromBigInteger((BigInteger)value, contract.NonNullableUnderlyingType);

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -27,7 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.ComponentModel;
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD10
 using System.Numerics;
 #endif
 using System.Text;
@@ -145,7 +145,7 @@ namespace Newtonsoft.Json.Utilities
                 { typeof(Guid?), PrimitiveTypeCode.GuidNullable },
                 { typeof(TimeSpan), PrimitiveTypeCode.TimeSpan },
                 { typeof(TimeSpan?), PrimitiveTypeCode.TimeSpanNullable },
-#if !(PORTABLE || PORTABLE40 || NET35 || NET20)
+#if !(PORTABLE || PORTABLE40 || NET35 || NET20) || NETSTANDARD10
                 { typeof(BigInteger), PrimitiveTypeCode.BigInteger },
                 { typeof(BigInteger?), PrimitiveTypeCode.BigIntegerNullable },
 #endif
@@ -311,7 +311,7 @@ namespace Newtonsoft.Json.Utilities
             return o => call(null, o);
         }
 
-#if !(NET20 || NET35 || PORTABLE || PORTABLE40)
+#if !(NET20 || NET35 || PORTABLE || PORTABLE40) || NETSTANDARD10
         internal static BigInteger ToBigInteger(object value)
         {
             if (value is BigInteger)
@@ -540,7 +540,7 @@ namespace Newtonsoft.Json.Utilities
                 }
             }
 
-#if !(NET20 || NET35 || PORTABLE40 || PORTABLE)
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD10
             if (targetType == typeof(BigInteger))
             {
                 value = ToBigInteger(initialValue);

--- a/Src/Newtonsoft.Json/project.json
+++ b/Src/Newtonsoft.Json/project.json
@@ -89,7 +89,7 @@
         "System.Xml": ""
       }
     },
-    "netstandard1.0": {
+    "netstandard1.1": {
       "compilationOptions": {
         "define": [ "NETSTANDARD10", "PORTABLE" ]
       },
@@ -108,6 +108,7 @@
         "System.Resources.ResourceManager": "4.0.1-rc2-24015",
         "System.Runtime": "4.1.0-rc2-24015",
         "System.Runtime.Extensions": "4.1.0-rc2-24015",
+        "System.Runtime.Numerics": "4.0.1-rc2-24015",
         "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24015",
         "System.Text.Encoding": "4.0.11-rc2-24015",
         "System.Text.Encoding.Extensions": "4.0.11-rc2-24015",


### PR DESCRIPTION
Hi, great that you're working on .NET core support!

I noticed the same issue as in https://github.com/JamesNK/Newtonsoft.Json/issues/838, that ulong parsing is broken for values greater than what fits into a signed long.

I've added a test that demonstrates the problem and hacked together something that enables BigInteger parsing on netstandard11 and up.

How do you think would this be solved best? I fear this will trigger subtle bugs when porting from framework to core if not resolved.