### PR TITLE
Handle IEEE754 overflows as ±Infinity instead of raising errors

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ParseTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ParseTests.cs
@@ -220,10 +220,14 @@ namespace Newtonsoft.Json.Tests.JsonTextReaderTests
             Assert.AreEqual(Double.MinValue, reader.Value);
 
             reader = new JsonTextReader(new StringReader("1E+309"));
-            ExceptionAssert.Throws<JsonReaderException>(() => reader.Read(), "Input string '1E+309' is not a valid number. Path '', line 1, position 6.");
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(Double.PositiveInfinity, reader.Value);
 
             reader = new JsonTextReader(new StringReader("-1E+5000"));
-            ExceptionAssert.Throws<JsonReaderException>(() => reader.Read(), "Input string '-1E+5000' is not a valid number. Path '', line 1, position 8.");
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(Double.NegativeInfinity, reader.Value);
 
             reader = new JsonTextReader(new StringReader("5.1231231E"));
             ExceptionAssert.Throws<JsonReaderException>(() => reader.Read(), "Input string '5.1231231E' is not a valid number. Path '', line 1, position 10.");

--- a/Src/Newtonsoft.Json.Tests/Utilities/ConvertUtilsTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/ConvertUtilsTests.cs
@@ -39,7 +39,7 @@ namespace Newtonsoft.Json.Tests.Utilities
     [TestFixture]
     public class ConvertUtilsTests : TestFixtureBase
     {
-        private void AssertDoubleTryParse(string s, ParseResult expectedResult, double? expectedValue)
+        private void AssertDoubleTryParse(string s, ParseResult expectedResult, double? expectedValue, bool expectOverflow = false)
         {
             double d;
             char[] c = s.ToCharArray();
@@ -54,7 +54,10 @@ namespace Newtonsoft.Json.Tests.Utilities
                 && s.IndexOf(".e", StringComparison.OrdinalIgnoreCase) == -1;
 
             Assert.AreEqual(expectedResult, result);
-            Assert.AreEqual(expectedResult == ParseResult.Success, result2);
+            if (!expectOverflow)
+            {
+                Assert.AreEqual(expectedResult == ParseResult.Success, result2);
+            }
 
             if (result2)
             {
@@ -103,8 +106,8 @@ namespace Newtonsoft.Json.Tests.Utilities
             AssertDoubleTryParse("1E-100", ParseResult.Success, 1E-100);
             AssertDoubleTryParse("1E-300", ParseResult.Success, 1E-300);
 
-            AssertDoubleTryParse("1E+309", ParseResult.Overflow, null);
-            AssertDoubleTryParse("-1E+5000", ParseResult.Overflow, null);
+            AssertDoubleTryParse("1E+309", ParseResult.Success, Double.PositiveInfinity, expectOverflow: true);
+            AssertDoubleTryParse("-1E+5000", ParseResult.Success, Double.NegativeInfinity, expectOverflow: true);
 
             AssertDoubleTryParse("01E308", ParseResult.Invalid, null);
             AssertDoubleTryParse("-01E308", ParseResult.Invalid, null);
@@ -132,10 +135,10 @@ namespace Newtonsoft.Json.Tests.Utilities
             AssertDoubleTryParse("1.7976931348623157E+308", ParseResult.Success, double.MaxValue);
             AssertDoubleTryParse("-1.7976931348623157E+308", ParseResult.Success, double.MinValue);
 
-            AssertDoubleTryParse("1.7976931348623159E+308", ParseResult.Overflow, null);
-            AssertDoubleTryParse("-1.7976931348623159E+308", ParseResult.Overflow, null);
+            AssertDoubleTryParse("1.7976931348623159E+308", ParseResult.Success, Double.PositiveInfinity, expectOverflow: true);
+            AssertDoubleTryParse("-1.7976931348623159E+308", ParseResult.Success, Double.NegativeInfinity, expectOverflow: true);
 
-            AssertDoubleTryParse("1E4294967297", ParseResult.Overflow, null);
+            AssertDoubleTryParse("1E4294967297", ParseResult.Success, Double.PositiveInfinity, expectOverflow: true);
             AssertDoubleTryParse("1E4294967297B", ParseResult.Invalid, null);
             AssertDoubleTryParse("1E-4294967297", ParseResult.Success, 0);
         }
@@ -155,7 +158,7 @@ namespace Newtonsoft.Json.Tests.Utilities
             AssertDoubleTryParse("4.94065645841247E-465", ParseResult.Success, 0);
             AssertDoubleTryParse("4.94065645841247E-555", ParseResult.Success, 0);
 
-            AssertDoubleTryParse("4.94065645841247E+555", ParseResult.Overflow, null);
+            AssertDoubleTryParse("4.94065645841247E+555", ParseResult.Success, Double.PositiveInfinity, expectOverflow: true);
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -1354,7 +1354,7 @@ namespace Newtonsoft.Json.Utilities
             exponent -= (numDecimalEnd - numDecimalStart);
 
             value = IEEE754.PackDouble(isNegative, mantissa, exponent);
-            return double.IsInfinity(value) ? ParseResult.Overflow : ParseResult.Success;
+            return ParseResult.Success;
         }
 
         public static bool TryConvertGuid(string s, out Guid g)


### PR DESCRIPTION
Highlighted by @nst in [Parsing JSON is a Minefield 💣](http://seriot.ch/parsing_json.html#22):
> According to RFC 7159, "A JSON parser MUST accept all texts that conform to the JSON grammar" (section 9). However, according to the same paragraph, "An implementation may set limits on the range and precision of numbers."

Most parsers just handle overflows as ±Infinity.