### PR TITLE
fix a bug of DataTableConverter

### DIFF
--- a/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
@@ -187,7 +187,7 @@ namespace Newtonsoft.Json.Converters
                 }
                 else
                 {
-                    dr[columnName] = (reader.Value != null) ? serializer.Deserialize(reader, column.DataType) : DBNull.Value;
+                    dr[columnName] = (reader.Value != null) ? (serializer.Deserialize(reader, column.DataType) ?? DBNull.Value) : DBNull.Value;
                 }
 
                 reader.ReadAndAssert();


### PR DESCRIPTION
if serializer handled Error event serializer.Deserialize(reader, column.DataType) will return null.but we need DBNull.Value