### PR TITLE
Modified PopulateDictionary method so that objects within that dictio…

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1381,14 +1381,17 @@ namespace Newtonsoft.Json.Serialization
                                 throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
                             }
 
+                            // This is an IDictionary, so it doesn't have TryGetValue. If the key is not found, null is returned.                            
+                            object existingValue = dictionary[keyValue];
+
                             object itemValue;
                             if (dictionaryValueConverter != null && dictionaryValueConverter.CanRead)
                             {
-                                itemValue = DeserializeConvertable(dictionaryValueConverter, reader, contract.DictionaryValueType, null);
+                                itemValue = DeserializeConvertable(dictionaryValueConverter, reader, contract.DictionaryValueType, existingValue);
                             }
                             else
                             {
-                                itemValue = CreateValueInternal(reader, contract.DictionaryValueType, contract.ItemContract, null, contract, containerProperty, null);
+                                itemValue = CreateValueInternal(reader, contract.DictionaryValueType, contract.ItemContract, null, contract, containerProperty, existingValue);
                             }
 
                             dictionary[keyValue] = itemValue;


### PR DESCRIPTION
When deserializing JSON into an existing object, this works well until you get to a dictionary. At that point, any object values in the dictionary are replaced with new values, rather than being populated in place.

This code changes the behavior to leave the existing object there and populate its children from the JSON stream.