### PR TITLE
Fix null reference error when deserializing bytes

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingTests.cs
@@ -385,6 +385,14 @@ namespace Newtonsoft.Json.Tests.JsonTextReaderTests
         }
 
         [Test]
+        public void ReadBytesEmptyWrappedObject()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{}"));
+
+            ExceptionAssert.Throws<JsonReaderException>(() => { reader.ReadAsBytes(); }, "Error reading bytes. Unexpected token: StartObject. Path '', line 1, position 2." );
+        }
+
+        [Test]
         public void ReadIntegerWithError()
         {
             string json = @"{

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -904,7 +904,7 @@ namespace Newtonsoft.Json
         internal void ReadIntoWrappedTypeObject()
         {
             ReaderReadAndAssert();
-            if (Value.ToString() == JsonTypeReflector.TypePropertyName)
+            if (Value != null && Value.ToString() == JsonTypeReflector.TypePropertyName)
             {
                 ReaderReadAndAssert();
                 if (Value != null && Value.ToString().StartsWith("System.Byte[]", StringComparison.Ordinal))


### PR DESCRIPTION
If the JSON contained empty object "{}" for a byte[] property, the `JsonReader` ended up trying to read the object content despite the fact that the content didn't exist. This caused a null reference exception.

The fix ensures the value exists before trying to read it. If the value doesn't exist, the execution ends up in "Unexpected token" exception with way more informative error message.

-------

There was a test that could have caught this. Unfortunately passing just `{` to the `JsonTextReader` causes the text reader to fail early while it's parsing the object and the execution never attempts to read the `$type` property.