### PR TITLE
Added an extension point to bson reader to allow optimization

### DIFF
--- a/Src/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonReader.cs
@@ -604,7 +604,7 @@ namespace Newtonsoft.Json.Bson
                     int length = Encoding.UTF8.GetChars(_byteBuffer, 0, byteCount, _charBuffer, 0);
 
                     MovePosition(totalBytesRead + 1);
-                    return new string(_charBuffer, 0, length);
+                    return GetString(_charBuffer, length);
                 }
                 else
                 {
@@ -692,7 +692,7 @@ namespace Newtonsoft.Json.Bson
                     // pref optimization to avoid reading into a string builder
                     // first iteration and all bytes read then return string directly
                     int charCount = Encoding.UTF8.GetChars(_byteBuffer, 0, byteCount, _charBuffer, 0);
-                    return new string(_charBuffer, 0, charCount);
+                    return GetString(_charBuffer, charCount);
                 }
                 else
                 {
@@ -720,6 +720,14 @@ namespace Newtonsoft.Json.Bson
             } while (totalBytesRead < length);
 
             return builder.ToString();
+        }
+
+        /// <summary>
+        /// An extension point that allows optimization of string instantiation. For instance, take it from a cache.
+        /// </summary>
+        protected virtual string GetString(char[] buffer, int charCount)
+        {
+            return new string(buffer, 0, charCount);
         }
 
         private int GetLastFullCharStop(int start)


### PR DESCRIPTION
I've been writing a stock exchange trading application. It uses bson-based messages for communications. I see huge string traffic, but most of the string are very short (4-20 chars) and already interned. The PR gives me opportunity to inherit from the original bson writer, and use my own cache to deserialize strings.  
