### PR TITLE
Make JsonValidatingReader close underlying JsonReader when CloseInput is true

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonValidatingReaderTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonValidatingReaderTests.cs
@@ -1747,6 +1747,17 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(JsonToken.None, reader.TokenType);
             Assert.AreEqual(null, validationEventArgs);
         }
+
+        [Test]
+        public void CloseAlsoClosesUnderlyingReader()
+        {
+            var underlyingReader = new TestObjects.JsonReaderStubWithIsClosed();
+            var validatingReader = new JsonValidatingReader(underlyingReader) { CloseInput = true };
+
+            validatingReader.Close();
+
+            Assert.IsTrue(underlyingReader.IsClosed);
+        }
     }
 }
 

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net20.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net20.csproj
@@ -171,6 +171,7 @@
     <Compile Include="TestObjects\Item.cs" />
     <Compile Include="TestObjects\JsonPropertyClass.cs" />
     <Compile Include="Serialization\JsonSerializerTest.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\SlowStream.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\ToggleReaderError.cs" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net35.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net35.csproj
@@ -208,6 +208,7 @@
     <Compile Include="TestObjects\IPrivateImplementationB.cs" />
     <Compile Include="TestObjects\IPrivateOverriddenImplementation.cs" />
     <Compile Include="TestObjects\Item.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\SlowStream.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\ToggleReaderError.cs" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Net40.csproj
@@ -329,6 +329,7 @@
     <Compile Include="TestObjects\JsonTextReaderTests\SlowStream.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\ToggleReaderError.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\UnmanagedResourceFakingJsonReader.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\ListOfIds.cs" />
     <Compile Include="TestObjects\MetroPropertyNameResolver.cs" />
     <Compile Include="TestObjects\MetroStringConverter.cs" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Portable.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Portable.csproj
@@ -201,6 +201,7 @@
     <Compile Include="TestObjects\IPrivateImplementationB.cs" />
     <Compile Include="TestObjects\IPrivateOverriddenImplementation.cs" />
     <Compile Include="TestObjects\Item.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\SlowStream.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\ToggleReaderError.cs" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Portable40.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.Portable40.csproj
@@ -205,6 +205,7 @@
     <Compile Include="TestObjects\IPrivateImplementationB.cs" />
     <Compile Include="TestObjects\IPrivateOverriddenImplementation.cs" />
     <Compile Include="TestObjects\Item.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\SlowStream.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\ToggleReaderError.cs" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -224,6 +224,7 @@
     <Compile Include="JsonConvertTest.cs" />
     <Compile Include="JsonTextReaderTests\MiscTests.cs" />
     <Compile Include="JsonTextReaderTests\ExceptionHandlingTests.cs" />
+    <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="JsonTextReaderTests\FloatTests.cs" />
     <Compile Include="JsonTextReaderTests\ParseTests.cs" />

--- a/Src/Newtonsoft.Json.Tests/TestObjects/JsonReaderStubWithIsClosed.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/JsonReaderStubWithIsClosed.cs
@@ -1,0 +1,44 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public sealed class JsonReaderStubWithIsClosed : JsonReader
+    {
+        public bool IsClosed { get; private set; }
+
+        public override void Close()
+        {
+            IsClosed = true;
+        }
+
+        public override bool Read()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -351,6 +351,19 @@ namespace Newtonsoft.Json
             get { return _reader; }
         }
 
+        /// <summary>
+        /// Changes the reader's state to <see cref="JsonReader.State.Closed"/>.
+        /// If <see cref="JsonReader.CloseInput"/> is set to <c>true</c>, the underlying <see cref="JsonReader"/> is also closed.
+        /// </summary>
+        public override void Close()
+        {
+            base.Close();
+            if (CloseInput && _reader != null)
+            {
+                _reader.Close();
+            }
+        }
+
         private void ValidateNotDisallowed(JsonSchemaModel schema)
         {
             if (schema == null)


### PR DESCRIPTION
This would take care of issue #1112.