### PR TITLE
Cache results when splitting fully qualified type names

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -85,6 +85,8 @@ namespace Newtonsoft.Json.Utilities
     {
         public static readonly Type[] EmptyTypes;
 
+        private static readonly ThreadSafeStore<string, TypeNameKey> FullyQualifiedTypeNameKeyCache = new ThreadSafeStore<string, TypeNameKey>(CreateFullyQualifiedTypeNameKey);
+
         static ReflectionUtils()
         {
 #if !(PORTABLE40 || PORTABLE)
@@ -865,6 +867,11 @@ namespace Newtonsoft.Json.Utilities
 #endif
 
         public static TypeNameKey SplitFullyQualifiedTypeName(string fullyQualifiedTypeName)
+        {
+            return FullyQualifiedTypeNameKeyCache.Get(fullyQualifiedTypeName);
+        }
+
+        private static TypeNameKey CreateFullyQualifiedTypeNameKey(string fullyQualifiedTypeName)
         {
             int? assemblyDelimiterIndex = GetAssemblyDelimiterIndex(fullyQualifiedTypeName);
 

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -85,7 +85,7 @@ namespace Newtonsoft.Json.Utilities
     {
         public static readonly Type[] EmptyTypes;
 
-        private static readonly ThreadSafeStore<string, TypeNameKey> FullyQualifiedTypeNameKeyCache = new ThreadSafeStore<string, TypeNameKey>(CreateFullyQualifiedTypeNameKey);
+        private static readonly ThreadSafeStore<string, TypeNameKey> FullyQualifiedTypeNameKeyCache = new ThreadSafeStore<string, TypeNameKey>(CreateFullyQualifiedTypeNameKey, 10000);
 
         static ReflectionUtils()
         {

--- a/Src/Newtonsoft.Json/Utilities/ThreadSafeStore.cs
+++ b/Src/Newtonsoft.Json/Utilities/ThreadSafeStore.cs
@@ -38,6 +38,7 @@ namespace Newtonsoft.Json.Utilities
         private readonly object _lock = new object();
         private Dictionary<TKey, TValue> _store;
         private readonly Func<TKey, TValue> _creator;
+        private int? _maxSize;
 
         public ThreadSafeStore(Func<TKey, TValue> creator)
         {
@@ -48,6 +49,11 @@ namespace Newtonsoft.Json.Utilities
 
             _creator = creator;
             _store = new Dictionary<TKey, TValue>();
+        }
+
+        public ThreadSafeStore(Func<TKey, TValue> creator, int maxSize) : this(creator)
+        {
+            _maxSize = maxSize;
         }
 
         public TValue Get(TKey key)
@@ -64,6 +70,11 @@ namespace Newtonsoft.Json.Utilities
         private TValue AddValue(TKey key)
         {
             TValue value = _creator(key);
+
+            if (_maxSize.HasValue && _store.Count >= _maxSize.Value)
+            {
+                return value;
+            }
 
             lock (_lock)
             {


### PR DESCRIPTION
Solves #1079.

In high performance scenarios when deserializing json objects that use $type the `SplitFullyQualifiedTypeName` method allocates a huge amount of strings to be GCed, although the types themselves are almost always the same.

This change caches the results instead of generating them again and again for each deserialization. 