### PR TITLE
Fix return type for SByte and SByteNullable in ToObject

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -1970,9 +1970,9 @@ namespace Newtonsoft.Json.Linq
                     case PrimitiveTypeCode.Char:
                         return (char)this;
                     case PrimitiveTypeCode.SByte:
-                        return (sbyte?)this;
-                    case PrimitiveTypeCode.SByteNullable:
                         return (sbyte)this;
+                    case PrimitiveTypeCode.SByteNullable:
+                        return (sbyte?)this;
                     case PrimitiveTypeCode.ByteNullable:
                         return (byte?)this;
                     case PrimitiveTypeCode.Byte:


### PR DESCRIPTION
Looking at the code, I noticed that SByte cast to (sbyte?) and SByteNullable cast to (sbyte). This seems backwards and in conflict with all the other cases.