### PR TITLE
Fix DeserializeXNode in .net core

### DIFF
--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1674,7 +1674,7 @@ namespace Newtonsoft.Json.Converters
 #if !PORTABLE
                 return XmlConvert.ToString(d, DateTimeUtils.ToSerializationMode(d.Kind));
 #else
-                return XmlConvert.ToString(d);
+                return XmlConvert.ToString(d, DateTimeUtils.ToDateTimeFormat(d.Kind));
 #endif
             }
             else if (reader.TokenType == JsonToken.Null)

--- a/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
@@ -73,6 +73,21 @@ namespace Newtonsoft.Json.Utilities
                     throw MiscellaneousUtils.CreateArgumentOutOfRangeException("kind", kind, "Unexpected DateTimeKind value.");
             }
         }
+#else
+        public static string ToDateTimeFormat(DateTimeKind kind)
+        {
+            switch (kind)
+            {
+                case DateTimeKind.Local:
+                    return "yyyy-MM-ddTHH:mm:sszzzzzzz";
+                case DateTimeKind.Unspecified:
+                    return "s";
+                case DateTimeKind.Utc:
+                    return "yyyy-MM-ddTHH:mm:ssZ";
+                default:
+                    throw new Exception("Unexpected DateTimeKind value.");
+            }
+        }
 #endif
 
         internal static DateTime EnsureDateTime(DateTime value, DateTimeZoneHandling timeZone)


### PR DESCRIPTION
Fix for issue [997](https://github.com/JamesNK/Newtonsoft.Json/issues/997)

Now in portable version (including the .net core) format for the DataTime in xml will be the same as the normal version of the library.