### PR TITLE
Add a test for deserializing an IEnumerable with implicit conversion

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -224,6 +224,34 @@ namespace Newtonsoft.Json.Tests.Serialization
 }", strJsonMainClass);
         }
 
+        [Test]
+        public void DeserializeGenericIEnumerableWithImplicitConversion()
+        {
+            string deserialized = @"{
+  ""Enumerable"": [ ""abc"", ""def"" ] 
+}";
+            var enumerableClass = JsonConvert.DeserializeObject<GenericIEnumerableWithImplicitConversion>(deserialized);
+            var enumerableObject = enumerableClass.Enumerable.ToArray();
+            Assert.AreEqual(2, enumerableObject.Length);
+            Assert.AreEqual("abc", enumerableObject[0].Value);
+            Assert.AreEqual("def", enumerableObject[1].Value);
+        }
+
+        public class GenericIEnumerableWithImplicitConversion
+        {
+            public IEnumerable<ClassWithImplicitOperator> Enumerable { get; set; }
+        }
+
+        public class ClassWithImplicitOperator
+        {
+            public string Value { get; set; }
+
+            public static implicit operator ClassWithImplicitOperator(string value)
+            {
+                return new ClassWithImplicitOperator() { Value = value };
+            }
+        }
+
 #if !(PORTABLE || PORTABLE40 || NET20 || NET35)
         [Test]
         public void LargeIntegerAsString()


### PR DESCRIPTION
The feature didn't seem to work on my PC, so I was going to implement the feature.

Turns out that implicit conversions are supported, and I had a typo in the product code.

Still, I'll send in some tests as I couldn;t find any else in the repo and so that I didn't entirely waste my time!