### PR TITLE
Added possibility to ignore whitespaces during deserialization of enum values

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
@@ -413,6 +413,52 @@ namespace Newtonsoft.Json.Tests.Converters
         }
 
         [Test]
+        public void DeserializeIgnoringWhitespaceEnum() 
+        {
+            string json = @"{
+  ""Enum"": ""dark goldenrod""
+}";
+
+            EnumContainer<StoreColor> container = JsonConvert.DeserializeObject<EnumContainer<StoreColor>>(json, new StringEnumConverter { IgnoreWhitespace = true });
+            Assert.AreEqual(StoreColor.DarkGoldenrod, container.Enum);
+        }
+
+        [Test]
+        public void DeserializeIgnoringWhitespaceFlagEnum() 
+        {
+             string json = @"{
+  ""Enum"": ""red,dark goldenrod, white""
+}";
+            EnumContainer<StoreColor> container = JsonConvert.DeserializeObject<EnumContainer<StoreColor>>(json, new StringEnumConverter { IgnoreWhitespace = true });
+            Assert.AreEqual(StoreColor.Red | StoreColor.DarkGoldenrod | StoreColor.White, container.Enum);
+        }
+
+        [Test]
+        public void DeserializeNonIgnoringWhitespaceEnum() 
+        {
+            string json = @"{
+  ""Enum"": ""dark goldenrod""
+}";
+            ExceptionAssert.Throws<JsonSerializationException>(() => {
+                EnumContainer<StoreColor> container = JsonConvert.DeserializeObject<EnumContainer<StoreColor>>(json, new StringEnumConverter { IgnoreWhitespace = false });
+            });
+        }
+
+        [Test]
+        public void DeserializeNonIngoringWhitespaceFlagEnum() 
+        {
+            string json = @"{
+  ""Enum"": ""red,dark goldenrod, white""
+}";
+            ExceptionAssert.Throws<JsonSerializationException>(() => {
+                EnumContainer<StoreColor> container = JsonConvert.DeserializeObject<EnumContainer<StoreColor>>(json, new StringEnumConverter { IgnoreWhitespace = false });
+                Assert.AreEqual(StoreColor.Red | StoreColor.DarkGoldenrod | StoreColor.White, container.Enum);
+            });
+        }
+
+
+
+        [Test]
         public void DeserializeInvalidString()
         {
             string json = "{ \"Value\" : \"Three\" }";

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -58,6 +58,12 @@ namespace Newtonsoft.Json.Converters
         public bool AllowIntegerValues { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether whitespaces should be ignored when deserializing
+        /// </summary>
+        /// <value><c>true</c> if whitespaces are ignored; otherwise, <c>false</c></value>
+        public bool IgnoreWhitespace { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="StringEnumConverter"/> class.
         /// </summary>
         public StringEnumConverter()
@@ -137,7 +143,7 @@ namespace Newtonsoft.Json.Converters
                 {
                     string enumText = reader.Value.ToString();
 
-                    return EnumUtils.ParseEnumName(enumText, isNullable, !AllowIntegerValues, t);
+                    return EnumUtils.ParseEnumName(enumText, isNullable, !AllowIntegerValues, IgnoreWhitespace, t);
                 }
 
                 if (reader.TokenType == JsonToken.Integer)

--- a/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
@@ -190,7 +190,7 @@ namespace Newtonsoft.Json.Utilities
             return values;
         }
 
-        public static object ParseEnumName(string enumText, bool isNullable, bool disallowValue, Type t)
+        public static object ParseEnumName(string enumText, bool isNullable, bool disallowValue, bool ignoreWhitespace, Type t)
         {
             if (enumText == string.Empty && isNullable)
             {
@@ -211,6 +211,11 @@ namespace Newtonsoft.Json.Utilities
                 for (int i = 0; i < names.Length; i++)
                 {
                     string name = names[i].Trim();
+
+                    if (ignoreWhitespace) 
+                    {
+                        name = name.Replace(" ", string.Empty);
+                    }
 
                     names[i] = TryResolvedEnumName(map, name, out resolvedEnumName)
                         ? resolvedEnumName
@@ -239,6 +244,10 @@ namespace Newtonsoft.Json.Utilities
                     {
                         throw new FormatException("Integer string '{0}' is not allowed.".FormatWith(CultureInfo.InvariantCulture, enumText));
                     }
+                }
+                if (ignoreWhitespace) 
+                {
+                    finalEnumText = finalEnumText.Replace(" ", string.Empty);
                 }
             }
 


### PR DESCRIPTION
For example now optionally we can deserialize such enums.  
```
{
  "Enum": "red,dark goldenrod, white"
}
```

We can often see such enums when deserializing objects from external (non .net projects). And every time we should think how to write custom converter that has all features of base one. 