### PR TITLE
Clean up XML documentation comments (continued)

### DIFF
--- a/Src/Newtonsoft.Json/FloatFormatHandling.cs
+++ b/Src/Newtonsoft.Json/FloatFormatHandling.cs
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json
         Symbol = 1,
 
         /// <summary>
-        /// Write special floating point values as the property's default value in JSON, e.g. 0.0 for a <see cref="System.Double"/> property, null for a <see cref="System.Nullable{Double}"/> property.
+        /// Write special floating point values as the property's default value in JSON, e.g. 0.0 for a <see cref="System.Double"/> property, <c>null</c> for a <see cref="System.Nullable{Double}"/> property.
         /// </summary>
         DefaultValue = 2
     }

--- a/Src/Newtonsoft.Json/JsonContainerAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonContainerAttribute.cs
@@ -60,8 +60,8 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// The parameter list to use when constructing the <see cref="JsonConverter"/> described by <see cref="ItemConverterType"/>.
-        /// If null, the default constructor is used.
-        /// When non-null, there must be a constructor defined in the <see cref="JsonConverter"/> that exactly matches the number,
+        /// If <c>null</c>, the default constructor is used.
+        /// When non-<c>null</c>, there must be a constructor defined in the <see cref="JsonConverter"/> that exactly matches the number,
         /// order, and type of these parameters.
         /// </summary>
         /// <example>
@@ -87,8 +87,8 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// The parameter list to use when constructing the <see cref="NamingStrategy"/> described by <see cref="NamingStrategyType"/>.
-        /// If null, the default constructor is used.
-        /// When non-null, there must be a constructor defined in the <see cref="NamingStrategy"/> that exactly matches the number,
+        /// If <c>null</c>, the default constructor is used.
+        /// When non-<c>null</c>, there must be a constructor defined in the <see cref="NamingStrategy"/> that exactly matches the number,
         /// order, and type of these parameters.
         /// </summary>
         /// <example>

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -579,7 +579,7 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="value">The object to serialize.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.
-        /// If this is null, default serialization settings will be used.</param>
+        /// If this is <c>null</c>, default serialization settings will be used.</param>
         /// <returns>
         /// A JSON string representation of the object.
         /// </returns>
@@ -593,7 +593,7 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="value">The object to serialize.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.
-        /// If this is null, default serialization settings will be used.</param>
+        /// If this is <c>null</c>, default serialization settings will be used.</param>
         /// <param name="type">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="TypeNameHandling"/> is Auto to write out the type name if the type of the value does not match.
@@ -615,7 +615,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The object to serialize.</param>
         /// <param name="formatting">Indicates how the output should be formatted.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.
-        /// If this is null, default serialization settings will be used.</param>
+        /// If this is <c>null</c>, default serialization settings will be used.</param>
         /// <returns>
         /// A JSON string representation of the object.
         /// </returns>
@@ -630,7 +630,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The object to serialize.</param>
         /// <param name="formatting">Indicates how the output should be formatted.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.
-        /// If this is null, default serialization settings will be used.</param>
+        /// If this is <c>null</c>, default serialization settings will be used.</param>
         /// <param name="type">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="TypeNameHandling"/> is Auto to write out the type name if the type of the value does not match.
@@ -698,7 +698,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The object to serialize.</param>
         /// <param name="formatting">Indicates how the output should be formatted.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.
-        /// If this is null, default serialization settings will be used.</param>
+        /// If this is <c>null</c>, default serialization settings will be used.</param>
         /// <returns>
         /// A task that represents the asynchronous serialization operation. The value of the <c>TResult</c> parameter contains a JSON string representation of the object.
         /// </returns>
@@ -727,7 +727,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The JSON to deserialize.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized object from the JSON string.</returns>
         public static object DeserializeObject(string value, JsonSerializerSettings settings)
@@ -785,7 +785,7 @@ namespace Newtonsoft.Json
         /// <param name="anonymousTypeObject">The anonymous type object.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized anonymous type from the JSON string.</returns>
         public static T DeserializeAnonymousType<T>(string value, T anonymousTypeObject, JsonSerializerSettings settings)
@@ -812,7 +812,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The object to deserialize.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized object from the JSON string.</returns>
         public static T DeserializeObject<T>(string value, JsonSerializerSettings settings)
@@ -843,7 +843,7 @@ namespace Newtonsoft.Json
         /// <param name="type">The type of the object to deserialize to.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>The deserialized object from the JSON string.</returns>
         public static object DeserializeObject(string value, Type type, JsonSerializerSettings settings)
@@ -888,7 +888,7 @@ namespace Newtonsoft.Json
         /// <param name="value">The JSON to deserialize.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>
         /// A task that represents the asynchronous deserialization operation. The value of the <c>TResult</c> parameter contains the deserialized object from the JSON string.
@@ -921,7 +921,7 @@ namespace Newtonsoft.Json
         /// <param name="type">The type of the object to deserialize to.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>
         /// A task that represents the asynchronous deserialization operation. The value of the <c>TResult</c> parameter contains the deserialized object from the JSON string.
@@ -952,7 +952,7 @@ namespace Newtonsoft.Json
         /// <param name="target">The target object to populate values onto.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         public static void PopulateObject(string value, object target, JsonSerializerSettings settings)
         {
@@ -977,7 +977,7 @@ namespace Newtonsoft.Json
         /// <param name="target">The target object to populate values onto.</param>
         /// <param name="settings">
         /// The <see cref="JsonSerializerSettings"/> used to deserialize the object.
-        /// If this is null, default serialization settings will be used.
+        /// If this is <c>null</c>, default serialization settings will be used.
         /// </param>
         /// <returns>
         /// A task that represents the asynchronous population operation.

--- a/Src/Newtonsoft.Json/JsonConverterAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonConverterAttribute.cs
@@ -48,7 +48,7 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// The parameter list to use when constructing the <see cref="JsonConverter"/> described by <see cref="ConverterType"/>.
-        /// If null, the default constructor is used.
+        /// If <c>null</c>, the default constructor is used.
         /// </summary>
         public object[] ConverterParameters { get; private set; }
 
@@ -70,7 +70,7 @@ namespace Newtonsoft.Json
         /// Initializes a new instance of the <see cref="JsonConverterAttribute"/> class.
         /// </summary>
         /// <param name="converterType">Type of the <see cref="JsonConverter"/>.</param>
-        /// <param name="converterParameters">Parameter list to use when constructing the <see cref="JsonConverter"/>. Can be null.</param>
+        /// <param name="converterParameters">Parameter list to use when constructing the <see cref="JsonConverter"/>. Can be <c>null</c>.</param>
         public JsonConverterAttribute(Type converterType, params object[] converterParameters)
             : this(converterType)
         {

--- a/Src/Newtonsoft.Json/JsonException.cs
+++ b/Src/Newtonsoft.Json/JsonException.cs
@@ -62,7 +62,7 @@ namespace Newtonsoft.Json
         /// with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
         public JsonException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -74,8 +74,8 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <c>null</c> or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
         public JsonException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -56,8 +56,8 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// The parameter list to use when constructing the <see cref="JsonConverter"/> described by <see cref="ItemConverterType"/>.
-        /// If null, the default constructor is used.
-        /// When non-null, there must be a constructor defined in the <see cref="JsonConverter"/> that exactly matches the number,
+        /// If <c>null</c>, the default constructor is used.
+        /// When non-<c>null</c>, there must be a constructor defined in the <see cref="JsonConverter"/> that exactly matches the number,
         /// order, and type of these parameters.
         /// </summary>
         /// <example>
@@ -75,8 +75,8 @@ namespace Newtonsoft.Json
 
         /// <summary>
         /// The parameter list to use when constructing the <see cref="NamingStrategy"/> described by NamingStrategyType.  
-        /// If null, the default constructor is used.
-        /// When non-null, there must be a constructor defined in the <see cref="NamingStrategy"/> that exactly matches the number,
+        /// If <c>null</c>, the default constructor is used.
+        /// When non-<c>null</c>, there must be a constructor defined in the <see cref="NamingStrategy"/> that exactly matches the number,
         /// order, and type of these parameters.
         /// </summary>
         /// <example>

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -509,7 +509,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Reads the next JSON token from the stream as a <see cref="Byte"/>[].
         /// </summary>
-        /// <returns>A <see cref="Byte"/>[] or a null reference if the next JSON token is null. This method will return <c>null</c> at the end of an array.</returns>
+        /// <returns>A <see cref="Byte"/>[] or <c>null</c> if the next JSON token is null. This method will return <c>null</c> at the end of an array.</returns>
         public virtual byte[] ReadAsBytes()
         {
             JsonToken t = GetContentToken();

--- a/Src/Newtonsoft.Json/JsonReaderException.cs
+++ b/Src/Newtonsoft.Json/JsonReaderException.cs
@@ -78,7 +78,7 @@ namespace Newtonsoft.Json
         /// with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
         public JsonReaderException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -90,8 +90,8 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <c>null</c> or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
         public JsonReaderException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/Newtonsoft.Json/JsonSerializationException.cs
+++ b/Src/Newtonsoft.Json/JsonSerializationException.cs
@@ -60,7 +60,7 @@ namespace Newtonsoft.Json
         /// with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
         public JsonSerializationException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -72,8 +72,8 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <c>null</c> or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
         public JsonSerializationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -445,7 +445,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Reads the next JSON token from the stream as a <see cref="Byte"/>[].
         /// </summary>
-        /// <returns>A <see cref="Byte"/>[] or a null reference if the next JSON token is null. This method will return <c>null</c> at the end of an array.</returns>
+        /// <returns>A <see cref="Byte"/>[] or <c>null</c> if the next JSON token is null. This method will return <c>null</c> at the end of an array.</returns>
         public override byte[] ReadAsBytes()
         {
             EnsureBuffer();
@@ -2440,7 +2440,7 @@ namespace Newtonsoft.Json
         /// Gets the current line number.
         /// </summary>
         /// <value>
-        /// The current line number or 0 if no line information is available (for example, HasLineInfo returns false).
+        /// The current line number or 0 if no line information is available (for example, HasLineInfo returns <c>false</c>).
         /// </value>
         public int LineNumber
         {
@@ -2459,7 +2459,7 @@ namespace Newtonsoft.Json
         /// Gets the current line position.
         /// </summary>
         /// <value>
-        /// The current line position or 0 if no line information is available (for example, HasLineInfo returns false).
+        /// The current line position or 0 if no line information is available (for example, HasLineInfo returns <c>false</c>).
         /// </value>
         public int LinePosition
         {

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -407,7 +407,7 @@ namespace Newtonsoft.Json
         /// Reads the next JSON token from the stream as a <see cref="Byte"/>[].
         /// </summary>
         /// <returns>
-        /// A <see cref="Byte"/>[] or a null reference if the next JSON token is null.
+        /// A <see cref="Byte"/>[] or <c>null</c> if the next JSON token is null.
         /// </returns>
         public override byte[] ReadAsBytes()
         {

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -505,7 +505,8 @@ namespace Newtonsoft.Json
         /// <param name="value">
         /// The value to write.
         /// A value is only required for tokens that have an associated value, e.g. the <see cref="String"/> property name for <see cref="JsonToken.PropertyName"/>.
-        /// A null value can be passed to the method for token's that don't have a value, e.g. <see cref="JsonToken.StartObject"/>.</param>
+        /// <c>null</c> can be passed to the method for tokens that don't have a value, e.g. <see cref="JsonToken.StartObject"/>.
+        /// </param>
         public void WriteToken(JsonToken token, object value)
         {
             switch (token)

--- a/Src/Newtonsoft.Json/JsonWriterException.cs
+++ b/Src/Newtonsoft.Json/JsonWriterException.cs
@@ -66,7 +66,7 @@ namespace Newtonsoft.Json
         /// with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
         public JsonWriterException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -78,8 +78,8 @@ namespace Newtonsoft.Json
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <c>null</c> or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
         public JsonWriterException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/Newtonsoft.Json/Linq/JArray.cs
+++ b/Src/Newtonsoft.Json/Linq/JArray.cs
@@ -120,7 +120,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JArray"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JArray"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
         public new static JArray Load(JsonReader reader, JsonLoadSettings settings)
         {
@@ -165,7 +165,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="json">A <see cref="String"/> that contains JSON.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JArray"/> populated from the string that contains JSON.</returns>
         /// <example>
         ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParseArray" title="Parsing a JSON Array from Text" />
@@ -363,7 +363,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.ICollection`1"/>.</param>
         /// <returns>
-        /// true if <paramref name="item"/> is found in the <see cref="T:System.Collections.Generic.ICollection`1"/>; otherwise, false.
+        /// <c>true</c> if <paramref name="item"/> is found in the <see cref="T:System.Collections.Generic.ICollection`1"/>; otherwise, <c>false</c>.
         /// </returns>
         public bool Contains(JToken item)
         {
@@ -383,7 +383,7 @@ namespace Newtonsoft.Json.Linq
         /// <summary>
         /// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.
         /// </summary>
-        /// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, false.</returns>
+        /// <returns><c>true</c> if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, <c>false</c>.</returns>
         public bool IsReadOnly
         {
             get { return false; }
@@ -394,7 +394,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="item">The object to remove from the <see cref="T:System.Collections.Generic.ICollection`1"/>.</param>
         /// <returns>
-        /// true if <paramref name="item"/> was successfully removed from the <see cref="T:System.Collections.Generic.ICollection`1"/>; otherwise, false. This method also returns false if <paramref name="item"/> is not found in the original <see cref="T:System.Collections.Generic.ICollection`1"/>.
+        /// <c>true</c> if <paramref name="item"/> was successfully removed from the <see cref="T:System.Collections.Generic.ICollection`1"/>; otherwise, <c>false</c>. This method also returns <c>false</c> if <paramref name="item"/> is not found in the original <see cref="T:System.Collections.Generic.ICollection`1"/>.
         /// </returns>
         /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only.</exception>
         public bool Remove(JToken item)

--- a/Src/Newtonsoft.Json/Linq/JConstructor.cs
+++ b/Src/Newtonsoft.Json/Linq/JConstructor.cs
@@ -222,7 +222,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JConstructor"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JConstructor"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
         public new static JConstructor Load(JsonReader reader, JsonLoadSettings settings)
         {

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -256,7 +256,7 @@ namespace Newtonsoft.Json.Linq
         /// Gets a <see cref="JProperty"/> the specified name.
         /// </summary>
         /// <param name="name">The property name.</param>
-        /// <returns>A <see cref="JProperty"/> with the specified name or null.</returns>
+        /// <returns>A <see cref="JProperty"/> with the specified name or <c>null</c>.</returns>
         public JProperty Property(string name)
         {
             if (name == null)
@@ -360,7 +360,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JObject"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JObject"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
         /// <exception cref="JsonReaderException">
         ///     <paramref name="reader"/> is not valid JSON.
@@ -413,7 +413,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="json">A <see cref="String"/> that contains JSON.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JObject"/> populated from the string that contains JSON.</returns>
         /// <exception cref="JsonReaderException">
         ///     <paramref name="json"/> is not valid JSON.

--- a/Src/Newtonsoft.Json/Linq/JProperty.cs
+++ b/Src/Newtonsoft.Json/Linq/JProperty.cs
@@ -375,7 +375,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JProperty"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JProperty"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
         public new static JProperty Load(JsonReader reader, JsonLoadSettings settings)
         {

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2093,7 +2093,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">An <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>
         /// An <see cref="JToken"/> that contains the token and its descendant tokens
         /// that were read from the reader. The runtime type of the token is determined
@@ -2168,7 +2168,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="json">A <see cref="String"/> that contains JSON.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>A <see cref="JToken"/> populated from the string that contains JSON.</returns>
         public static JToken Parse(string json, JsonLoadSettings settings)
         {
@@ -2190,7 +2190,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="reader">A <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
         /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
-        /// If this is null, default load settings will be used.</param>
+        /// If this is <c>null</c>, default load settings will be used.</param>
         /// <returns>
         /// A <see cref="JToken"/> that contains the token and its descendant tokens
         /// that were read from the reader. The runtime type of the token is determined
@@ -2286,7 +2286,7 @@ namespace Newtonsoft.Json.Linq
         /// <param name="path">
         /// A <see cref="String"/> that contains a JPath expression.
         /// </param>
-        /// <returns>A <see cref="JToken"/>, or null.</returns>
+        /// <returns>A <see cref="JToken"/>, or <c>null</c>.</returns>
         public JToken SelectToken(string path)
         {
             return SelectToken(path, false);

--- a/Src/Newtonsoft.Json/Linq/JTokenEqualityComparer.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenEqualityComparer.cs
@@ -50,7 +50,7 @@ namespace Newtonsoft.Json.Linq
         /// </summary>
         /// <param name="obj">The <see cref="T:System.Object"/> for which a hash code is to be returned.</param>
         /// <returns>A hash code for the specified object.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.</exception>
+        /// <exception cref="T:System.ArgumentNullException">The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is <c>null</c>.</exception>
         public int GetHashCode(JToken obj)
         {
             if (obj == null)

--- a/Src/Newtonsoft.Json/MemberSerialization.cs
+++ b/Src/Newtonsoft.Json/MemberSerialization.cs
@@ -50,7 +50,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// All public and private fields are serialized. Members can be excluded using <see cref="JsonIgnoreAttribute"/> or <see cref="NonSerializedAttribute"/>.
         /// This member serialization mode can also be set by marking the class with <see cref="SerializableAttribute"/>
-        /// and setting IgnoreSerializableAttribute on <see cref="DefaultContractResolver"/> to false.
+        /// and setting IgnoreSerializableAttribute on <see cref="DefaultContractResolver"/> to <c>false</c>.
         /// </summary>
         Fields = 2
 #pragma warning restore 1584,1711,1572,1581,1580,1574

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaException.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaException.cs
@@ -82,7 +82,7 @@ namespace Newtonsoft.Json.Schema
         /// with a specified error message and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
         public JsonSchemaException(string message, Exception innerException)
             : base(message, innerException)
         {
@@ -94,8 +94,8 @@ namespace Newtonsoft.Json.Schema
         /// </summary>
         /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is null.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <c>null</c> or <see cref="P:System.Exception.HResult"/> is zero (0).</exception>
         public JsonSchemaException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -211,7 +211,7 @@ namespace Newtonsoft.Json.Serialization
         /// If set to <c>true</c> the <see cref="DefaultContractResolver"/> will use a cached shared with other resolvers of the same type.
         /// Sharing the cache will significantly improve performance with multiple resolver instances because expensive reflection will only
         /// happen once. This setting can cause unexpected behavior if different instances of the resolver are suppose to produce different
-        /// results. When set to false it is highly recommended to reuse <see cref="DefaultContractResolver"/> instances with the <see cref="JsonSerializer"/>.
+        /// results. When set to <c>false</c> it is highly recommended to reuse <see cref="DefaultContractResolver"/> instances with the <see cref="JsonSerializer"/>.
         /// </param>
         [ObsoleteAttribute("DefaultContractResolver(bool) is obsolete. Use the parameterless constructor and cache instances of the contract resolver within your application for optimal performance.")]
         public DefaultContractResolver(bool shareCache)

--- a/Src/Newtonsoft.Json/Serialization/IAttributeProvider.cs
+++ b/Src/Newtonsoft.Json/Serialization/IAttributeProvider.cs
@@ -36,7 +36,7 @@ namespace Newtonsoft.Json.Serialization
         /// <summary>
         /// Returns a collection of all of the attributes, or an empty collection if there are no attributes.
         /// </summary>
-        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute.</param>
+        /// <param name="inherit">When <c>true</c>, look up the hierarchy chain for the inherited custom attribute.</param>
         /// <returns>A collection of <see cref="Attribute"/>s, or an empty collection.</returns>
         IList<Attribute> GetAttributes(bool inherit);
 
@@ -44,7 +44,7 @@ namespace Newtonsoft.Json.Serialization
         /// Returns a collection of attributes, identified by type, or an empty collection if there are no attributes.
         /// </summary>
         /// <param name="attributeType">The type of the attributes.</param>
-        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute.</param>
+        /// <param name="inherit">When <c>true</c>, look up the hierarchy chain for the inherited custom attribute.</param>
         /// <returns>A collection of <see cref="Attribute"/>s, or an empty collection.</returns>
         IList<Attribute> GetAttributes(Type attributeType, bool inherit);
     }

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -177,7 +177,7 @@ namespace Newtonsoft.Json.Serialization
         /// </summary>
         /// <param name="converterType">The JsonConverter type to create.</param>
         /// <param name="converterArgs">Optional arguments to pass to an initializing constructor of the JsonConverter.
-        /// If null, the default constructor is used.</param>
+        /// If <c>null</c>, the default constructor is used.</param>
         public static JsonConverter CreateJsonConverterInstance(Type converterType, object[] converterArgs)
         {
             Func<object[], object> converterCreator = CreatorCache.Get(converterType);

--- a/Src/Newtonsoft.Json/Serialization/ReflectionAttributeProvider.cs
+++ b/Src/Newtonsoft.Json/Serialization/ReflectionAttributeProvider.cs
@@ -50,7 +50,7 @@ namespace Newtonsoft.Json.Serialization
         /// <summary>
         /// Returns a collection of all of the attributes, or an empty collection if there are no attributes.
         /// </summary>
-        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute.</param>
+        /// <param name="inherit">When <c>true</c>, look up the hierarchy chain for the inherited custom attribute.</param>
         /// <returns>A collection of <see cref="Attribute"/>s, or an empty collection.</returns>
         public IList<Attribute> GetAttributes(bool inherit)
         {
@@ -61,7 +61,7 @@ namespace Newtonsoft.Json.Serialization
         /// Returns a collection of attributes, identified by type, or an empty collection if there are no attributes.
         /// </summary>
         /// <param name="attributeType">The type of the attributes.</param>
-        /// <param name="inherit">When true, look up the hierarchy chain for the inherited custom attribute.</param>
+        /// <param name="inherit">When <c>true</c>, look up the hierarchy chain for the inherited custom attribute.</param>
         /// <returns>A collection of <see cref="Attribute"/>s, or an empty collection.</returns>
         public IList<Attribute> GetAttributes(Type attributeType, bool inherit)
         {

--- a/Src/Newtonsoft.Json/Utilities/CollectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/CollectionUtils.cs
@@ -42,11 +42,11 @@ namespace Newtonsoft.Json.Utilities
     internal static class CollectionUtils
     {
         /// <summary>
-        /// Determines whether the collection is null or empty.
+        /// Determines whether the collection is <c>null</c> or empty.
         /// </summary>
         /// <param name="collection">The collection.</param>
         /// <returns>
-        /// 	<c>true</c> if the collection is null or empty; otherwise, <c>false</c>.
+        /// 	<c>true</c> if the collection is <c>null</c> or empty; otherwise, <c>false</c>.
         /// </returns>
         public static bool IsNullOrEmpty<T>(ICollection<T> collection)
         {

--- a/Src/Newtonsoft.Json/Utilities/MethodBinder.cs
+++ b/Src/Newtonsoft.Json/Utilities/MethodBinder.cs
@@ -41,7 +41,7 @@
         /// </summary>
         /// <param name="from">Source primitive type.</param>
         /// <param name="to">Target primitive type.</param>
-        /// <returns>True if source type can be widened to target type, false otherwise.</returns>
+        /// <returns><c>true</c> if source type can be widened to target type, <c>false</c> otherwise.</returns>
         private static bool CanConvertPrimitive(Type from, Type to)
         {
             if (from == to)
@@ -80,7 +80,7 @@
         /// <param name="parameters">Method parameters.</param>
         /// <param name="types">Argument types.</param>
         /// <param name="enableParamArray">Try to pack extra arguments into ParamArray.</param>
-        /// <returns>True if method can be called with given arguments, false otherwise.</returns>
+        /// <returns><c>true</c> if method can be called with given arguments, <c>false</c> otherwise.</returns>
         private static bool FilterParameters(ParameterInfo[] parameters, IList<Type> types, bool enableParamArray)
         {
             ValidationUtils.ArgumentNotNull(parameters, nameof(parameters));

--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -75,7 +75,7 @@ namespace Newtonsoft.Json.Utilities
         }
 
         /// <summary>
-        /// Determines whether the string is all white space. Empty string will return false.
+        /// Determines whether the string is all white space. Empty string will return <c>false</c>.
         /// </summary>
         /// <param name="s">The string to test whether it is all white space.</param>
         /// <returns>


### PR DESCRIPTION
This one makes the formatting of `true`, `false`, and `null` consistent where they refer to the C# keywords.

There are a few instances of "null" where a different kind of nullity is or might be referred to (e.g. "null tokens", which apparently include those with token types `JsonToken.Null` or `JsonToken.None`). These remain as they are.

I also collapsed the rarely used phrases "null reference", "null value", and "null (Nothing in Visual Basic)" simply into `null`. (Regarding the last one, it doesn't make much sense to only explain `null` to VB.NET programmers in approx. 5 out of 100 cases.)