### PR TITLE
Improve JsonConvert.ToString(object) error message

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -534,7 +534,7 @@ namespace Newtonsoft.Json.Tests
         [Test]
         public void ToStringInvalid()
         {
-            ExceptionAssert.Throws<ArgumentException>(() => { JsonConvert.ToString(new Version(1, 0)); }, "Unsupported type: System.Version. Use the JsonSerializer class to get the object's JSON representation.");
+            ExceptionAssert.Throws<ArgumentException>(() => { JsonConvert.ToString(new Version(1, 0)); }, "Unsupported type: System.Version. Use the JsonSerializer class or the JsonConvert.SerializeObject method to get the object's JSON representation.");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -516,7 +516,7 @@ namespace Newtonsoft.Json
 #endif
             }
 
-            throw new ArgumentException("Unsupported type: {0}. Use the JsonSerializer class to get the object's JSON representation.".FormatWith(CultureInfo.InvariantCulture, value.GetType()));
+            throw new ArgumentException("Unsupported type: {0}. Use the JsonSerializer class or the JsonConvert.SerializeObject method to get the object's JSON representation.".FormatWith(CultureInfo.InvariantCulture, value.GetType()));
         }
 
         #region Serialize


### PR DESCRIPTION
We had this error on one of our projects, turns out `JsonConvert.ToString()` was used instead of `JsonConvert.SerializeObject` 