### PR TITLE
Fix build when path has whitespace

### DIFF
--- a/Build/runbuild.cmd
+++ b/Build/runbuild.cmd
@@ -1,5 +1,5 @@
 cls
-powershell -Command "& { [Console]::WindowWidth = 150; [Console]::WindowHeight = 50; Start-Transcript %~dp0runbuild.txt; Import-Module %~dp0..\Tools\PSake\psake.psm1; Invoke-psake %~dp0..\Build\build.ps1 %*; Stop-Transcript; exit !($psake.build_success); }"
+powershell -Command "& { [Console]::WindowWidth = 150; [Console]::WindowHeight = 50; Start-Transcript '%~dp0runbuild.txt'; Import-Module '%~dp0..\Tools\PSake\psake.psm1'; Invoke-psake '%~dp0..\Build\build.ps1' %*; Stop-Transcript; exit !($psake.build_success); }"
 
 ECHO %ERRORLEVEL%
 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
This escapes the paths used in the build script so the project can be built under a path that has whitespace, e.g. `C:\src\repos\foo projects\Newtonsoft.Json`.