### PR TITLE
Add support for asynchronous operations.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Bson/BsonReaderAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Bson/BsonReaderAsyncTests.cs
@@ -1,0 +1,1768 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Tests.TestObjects;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+using System.Text.RegularExpressions;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Bson;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+namespace Newtonsoft.Json.Tests.Bson
+{
+    [TestFixture]
+    public class BsonReaderAsyncTests : TestFixtureBase
+    {
+        private const char Euro = '\u20ac';
+
+        [Test]
+        public async Task DeserializeLargeBsonObjectAsync()
+        {
+            byte[] data = System.IO.File.ReadAllBytes(@"SpaceShipV2.bson");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual("1", (string)o["$id"]);
+        }
+
+        public class MyTest
+        {
+            public DateTime TimeStamp { get; set; }
+            public string UserName { get; set; }
+            public MemoryStream Blob { get; set; }
+        }
+
+        public async Task Bson_SupportMultipleContentAsync()
+        {
+            MemoryStream myStream = new MemoryStream();
+            BsonWriter writer = new BsonWriter(myStream);
+            JsonSerializer serializer = new JsonSerializer();
+            MyTest tst1 = new MyTest
+            {
+                TimeStamp = new DateTime(2000, 12, 20, 12, 59, 59, DateTimeKind.Utc),
+                UserName = "Joe Doe"
+            };
+            MyTest tst2 = new MyTest
+            {
+                TimeStamp = new DateTime(2010, 12, 20, 12, 59, 59, DateTimeKind.Utc),
+                UserName = "Bob"
+            };
+            await serializer.SerializeAsync(writer, tst1);
+            await serializer.SerializeAsync( writer, tst2);
+
+            myStream.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(myStream)
+            {
+                SupportMultipleContent = true,
+                DateTimeKindHandling = DateTimeKind.Utc
+            };
+
+            MyTest tst1A = await serializer.DeserializeAsync<MyTest>(reader);
+
+            await reader.ReadAsync();
+
+            MyTest tst2A = await serializer.DeserializeAsync<MyTest>(reader);
+
+            Assert.AreEqual(tst1.UserName, tst1A.UserName);
+            Assert.AreEqual(tst1.TimeStamp, tst1A.TimeStamp);
+
+            Assert.AreEqual(tst2.UserName, tst2A.UserName);
+            Assert.AreEqual(tst2.TimeStamp, tst2A.TimeStamp);
+        }
+
+        [Test]
+        public async Task ReadSingleObjectAsync()
+        {
+            byte[] data = HexToBytes("0F-00-00-00-10-42-6C-61-68-00-01-00-00-00-00");
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("Blah", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(1L, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadGuid_TextAsync()
+        {
+            byte[] data = HexToBytes("31-00-00-00-02-30-00-25-00-00-00-64-38-32-31-65-65-64-37-2D-34-62-35-63-2D-34-33-63-39-2D-38-61-63-32-2D-36-39-32-38-65-35-37-39-62-37-30-35-00-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("d821eed7-4b5c-43c9-8ac2-6928e579b705", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+
+            ms = new MemoryStream(data);
+            reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            JsonSerializer serializer = new JsonSerializer();
+            IList<Guid> l = await serializer.DeserializeAsync<IList<Guid>>(reader);
+
+            Assert.AreEqual(1, l.Count);
+            Assert.AreEqual(new Guid("D821EED7-4B5C-43C9-8AC2-6928E579B705"), l[0]);
+        }
+
+        [Test]
+        public async Task ReadGuid_BytesAsync()
+        {
+            byte[] data = HexToBytes("1D-00-00-00-05-30-00-10-00-00-00-04-D7-EE-21-D8-5C-4B-C9-43-8A-C2-69-28-E5-79-B7-05-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Guid g = new Guid("D821EED7-4B5C-43C9-8AC2-6928E579B705");
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            Assert.AreEqual(g, reader.Value);
+            Assert.AreEqual(typeof(Guid), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+
+            ms = new MemoryStream(data);
+            reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            JsonSerializer serializer = new JsonSerializer();
+            IList<Guid> l = await serializer.DeserializeAsync<IList<Guid>>(reader);
+
+            Assert.AreEqual(1, l.Count);
+            Assert.AreEqual(g, l[0]);
+        }
+
+        [Test]
+        public async Task ReadDoubleAsync()
+        {
+            byte[] data = HexToBytes("10-00-00-00-01-30-00-8F-C2-F5-28-5C-FF-58-40-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(99.99d, reader.Value);
+            Assert.AreEqual(typeof(double), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadDouble_DecimalAsync()
+        {
+            byte[] data = HexToBytes("10-00-00-00-01-30-00-8F-C2-F5-28-5C-FF-58-40-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(99.99m, reader.Value);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadValuesAsync()
+        {
+            byte[] data = HexToBytes("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-01-37-00-00-00-00-00-00-00-F0-45-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-02-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00");
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+#pragma warning disable 612,618
+            reader.JsonNet35BinaryCompatibility = true;
+#pragma warning restore 612,618
+            reader.ReadRootValueAsArray = true;
+            reader.DateTimeKindHandling = DateTimeKind.Utc;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(long.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(long.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual((long)int.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual((long)int.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual((long)byte.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual((long)sbyte.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("a", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual((double)decimal.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(double), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(double.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(double), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual((double)float.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(double), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Boolean, reader.TokenType);
+            Assert.AreEqual(true, reader.Value);
+            Assert.AreEqual(typeof(bool), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(new byte[] { 0, 1, 2, 3, 4 }, (byte[])reader.Value);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 12, 29, 12, 30, 0, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 12, 29, 12, 30, 0, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadObjectBsonFromSiteAsync()
+        {
+            byte[] data = HexToBytes("20-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-02-32-00-02-00-00-00-63-00-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("0", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("a", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("1", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("b", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("2", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("c", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadArrayBsonFromSiteAsync()
+        {
+            byte[] data = HexToBytes("20-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-02-32-00-02-00-00-00-63-00-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.AreEqual(false, reader.ReadRootValueAsArray);
+            Assert.AreEqual(DateTimeKind.Local, reader.DateTimeKindHandling);
+
+            reader.ReadRootValueAsArray = true;
+            reader.DateTimeKindHandling = DateTimeKind.Utc;
+
+            Assert.AreEqual(true, reader.ReadRootValueAsArray);
+            Assert.AreEqual(DateTimeKind.Utc, reader.DateTimeKindHandling);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("a", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("b", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("c", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadAsInt32BadStringAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                byte[] data = HexToBytes("20-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-02-32-00-02-00-00-00-63-00-00");
+
+                MemoryStream ms = new MemoryStream(data);
+                BsonReader reader = new BsonReader(ms);
+
+                Assert.AreEqual(false, reader.ReadRootValueAsArray);
+                Assert.AreEqual(DateTimeKind.Local, reader.DateTimeKindHandling);
+
+                reader.ReadRootValueAsArray = true;
+                reader.DateTimeKindHandling = DateTimeKind.Utc;
+
+                Assert.AreEqual(true, reader.ReadRootValueAsArray);
+                Assert.AreEqual(DateTimeKind.Utc, reader.DateTimeKindHandling);
+
+                Assert.IsTrue(await reader.ReadAsync());
+                Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+                await reader.ReadAsInt32Async();
+            }, "Could not convert string to integer: a. Path '[0]'.");
+        }
+
+        [Test]
+        public async Task ReadBytesAsync()
+        {
+            byte[] data = HexToBytes("2B-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-05-32-00-0C-00-00-00-02-48-65-6C-6C-6F-20-77-6F-72-6C-64-21-00");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms, true, DateTimeKind.Utc);
+#pragma warning disable 612,618
+            reader.JsonNet35BinaryCompatibility = true;
+#pragma warning restore 612,618
+
+            Assert.AreEqual(true, reader.ReadRootValueAsArray);
+            Assert.AreEqual(DateTimeKind.Utc, reader.DateTimeKindHandling);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("a", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("b", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            byte[] encodedStringData = await reader.ReadAsBytesAsync();
+            Assert.IsNotNull(encodedStringData);
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            Assert.AreEqual(encodedStringData, reader.Value);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+
+            string decodedString = Encoding.UTF8.GetString(encodedStringData, 0, encodedStringData.Length);
+            Assert.AreEqual("Hello world!", decodedString);
+        }
+
+        [Test]
+        public async Task ReadOidAsync()
+        {
+            byte[] data = HexToBytes("29000000075F6964004ABBED9D1D8B0F02180000010274657374000900000031323334C2A335360000");
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("_id", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(HexToBytes("4ABBED9D1D8B0F0218000001"), (byte[])reader.Value);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("test", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("1234£56", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadNestedArrayAsync()
+        {
+            string hexdoc = "82-00-00-00-07-5F-69-64-00-4A-78-93-79-17-22-00-00-00-00-61-CF-04-61-00-5D-00-00-00-01-30-00-00-00-00-00-00-00-F0-3F-01-31-00-00-00-00-00-00-00-00-40-01-32-00-00-00-00-00-00-00-08-40-01-33-00-00-00-00-00-00-00-10-40-01-34-00-00-00-00-00-00-00-14-50-01-35-00-00-00-00-00-00-00-18-40-01-36-00-00-00-00-00-00-00-1C-40-01-37-00-00-00-00-00-00-00-20-40-00-02-62-00-05-00-00-00-74-65-73-74-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("_id", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(HexToBytes("4A-78-93-79-17-22-00-00-00-00-61-CF"), (byte[])reader.Value);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("a", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            for (int i = 1; i <= 8; i++)
+            {
+                Assert.IsTrue(await reader.ReadAsync());
+                Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+                double value = (i != 5)
+                    ? Convert.ToDouble(i)
+                    : 5.78960446186581E+77d;
+
+                Assert.AreEqual(value, reader.Value);
+            }
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("b", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("test", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadNestedArrayIntoLinqAsync()
+        {
+            string hexdoc = "87-00-00-00-05-5F-69-64-00-0C-00-00-00-00-4A-78-93-79-17-22-00-00-00-00-61-CF-04-61-00-5D-00-00-00-01-30-00-00-00-00-00-00-00-F0-3F-01-31-00-00-00-00-00-00-00-00-40-01-32-00-00-00-00-00-00-00-08-40-01-33-00-00-00-00-00-00-00-10-40-01-34-00-00-00-00-00-00-00-14-50-01-35-00-00-00-00-00-00-00-18-40-01-36-00-00-00-00-00-00-00-1C-40-01-37-00-00-00-00-00-00-00-20-40-00-02-62-00-05-00-00-00-74-65-73-74-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            BsonReader reader = new BsonReader(new MemoryStream(data));
+#pragma warning disable 612,618
+            reader.JsonNet35BinaryCompatibility = true;
+#pragma warning restore 612,618
+
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(3, o.Count);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await o.WriteToAsync(writer);
+            await writer.FlushAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual(hexdoc, bson);
+        }
+
+        [Test]
+        public async Task OidAndBytesAreEqualAsync()
+        {
+            byte[] data1 = HexToBytes(
+                "82-00-00-00-07-5F-69-64-00-4A-78-93-79-17-22-00-00-00-00-61-CF-04-61-00-5D-00-00-00-01-30-00-00-00-00-00-00-00-F0-3F-01-31-00-00-00-00-00-00-00-00-40-01-32-00-00-00-00-00-00-00-08-40-01-33-00-00-00-00-00-00-00-10-40-01-34-00-00-00-00-00-00-00-14-50-01-35-00-00-00-00-00-00-00-18-40-01-36-00-00-00-00-00-00-00-1C-40-01-37-00-00-00-00-00-00-00-20-40-00-02-62-00-05-00-00-00-74-65-73-74-00-00");
+
+            BsonReader reader1 = new BsonReader(new MemoryStream(data1));
+#pragma warning disable 612,618
+            reader1.JsonNet35BinaryCompatibility = true;
+#pragma warning restore 612,618
+
+            // oid
+            JObject o1 = (JObject)await JToken.ReadFromAsync(reader1);
+
+            byte[] data2 = HexToBytes(
+                "87-00-00-00-05-5F-69-64-00-0C-00-00-00-02-4A-78-93-79-17-22-00-00-00-00-61-CF-04-61-00-5D-00-00-00-01-30-00-00-00-00-00-00-00-F0-3F-01-31-00-00-00-00-00-00-00-00-40-01-32-00-00-00-00-00-00-00-08-40-01-33-00-00-00-00-00-00-00-10-40-01-34-00-00-00-00-00-00-00-14-50-01-35-00-00-00-00-00-00-00-18-40-01-36-00-00-00-00-00-00-00-1C-40-01-37-00-00-00-00-00-00-00-20-40-00-02-62-00-05-00-00-00-74-65-73-74-00-00");
+
+            BsonReader reader2 = new BsonReader(new MemoryStream(data2));
+#pragma warning disable 612,618
+            reader2.JsonNet35BinaryCompatibility = true;
+#pragma warning restore 612,618
+
+            // bytes
+            JObject o2 = (JObject)await JToken.ReadFromAsync(reader2);
+
+            Assert.IsTrue(o1.DeepEquals(o2));
+        }
+
+        [Test]
+        public async Task ReadRegexAsync()
+        {
+            string hexdoc = "15-00-00-00-0B-72-65-67-65-78-00-74-65-73-74-00-67-69-6D-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("regex", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(@"/test/gim", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadCodeAsync()
+        {
+            string hexdoc = "1A-00-00-00-0D-63-6F-64-65-00-0B-00-00-00-49-20-61-6D-20-63-6F-64-65-21-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("code", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(@"I am code!", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadUndefinedAsync()
+        {
+            string hexdoc = "10-00-00-00-06-75-6E-64-65-66-69-6E-65-64-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("undefined", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+            Assert.AreEqual(null, reader.Value);
+            Assert.AreEqual(null, reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadLongAsync()
+        {
+            string hexdoc = "13-00-00-00-12-6C-6F-6E-67-00-FF-FF-FF-FF-FF-FF-FF-7F-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("long", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(long.MaxValue, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadReferenceAsync()
+        {
+            string hexdoc = "1E-00-00-00-0C-6F-69-64-00-04-00-00-00-6F-69-64-00-01-02-03-04-05-06-07-08-09-0A-0B-0C-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("oid", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("$ref", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("oid", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("$id", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, (byte[])reader.Value);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadCodeWScopeAsync()
+        {
+            string hexdoc = "75-00-00-00-0F-63-6F-64-65-57-69-74-68-53-63-6F-70-65-00-61-00-00-00-35-00-00-00-66-6F-72-20-28-69-6E-74-20-69-20-3D-20-30-3B-20-69-20-3C-20-31-30-30-30-3B-20-69-2B-2B-29-0D-0A-7B-0D-0A-20-20-61-6C-65-72-74-28-61-72-67-31-29-3B-0D-0A-7D-00-24-00-00-00-02-61-72-67-31-00-15-00-00-00-4A-73-6F-6E-2E-4E-45-54-20-69-73-20-61-77-65-73-6F-6D-65-2E-00-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("codeWithScope", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("$code", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("for (int i = 0; i < 1000; i++)\r\n{\r\n  alert(arg1);\r\n}", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("$scope", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("arg1", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("Json.NET is awesome.", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadEndOfStreamAsync()
+        {
+            BsonReader reader = new BsonReader(new MemoryStream());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadLargeStringsAsync()
+        {
+            string bson =
+                "4E-02-00-00-02-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-22-01-00-00-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-00";
+
+            BsonReader reader = new BsonReader(new MemoryStream(HexToBytes(bson)));
+
+            StringBuilder largeStringBuilder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                if (i > 0)
+                {
+                    largeStringBuilder.Append("-");
+                }
+
+                largeStringBuilder.Append(i.ToString(CultureInfo.InvariantCulture));
+            }
+            string largeString = largeStringBuilder.ToString();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual(largeString, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(largeString, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ReadEmptyStringsAsync()
+        {
+            string bson = "0C-00-00-00-02-00-01-00-00-00-00-00";
+
+            BsonReader reader = new BsonReader(new MemoryStream(HexToBytes(bson)));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task WriteAndReadEmptyListsAndDictionariesAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Arguments");
+            await writer.WriteStartObjectAsync();
+            await writer.WriteEndObjectAsync();
+            await writer.WritePropertyNameAsync("List");
+            await writer.WriteStartArrayAsync();
+            await writer.WriteEndArrayAsync();
+            await writer.WriteEndObjectAsync();
+
+            string bson = BitConverter.ToString(ms.ToArray());
+
+            Assert.AreEqual("20-00-00-00-03-41-72-67-75-6D-65-6E-74-73-00-05-00-00-00-00-04-4C-69-73-74-00-05-00-00-00-00-00", bson);
+
+            BsonReader reader = new BsonReader(new MemoryStream(HexToBytes(bson)));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("Arguments", reader.Value.ToString());
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("List", reader.Value.ToString());
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task DateTimeKindHandlingAsync()
+        {
+            DateTime value = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("DateTime");
+            await writer.WriteValueAsync(value);
+            await writer.WriteEndObjectAsync();
+
+            byte[] bson = ms.ToArray();
+
+            BsonReader reader = new BsonReader(new MemoryStream(bson), false, DateTimeKind.Utc);
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(value, (DateTime)o["DateTime"]);
+
+            reader = new BsonReader(new MemoryStream(bson), false, DateTimeKind.Local);
+            o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(value.ToLocalTime(), (DateTime)o["DateTime"]);
+
+            reader = new BsonReader(new MemoryStream(bson), false, DateTimeKind.Unspecified);
+            o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(DateTime.SpecifyKind(value, DateTimeKind.Unspecified), (DateTime)o["DateTime"]);
+        }
+
+        [Test]
+        public async Task UnspecifiedDateTimeKindHandlingAsync()
+        {
+            DateTime value = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            writer.DateTimeKindHandling = DateTimeKind.Unspecified;
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("DateTime");
+            await writer.WriteValueAsync(value);
+            await writer.WriteEndObjectAsync();
+
+            byte[] bson = ms.ToArray();
+
+            BsonReader reader = new BsonReader(new MemoryStream(bson), false, DateTimeKind.Unspecified);
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(value, (DateTime)o["DateTime"]);
+        }
+
+        [Test]
+        public async Task LocalDateTimeKindHandlingAsync()
+        {
+            DateTime value = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("DateTime");
+            await writer.WriteValueAsync(value);
+            await writer.WriteEndObjectAsync();
+
+            byte[] bson = ms.ToArray();
+
+            JObject o;
+            BsonReader reader;
+
+            reader = new BsonReader(new MemoryStream(bson), false, DateTimeKind.Local);
+            o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(value, (DateTime)o["DateTime"]);
+        }
+
+        private async Task<string> WriteAndReadStringValueAsync(string val)
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter bs = new BsonWriter(ms);
+            await bs.WriteStartObjectAsync();
+            await bs.WritePropertyNameAsync("StringValue");
+            await bs.WriteValueAsync(val);
+            await bs.WriteEndAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            // object
+            await reader.ReadAsync();
+            // property name
+            await reader.ReadAsync();
+            // string
+            await reader.ReadAsync();
+            return (string)reader.Value;
+        }
+
+        private async Task<string> WriteAndReadStringPropertyNameAsync(string val)
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter bs = new BsonWriter(ms);
+            await bs.WriteStartObjectAsync();
+            await bs.WritePropertyNameAsync(val);
+            await bs.WriteValueAsync("Dummy");
+            await bs.WriteEndAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            // object
+            await reader.ReadAsync();
+            // property name
+            await reader.ReadAsync();
+            return (string)reader.Value;
+        }
+
+        [Test]
+        public async Task TestReadLenStringValueShortTripleByteAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            //sb.Append('1',127); //first char of euro at the end of the boundry.
+            //sb.Append(euro, 5);
+            //sb.Append('1',128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadLenStringValueTripleByteCharBufferBoundry0Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 127); //first char of euro at the end of the boundry.
+            sb.Append(Euro, 5);
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadLenStringValueTripleByteCharBufferBoundry1Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 126);
+            sb.Append(Euro, 5); //middle char of euro at the end of the boundry.
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            string result = await  WriteAndReadStringValueAsync(expected);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task TestReadLenStringValueTripleByteCharOneAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(Euro, 1); //Just one triple byte char in the string.
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadLenStringValueTripleByteCharBufferBoundry2Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 125);
+            sb.Append(Euro, 5); //last char of the eruo at the end of the boundry.
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringValueAsync()
+        {
+            string expected = "test";
+            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringValueLongAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('t', 150);
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await  WriteAndReadStringValueAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameShortTripleByteAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            //sb.Append('1',127); //first char of euro at the end of the boundry.
+            //sb.Append(euro, 5);
+            //sb.Append('1',128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameTripleByteCharBufferBoundry0Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 127); //first char of euro at the end of the boundry.
+            sb.Append(Euro, 5);
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            string result = await WriteAndReadStringPropertyNameAsync(expected);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameTripleByteCharBufferBoundry1Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 126);
+            sb.Append(Euro, 5); //middle char of euro at the end of the boundry.
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameTripleByteCharOneAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(Euro, 1); //Just one triple byte char in the string.
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameTripleByteCharBufferBoundry2Async()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('1', 125);
+            sb.Append(Euro, 5); //last char of the eruo at the end of the boundry.
+            sb.Append('1', 128);
+            sb.Append(Euro);
+
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameAsync()
+        {
+            string expected = "test";
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task TestReadStringPropertyNameLongAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append('t', 150);
+            string expected = sb.ToString();
+            Assert.AreEqual(expected, await WriteAndReadStringPropertyNameAsync(expected));
+        }
+
+        [Test]
+        public async Task ReadRegexWithOptionsAsync()
+        {
+            string hexdoc = "1A-00-00-00-0B-72-65-67-65-78-00-61-62-63-00-69-00-0B-74-65-73-74-00-00-00-00";
+
+            byte[] data = HexToBytes(hexdoc);
+
+            MemoryStream ms = new MemoryStream(data);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("/abc/i", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("//", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task CanRoundTripStackOverflowDataAsync()
+        {
+            var doc =
+                @"{
+""AboutMe"": ""<p>I'm the Director for Research and Development for <a href=\""http://www.prophoenix.com\"" rel=\""nofollow\"">ProPhoenix</a>, a public safety software company.  This position allows me to investigate new and existing technologies and incorporate them into our product line, with the end goal being to help public safety agencies to do their jobs more effeciently and safely.</p>\r\n\r\n<p>I'm an advocate for PowerShell, as I believe it encourages administrative best practices and allows developers to provide additional access to their applications, without needing to explicity write code for each administrative feature.  Part of my advocacy for PowerShell includes <a href=\""http://blog.usepowershell.com\"" rel=\""nofollow\"">my blog</a>, appearances on various podcasts, and acting as a Community Director for <a href=\""http://powershellcommunity.org\"" rel=\""nofollow\"">PowerShellCommunity.Org</a></p>\r\n\r\n<p>I’m also a co-host of Mind of Root (a weekly audio podcast about systems administration, tech news, and topics).</p>\r\n"",
+""WebsiteUrl"": ""http://blog.usepowershell.com""
+}";
+            JObject parsed = JObject.Parse(doc);
+            var memoryStream = new MemoryStream();
+            var bsonWriter = new BsonWriter(memoryStream);
+            await parsed.WriteToAsync(bsonWriter);
+            await bsonWriter.FlushAsync();
+            memoryStream.Position = 0;
+
+            BsonReader reader = new BsonReader(memoryStream);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("AboutMe", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("<p>I'm the Director for Research and Development for <a href=\"http://www.prophoenix.com\" rel=\"nofollow\">ProPhoenix</a>, a public safety software company.  This position allows me to investigate new and existing technologies and incorporate them into our product line, with the end goal being to help public safety agencies to do their jobs more effeciently and safely.</p>\r\n\r\n<p>I'm an advocate for PowerShell, as I believe it encourages administrative best practices and allows developers to provide additional access to their applications, without needing to explicity write code for each administrative feature.  Part of my advocacy for PowerShell includes <a href=\"http://blog.usepowershell.com\" rel=\"nofollow\">my blog</a>, appearances on various podcasts, and acting as a Community Director for <a href=\"http://powershellcommunity.org\" rel=\"nofollow\">PowerShellCommunity.Org</a></p>\r\n\r\n<p>I’m also a co-host of Mind of Root (a weekly audio podcast about systems administration, tech news, and topics).</p>\r\n", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("WebsiteUrl", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("http://blog.usepowershell.com", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task MultibyteCharacterPropertyNamesAndStringsAsync()
+        {
+            string json = @"{
+  ""ΕΝΤΟΛΗ ΧΧΧ ΧΧΧΧΧΧΧΧΧ ΤΑ ΠΡΩΤΑΣΦΑΛΙΣΤΗΡΙΑ ΠΟΥ ΔΕΝ ΕΧΟΥΝ ΥΠΟΛΟΙΠΟ ΝΑ ΤΑ ΣΤΕΛΝΟΥΜΕ ΑΠΕΥΘΕΙΑΣ ΣΤΟΥΣ ΠΕΛΑΤΕΣ"": ""ΕΝΤΟΛΗ ΧΧΧ ΧΧΧΧΧΧΧΧΧ ΤΑ ΠΡΩΤΑΣΦΑΛΙΣΤΗΡΙΑ ΠΟΥ ΔΕΝ ΕΧΟΥΝ ΥΠΟΛΟΙΠΟ ΝΑ ΤΑ ΣΤΕΛΝΟΥΜΕ ΑΠΕΥΘΕΙΑΣ ΣΤΟΥΣ ΠΕΛΑΤΕΣ""
+}";
+            JObject parsed = JObject.Parse(json);
+            var memoryStream = new MemoryStream();
+            var bsonWriter = new BsonWriter(memoryStream);
+            await parsed.WriteToAsync(bsonWriter);
+            await bsonWriter.FlushAsync();
+            memoryStream.Position = 0;
+
+            BsonReader reader = new BsonReader(memoryStream);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("ΕΝΤΟΛΗ ΧΧΧ ΧΧΧΧΧΧΧΧΧ ΤΑ ΠΡΩΤΑΣΦΑΛΙΣΤΗΡΙΑ ΠΟΥ ΔΕΝ ΕΧΟΥΝ ΥΠΟΛΟΙΠΟ ΝΑ ΤΑ ΣΤΕΛΝΟΥΜΕ ΑΠΕΥΘΕΙΑΣ ΣΤΟΥΣ ΠΕΛΑΤΕΣ", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("ΕΝΤΟΛΗ ΧΧΧ ΧΧΧΧΧΧΧΧΧ ΤΑ ΠΡΩΤΑΣΦΑΛΙΣΤΗΡΙΑ ΠΟΥ ΔΕΝ ΕΧΟΥΝ ΥΠΟΛΟΙΠΟ ΝΑ ΤΑ ΣΤΕΛΝΟΥΜΕ ΑΠΕΥΘΕΙΑΣ ΣΤΟΥΣ ΠΕΛΑΤΕΣ", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+        }
+
+        [Test]
+        public async Task UriGuidTimeSpanTestClassEmptyTestAsync()
+        {
+            UriGuidTimeSpanTestClass c1 = new UriGuidTimeSpanTestClass();
+
+            var memoryStream = new MemoryStream();
+            var bsonWriter = new BsonWriter(memoryStream);
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.SerializeAsync(bsonWriter, c1);
+            await bsonWriter.FlushAsync();
+            memoryStream.Position = 0;
+
+            var bsonReader = new BsonReader(memoryStream);
+
+            UriGuidTimeSpanTestClass c2 = await serializer.DeserializeAsync<UriGuidTimeSpanTestClass>(bsonReader);
+            Assert.AreEqual(c1.Guid, c2.Guid);
+            Assert.AreEqual(c1.NullableGuid, c2.NullableGuid);
+            Assert.AreEqual(c1.TimeSpan, c2.TimeSpan);
+            Assert.AreEqual(c1.NullableTimeSpan, c2.NullableTimeSpan);
+            Assert.AreEqual(c1.Uri, c2.Uri);
+        }
+
+        [Test]
+        public async Task UriGuidTimeSpanTestClassValuesTestAsync()
+        {
+            UriGuidTimeSpanTestClass c1 = new UriGuidTimeSpanTestClass
+            {
+                Guid = new Guid("1924129C-F7E0-40F3-9607-9939C531395A"),
+                NullableGuid = new Guid("9E9F3ADF-E017-4F72-91E0-617EBE85967D"),
+                TimeSpan = TimeSpan.FromDays(1),
+                NullableTimeSpan = TimeSpan.FromHours(1),
+                Uri = new Uri("http://testuri.com")
+            };
+
+            var memoryStream = new MemoryStream();
+            var bsonWriter = new BsonWriter(memoryStream);
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.SerializeAsync(bsonWriter, c1);
+            await bsonWriter.FlushAsync();
+            memoryStream.Position = 0;
+
+            var bsonReader = new BsonReader(memoryStream);
+
+            UriGuidTimeSpanTestClass c2 = await serializer.DeserializeAsync<UriGuidTimeSpanTestClass>(bsonReader);
+            Assert.AreEqual(c1.Guid, c2.Guid);
+            Assert.AreEqual(c1.NullableGuid, c2.NullableGuid);
+            Assert.AreEqual(c1.TimeSpan, c2.TimeSpan);
+            Assert.AreEqual(c1.NullableTimeSpan, c2.NullableTimeSpan);
+            Assert.AreEqual(c1.Uri, c2.Uri);
+        }
+
+        [Test]
+        public async Task DeserializeByteArrayWithTypeNameHandlingAsync()
+        {
+            TestObject test = new TestObject("Test", new byte[] { 72, 63, 62, 71, 92, 55 });
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.TypeNameHandling = TypeNameHandling.All;
+
+            byte[] objectBytes;
+            using (MemoryStream bsonStream = new MemoryStream())
+            using (JsonWriter bsonWriter = new BsonWriter(bsonStream))
+            {
+                await serializer.SerializeAsync(bsonWriter, test);
+                await bsonWriter.FlushAsync();
+
+                objectBytes = bsonStream.ToArray();
+            }
+
+            using (MemoryStream bsonStream = new MemoryStream(objectBytes))
+            using (JsonReader bsonReader = new BsonReader(bsonStream))
+            {
+                // Get exception here
+                TestObject newObject = (TestObject)await serializer.DeserializeAsync(bsonReader);
+
+                Assert.AreEqual("Test", newObject.Name);
+                CollectionAssert.AreEquivalent(new byte[] { 72, 63, 62, 71, 92, 55 }, newObject.Data);
+            }
+        }
+        
+        [Test]
+        public async Task Utf8TextAsync()
+        {
+            string badText = System.IO.File.ReadAllText(@"PoisonText.txt");
+            var j = new JObject();
+            j["test"] = badText;
+
+            var memoryStream = new MemoryStream();
+            var bsonWriter = new BsonWriter(memoryStream);
+            await j.WriteToAsync(bsonWriter);
+            await bsonWriter.FlushAsync();
+
+            memoryStream.Position = 0;
+            JObject o = await JObject.LoadAsync(new BsonReader(memoryStream));
+
+            Assert.AreEqual(badText, (string)o["test"]);
+        }
+
+#if !PORTABLE || NETSTANDARD1_1
+        public class BigIntegerTestClass
+        {
+            public BigInteger Blah { get; set; }
+        }
+
+        [Test]
+        public async Task WriteBigIntegerAsync()
+        {
+            BigInteger i = BigInteger.Parse("1999999999999999999999999999999999999999999999999999999999990");
+
+            byte[] data = HexToBytes("2A-00-00-00-05-42-6C-61-68-00-1A-00-00-00-00-F6-FF-FF-FF-FF-FF-FF-1F-B2-21-CB-28-59-84-C4-AE-03-8A-44-34-2F-4C-4E-9E-3E-01-00");
+            MemoryStream ms = new MemoryStream(data);
+
+            BsonReader reader = new BsonReader(ms);
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            BigIntegerTestClass c = await serializer.DeserializeAsync<BigIntegerTestClass>(reader);
+
+            Assert.AreEqual(i, c.Blah);
+        }
+#endif
+
+        public class RegexTestClass
+        {
+            public Regex Regex { get; set; }
+        }
+
+        [Test]
+        public async Task DeserializeRegexNonConverterBsonAsync()
+        {
+            string hex = "46-00-00-00-03-52-65-67-65-78-00-3A-00-00-00-02-70-61-74-74-65-72-6E-00-05-00-00-00-28-68-69-29-00-10-6F-70-74-69-6F-6E-73-00-05-00-00-00-12-6D-61-74-63-68-54-69-6D-65-6F-75-74-00-F0-D8-FF-FF-FF-FF-FF-FF-00-00";
+            byte[] data = HexToBytes(hex);
+            MemoryStream ms = new MemoryStream(data);
+
+            BsonReader reader = new BsonReader(ms);
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            RegexTestClass c = await serializer.DeserializeAsync<RegexTestClass>(reader);
+
+            Assert.AreEqual("(hi)", c.Regex.ToString());
+            Assert.AreEqual(RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase, c.Regex.Options);
+        }
+
+        [Test]
+        public async Task DeserializeRegexBsonAsync()
+        {
+            string hex = "15-00-00-00-0B-52-65-67-65-78-00-28-68-69-29-00-69-75-78-00-00";
+            byte[] data = HexToBytes(hex);
+            MemoryStream ms = new MemoryStream(data);
+
+            BsonReader reader = new BsonReader(ms);
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            RegexTestClass c = await serializer.DeserializeAsync<RegexTestClass>(reader);
+
+            Assert.AreEqual("(hi)", c.Regex.ToString());
+            Assert.AreEqual(RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase, c.Regex.Options);
+        }
+
+        class Zoo
+        {
+            public List<Animal> Animals { get; set; }
+        }
+
+        class Animal
+        {
+            public Animal(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; private set; }
+        }
+
+        class Dog : Animal
+        {
+            public Dog(string name)
+                : base(name)
+            {
+            }
+        }
+
+        class Cat : Animal
+        {
+            public Cat(string name)
+                : base(name)
+            {
+            }
+        }
+
+        public class MyBinder : DefaultSerializationBinder
+        {
+            public bool BindToTypeCalled { get; set; }
+
+#if !(NET20 || NET35)
+            public bool BindToNameCalled { get; set; }
+
+            public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
+            {
+                BindToNameCalled = true;
+                base.BindToName(serializedType, out assemblyName, out typeName);
+            }
+#endif
+
+            public override Type BindToType(string assemblyName, string typeName)
+            {
+                BindToTypeCalled = true;
+                return base.BindToType(assemblyName, typeName);
+            }
+        }
+
+        [Test]
+        public async Task TypeNameHandlingAutoAsync()
+        {
+            var binder = new MyBinder();
+
+            var settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto,
+#pragma warning disable CS0618 // Type or member is obsolete
+                Binder = binder
+#pragma warning restore CS0618 // Type or member is obsolete
+            };
+
+            Zoo zoo = new Zoo
+            {
+                Animals = new List<Animal>
+                {
+                    new Dog("Dog!")
+                }
+            };
+
+            JsonSerializer serializer = JsonSerializer.Create(settings);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter bsonWriter = new BsonWriter(ms);
+            await serializer.SerializeAsync(bsonWriter, zoo);
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = await serializer.DeserializeAsync<Zoo>(new BsonReader(ms));
+
+            Assert.AreEqual(1, deserialized.Animals.Count);
+            Assert.AreEqual("Dog!", deserialized.Animals[0].Name);
+            Assert.IsTrue(deserialized.Animals[0] is Dog);
+
+#if !(NET20 || NET35)
+            Assert.IsTrue(binder.BindToNameCalled);
+#endif
+            Assert.IsTrue(binder.BindToTypeCalled);
+        }
+
+        [Test]
+        public async Task GuidsShouldBeProperlyDeserialisedAsync()
+        {
+            Guid g = new Guid("822C0CE6-CC42-4753-A3C3-26F0684A4B88");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("TheGuid");
+            await writer.WriteValueAsync(g);
+            await writer.WriteEndObjectAsync();
+            await writer.FlushAsync();
+
+            byte[] bytes = ms.ToArray();
+
+            BsonReader reader = new BsonReader(new MemoryStream(bytes));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            Assert.AreEqual(typeof(Guid), reader.ValueType);
+            Assert.AreEqual(g, (Guid)reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.MetadataPropertyHandling = MetadataPropertyHandling.Default;
+            ObjectTestClass b = await serializer.DeserializeAsync<ObjectTestClass>(new BsonReader(new MemoryStream(bytes)));
+            Assert.AreEqual(typeof(Guid), b.TheGuid.GetType());
+            Assert.AreEqual(g, (Guid)b.TheGuid);
+        }
+
+        [Test]
+        public async Task GuidsShouldBeProperlyDeserialised_AsBytesAsync()
+        {
+            Guid g = new Guid("822C0CE6-CC42-4753-A3C3-26F0684A4B88");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("TheGuid");
+            await writer.WriteValueAsync(g);
+            await writer.WriteEndObjectAsync();
+            await writer.FlushAsync();
+
+            byte[] bytes = ms.ToArray();
+
+            BsonReader reader = new BsonReader(new MemoryStream(bytes));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            CollectionAssert.AreEquivalent(g.ToByteArray(), reader.ReadAsBytes());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+            CollectionAssert.AreEquivalent(g.ToByteArray(), (byte[])reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+
+            JsonSerializer serializer = new JsonSerializer();
+            BytesTestClass b = await serializer.DeserializeAsync<BytesTestClass>(new BsonReader(new MemoryStream(bytes)));
+            CollectionAssert.AreEquivalent(g.ToByteArray(), b.TheGuid);
+        }
+
+        [Test]
+        public async Task GuidsShouldBeProperlyDeserialised_AsBytes_ReadAheadAsync()
+        {
+            Guid g = new Guid("822C0CE6-CC42-4753-A3C3-26F0684A4B88");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("TheGuid");
+            await writer.WriteValueAsync(g);
+            await writer.WriteEndObjectAsync();
+            await writer.FlushAsync();
+
+            byte[] bytes = ms.ToArray();
+
+            BsonReader reader = new BsonReader(new MemoryStream(bytes));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            CollectionAssert.AreEquivalent(g.ToByteArray(), reader.ReadAsBytes());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            Assert.AreEqual(typeof(byte[]), reader.ValueType);
+            CollectionAssert.AreEquivalent(g.ToByteArray(), (byte[])reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.MetadataPropertyHandling = MetadataPropertyHandling.ReadAhead;
+            BytesTestClass b = await serializer.DeserializeAsync<BytesTestClass>(new BsonReader(new MemoryStream(bytes)));
+            CollectionAssert.AreEquivalent(g.ToByteArray(), b.TheGuid);
+        }
+
+        [Test]
+        public async Task DeserializeBsonDocumentWithStringAsync()
+        {
+            byte[] data = HexToBytes("10-00-00-00-02-62-00-04-00-00-00-61-62-63-00-00");
+            JsonSerializer serializer = new JsonSerializer();
+            JObject jObj = (JObject) await serializer.DeserializeAsync(new BsonReader(new MemoryStream(data)));
+            string stringValue = jObj.Value<string>("b");
+            Assert.AreEqual("abc", stringValue);
+        }
+
+        [Test]
+        public async Task DeserializeBsonDocumentWithGuidAsync()
+        {
+            byte[] data = HexToBytes("1D-00-00-00-05-62-00-10-00-00-00-04-DF-41-E3-E2-39-EE-BB-4C-86-C0-06-A7-64-33-61-E1-00");
+            JsonSerializer serializer = new JsonSerializer();
+            JObject jObj = (JObject) await serializer.DeserializeAsync(new BsonReader(new MemoryStream(data)));
+            Guid guidValue = jObj.Value<Guid>("b");
+            Assert.AreEqual(new Guid("e2e341df-ee39-4cbb-86c0-06a7643361e1"), guidValue);
+        }
+
+        public class BytesTestClass
+        {
+            public byte[] TheGuid { get; set; }
+        }
+
+        public class ObjectTestClass
+        {
+            public object TheGuid { get; set; }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Bson/BsonWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Bson/BsonWriterAsyncTests.cs
@@ -1,0 +1,841 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+#if !(NET20 || NET35 || PORTABLE) || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Bson;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Tests.TestObjects;
+using System.Globalization;
+using Newtonsoft.Json.Tests.TestObjects.GeoCoding;
+#if NET20
+using Newtonsoft.Json.Utilities.LinqBridge;
+#else
+using System.Linq;
+
+#endif
+
+namespace Newtonsoft.Json.Tests.Bson
+{
+    [TestFixture]
+    public class BsonWriterAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task CloseOutputAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            Assert.IsTrue(ms.CanRead);
+            await writer.CloseAsync();
+            Assert.IsFalse(ms.CanRead);
+
+            ms = new MemoryStream();
+            writer = new BsonWriter(ms) { CloseOutput = false };
+
+            Assert.IsTrue(ms.CanRead);
+            await writer.CloseAsync();
+            Assert.IsTrue(ms.CanRead);
+        }
+
+        [Test]
+        public async Task WriteSingleObjectAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Blah");
+            await writer.WriteValueAsync(1);
+            await writer.WriteEndObjectAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("0F-00-00-00-10-42-6C-61-68-00-01-00-00-00-00", bson);
+        }
+
+#if !NET20
+        [Test]
+        public async Task WriteValuesAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(long.MaxValue);
+            await writer.WriteValueAsync((ulong)long.MaxValue);
+            await writer.WriteValueAsync(int.MaxValue);
+            await writer.WriteValueAsync((uint)int.MaxValue);
+            await writer.WriteValueAsync(byte.MaxValue);
+            await writer.WriteValueAsync(sbyte.MaxValue);
+            await writer.WriteValueAsync('a');
+            await writer.WriteValueAsync(decimal.MaxValue);
+            await writer.WriteValueAsync(double.MaxValue);
+            await writer.WriteValueAsync(float.MaxValue);
+            await writer.WriteValueAsync(true);
+            await writer.WriteValueAsync(new byte[] { 0, 1, 2, 3, 4 });
+            await writer.WriteValueAsync(new DateTimeOffset(2000, 12, 29, 12, 30, 0, TimeSpan.Zero));
+            await writer.WriteValueAsync(new DateTime(2000, 12, 29, 12, 30, 0, DateTimeKind.Utc));
+            await writer.WriteEndAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("8C-00-00-00-12-30-00-FF-FF-FF-FF-FF-FF-FF-7F-12-31-00-FF-FF-FF-FF-FF-FF-FF-7F-10-32-00-FF-FF-FF-7F-10-33-00-FF-FF-FF-7F-10-34-00-FF-00-00-00-10-35-00-7F-00-00-00-02-36-00-02-00-00-00-61-00-01-37-00-00-00-00-00-00-00-F0-45-01-38-00-FF-FF-FF-FF-FF-FF-EF-7F-01-39-00-00-00-00-E0-FF-FF-EF-47-08-31-30-00-01-05-31-31-00-05-00-00-00-00-00-01-02-03-04-09-31-32-00-40-C5-E2-BA-E3-00-00-00-09-31-33-00-40-C5-E2-BA-E3-00-00-00-00", bson);
+        }
+#endif
+
+        [Test]
+        public async Task WriteDoubleAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(99.99d);
+            await writer.WriteEndAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("10-00-00-00-01-30-00-8F-C2-F5-28-5C-FF-58-40-00", bson);
+        }
+
+        [Test]
+        public async Task WriteGuidAsync()
+        {
+            Guid g = new Guid("D821EED7-4B5C-43C9-8AC2-6928E579B705");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(g);
+            await writer.WriteEndAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("1D-00-00-00-05-30-00-10-00-00-00-04-D7-EE-21-D8-5C-4B-C9-43-8A-C2-69-28-E5-79-B7-05-00", bson);
+        }
+
+        [Test]
+        public async Task WriteArrayBsonFromSiteAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync("a");
+            await writer.WriteValueAsync("b");
+            await writer.WriteValueAsync("c");
+            await writer.WriteEndArrayAsync();
+
+            await writer.FlushAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            string expected = "20-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-02-32-00-02-00-00-00-63-00-00";
+            string bson = BytesToHex(ms.ToArray());
+
+            Assert.AreEqual(expected, bson);
+        }
+
+        [Test]
+        public async Task WriteBytesAsync()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("Hello world!");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync("a");
+            await writer.WriteValueAsync("b");
+            await writer.WriteValueAsync(data);
+            await writer.WriteEndArrayAsync();
+
+            await writer.FlushAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            string expected = "2B-00-00-00-02-30-00-02-00-00-00-61-00-02-31-00-02-00-00-00-62-00-05-32-00-0C-00-00-00-00-48-65-6C-6C-6F-20-77-6F-72-6C-64-21-00";
+            string bson = BytesToHex(ms.ToArray());
+
+            Assert.AreEqual(expected, bson);
+
+            BsonReader reader = new BsonReader(new MemoryStream(ms.ToArray()));
+            reader.ReadRootValueAsArray = true;
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(data, (byte[])reader.Value);
+        }
+
+        [Test]
+        public async Task WriteNestedArrayAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartObjectAsync();
+
+            await writer.WritePropertyNameAsync("_id");
+            await writer.WriteValueAsync(HexToBytes("4A-78-93-79-17-22-00-00-00-00-61-CF"));
+
+            await writer.WritePropertyNameAsync("a");
+            await writer.WriteStartArrayAsync();
+            for (int i = 1; i <= 8; i++)
+            {
+                double value = (i != 5)
+                    ? Convert.ToDouble(i)
+                    : 5.78960446186581E+77d;
+
+                await writer.WriteValueAsync(value);
+            }
+            await writer.WriteEndArrayAsync();
+
+            await writer.WritePropertyNameAsync("b");
+            await writer.WriteValueAsync("test");
+
+            await writer.WriteEndObjectAsync();
+
+            await writer.FlushAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            string expected = "87-00-00-00-05-5F-69-64-00-0C-00-00-00-00-4A-78-93-79-17-22-00-00-00-00-61-CF-04-61-00-5D-00-00-00-01-30-00-00-00-00-00-00-00-F0-3F-01-31-00-00-00-00-00-00-00-00-40-01-32-00-00-00-00-00-00-00-08-40-01-33-00-00-00-00-00-00-00-10-40-01-34-00-00-00-00-00-00-00-14-50-01-35-00-00-00-00-00-00-00-18-40-01-36-00-00-00-00-00-00-00-1C-40-01-37-00-00-00-00-00-00-00-20-40-00-02-62-00-05-00-00-00-74-65-73-74-00-00";
+            string bson = BytesToHex(ms.ToArray());
+
+            Assert.AreEqual(expected, bson);
+        }
+
+        [Test]
+        public async Task WriteSerializedStoreAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            Store s1 = new Store();
+            s1.Color = StoreColor.White;
+            s1.Cost = 999.59m;
+            s1.Employees = int.MaxValue - 1;
+            s1.Open = true;
+            s1.product.Add(new Product
+            {
+                ExpiryDate = new DateTime(2000, 9, 28, 3, 59, 58, DateTimeKind.Local),
+                Name = "BSON!",
+                Price = -0.1m,
+                Sizes = new[] { "First", "Second" }
+            });
+            s1.Establised = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.SerializeAsync(writer, s1);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+            Store s2 = (Store)await serializer.DeserializeAsync(reader, typeof(Store));
+
+            Assert.AreNotEqual(s1, s2);
+            Assert.AreEqual(s1.Color, s2.Color);
+            Assert.AreEqual(s1.Cost, s2.Cost);
+            Assert.AreEqual(s1.Employees, s2.Employees);
+            Assert.AreEqual(s1.Escape, s2.Escape);
+            Assert.AreEqual(s1.Establised, s2.Establised);
+            Assert.AreEqual(s1.Mottos.Count, s2.Mottos.Count);
+            Assert.AreEqual(s1.Mottos.First(), s2.Mottos.First());
+            Assert.AreEqual(s1.Mottos.Last(), s2.Mottos.Last());
+            Assert.AreEqual(s1.Open, s2.Open);
+            Assert.AreEqual(s1.product.Count, s2.product.Count);
+            Assert.AreEqual(s1.RoomsPerFloor.Length, s2.RoomsPerFloor.Length);
+            Assert.AreEqual(s1.Symbol, s2.Symbol);
+            Assert.AreEqual(s1.Width, s2.Width);
+
+            MemoryStream ms1 = new MemoryStream();
+            BsonWriter writer1 = new BsonWriter(ms1);
+
+            await serializer.SerializeAsync(writer1, s1);
+
+            CollectionAssert.AreEquivalent(ms.ToArray(), ms1.ToArray());
+        }
+
+        [Test]
+        public async Task WriteLargeStringsAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            StringBuilder largeStringBuilder = new StringBuilder();
+            for (int i = 0; i < 100; i++)
+            {
+                if (i > 0)
+                {
+                    largeStringBuilder.Append("-");
+                }
+
+                largeStringBuilder.Append(i.ToString(CultureInfo.InvariantCulture));
+            }
+            string largeString = largeStringBuilder.ToString();
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync(largeString);
+            await writer.WriteValueAsync(largeString);
+            await writer.WriteEndObjectAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("4E-02-00-00-02-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-22-01-00-00-30-2D-31-2D-32-2D-33-2D-34-2D-35-2D-36-2D-37-2D-38-2D-39-2D-31-30-2D-31-31-2D-31-32-2D-31-33-2D-31-34-2D-31-35-2D-31-36-2D-31-37-2D-31-38-2D-31-39-2D-32-30-2D-32-31-2D-32-32-2D-32-33-2D-32-34-2D-32-35-2D-32-36-2D-32-37-2D-32-38-2D-32-39-2D-33-30-2D-33-31-2D-33-32-2D-33-33-2D-33-34-2D-33-35-2D-33-36-2D-33-37-2D-33-38-2D-33-39-2D-34-30-2D-34-31-2D-34-32-2D-34-33-2D-34-34-2D-34-35-2D-34-36-2D-34-37-2D-34-38-2D-34-39-2D-35-30-2D-35-31-2D-35-32-2D-35-33-2D-35-34-2D-35-35-2D-35-36-2D-35-37-2D-35-38-2D-35-39-2D-36-30-2D-36-31-2D-36-32-2D-36-33-2D-36-34-2D-36-35-2D-36-36-2D-36-37-2D-36-38-2D-36-39-2D-37-30-2D-37-31-2D-37-32-2D-37-33-2D-37-34-2D-37-35-2D-37-36-2D-37-37-2D-37-38-2D-37-39-2D-38-30-2D-38-31-2D-38-32-2D-38-33-2D-38-34-2D-38-35-2D-38-36-2D-38-37-2D-38-38-2D-38-39-2D-39-30-2D-39-31-2D-39-32-2D-39-33-2D-39-34-2D-39-35-2D-39-36-2D-39-37-2D-39-38-2D-39-39-00-00", bson);
+        }
+
+        [Test]
+        public async Task SerializeGoogleGeoCodeAsync()
+        {
+            string json = @"{
+  ""name"": ""1600 Amphitheatre Parkway, Mountain View, CA, USA"",
+  ""Status"": {
+    ""code"": 200,
+    ""request"": ""geocode""
+  },
+  ""Placemark"": [
+    {
+      ""address"": ""1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA"",
+      ""AddressDetails"": {
+        ""Country"": {
+          ""CountryNameCode"": ""US"",
+          ""AdministrativeArea"": {
+            ""AdministrativeAreaName"": ""CA"",
+            ""SubAdministrativeArea"": {
+              ""SubAdministrativeAreaName"": ""Santa Clara"",
+              ""Locality"": {
+                ""LocalityName"": ""Mountain View"",
+                ""Thoroughfare"": {
+                  ""ThoroughfareName"": ""1600 Amphitheatre Pkwy""
+                },
+                ""PostalCode"": {
+                  ""PostalCodeNumber"": ""94043""
+                }
+              }
+            }
+          }
+        },
+        ""Accuracy"": 8
+      },
+      ""Point"": {
+        ""coordinates"": [-122.083739, 37.423021, 0]
+      }
+    }
+  ]
+}";
+
+            GoogleMapGeocoderStructure jsonGoogleMapGeocoder = JsonConvert.DeserializeObject<GoogleMapGeocoderStructure>(json);
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.SerializeAsync(writer, jsonGoogleMapGeocoder);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+            GoogleMapGeocoderStructure bsonGoogleMapGeocoder = (GoogleMapGeocoderStructure)await serializer.DeserializeAsync(reader, typeof(GoogleMapGeocoderStructure));
+
+            Assert.IsNotNull(bsonGoogleMapGeocoder);
+            Assert.AreEqual("1600 Amphitheatre Parkway, Mountain View, CA, USA", bsonGoogleMapGeocoder.Name);
+            Assert.AreEqual("200", bsonGoogleMapGeocoder.Status.Code);
+            Assert.AreEqual("geocode", bsonGoogleMapGeocoder.Status.Request);
+
+            IList<Placemark> placemarks = bsonGoogleMapGeocoder.Placemark;
+            Assert.IsNotNull(placemarks);
+            Assert.AreEqual(1, placemarks.Count);
+
+            Placemark placemark = placemarks[0];
+            Assert.AreEqual("1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA", placemark.Address);
+            Assert.AreEqual(8, placemark.AddressDetails.Accuracy);
+            Assert.AreEqual("US", placemark.AddressDetails.Country.CountryNameCode);
+            Assert.AreEqual("CA", placemark.AddressDetails.Country.AdministrativeArea.AdministrativeAreaName);
+            Assert.AreEqual("Santa Clara", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.SubAdministrativeAreaName);
+            Assert.AreEqual("Mountain View", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.Locality.LocalityName);
+            Assert.AreEqual("1600 Amphitheatre Pkwy", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.Locality.Thoroughfare.ThoroughfareName);
+            Assert.AreEqual("94043", placemark.AddressDetails.Country.AdministrativeArea.SubAdministrativeArea.Locality.PostalCode.PostalCodeNumber);
+            Assert.AreEqual(-122.083739m, placemark.Point.Coordinates[0]);
+            Assert.AreEqual(37.423021m, placemark.Point.Coordinates[1]);
+            Assert.AreEqual(0m, placemark.Point.Coordinates[2]);
+        }
+
+        [Test]
+        public async Task WriteEmptyStringsAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("");
+            await writer.WriteValueAsync("");
+            await writer.WriteEndObjectAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("0C-00-00-00-02-00-01-00-00-00-00-00", bson);
+        }
+
+        [Test]
+        public async Task WriteCommentAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                MemoryStream ms = new MemoryStream();
+                BsonWriter writer = new BsonWriter(ms);
+
+                await writer.WriteStartArrayAsync();
+                await writer.WriteCommentAsync("fail");
+            }, "Cannot write JSON comment as BSON. Path ''.");
+        }
+
+        [Test]
+        public async Task WriteConstructorAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                MemoryStream ms = new MemoryStream();
+                BsonWriter writer = new BsonWriter(ms);
+
+                await writer.WriteStartArrayAsync();
+                await writer.WriteStartConstructorAsync("fail");
+            }, "Cannot write JSON constructor as BSON. Path ''.");
+        }
+
+        [Test]
+        public async Task WriteRawAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                MemoryStream ms = new MemoryStream();
+                BsonWriter writer = new BsonWriter(ms);
+
+                await writer.WriteStartArrayAsync();
+                await writer.WriteRawAsync("fail");
+            }, "Cannot write raw JSON as BSON. Path ''.");
+        }
+
+        [Test]
+        public async Task WriteRawValueAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                MemoryStream ms = new MemoryStream();
+                BsonWriter writer = new BsonWriter(ms);
+
+                await writer.WriteStartArrayAsync();
+                await writer.WriteRawValueAsync("fail");
+            }, "Cannot write raw JSON as BSON. Path ''.");
+        }
+
+        [Test]
+        public async Task ExampleAsync()
+        {
+            Product p = new Product();
+            p.ExpiryDate = DateTime.Parse("2009-04-05T14:45:00Z");
+            p.Name = "Carlos' Spicy Wieners";
+            p.Price = 9.95m;
+            p.Sizes = new[] { "Small", "Medium", "Large" };
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            // serialize product to BSON
+            BsonWriter writer = new BsonWriter(ms);
+            await serializer.SerializeAsync(writer, p);
+
+            Console.WriteLine(BitConverter.ToString(ms.ToArray()));
+            // 7C-00-00-00-02-4E-61-6D-65-00-16-00-00-00-43-61-72-6C-
+            // 6F-73-27-20-53-70-69-63-79-20-57-69-65-6E-65-72-73-00-
+            // 09-45-78-70-69-72-79-44-61-74-65-00-E0-51-BD-76-20-01-
+            // 00-00-01-50-72-69-63-65-00-66-66-66-66-66-E6-23-40-04-
+            // 53-69-7A-65-73-00-2D-00-00-00-02-30-00-06-00-00-00-53-
+            // 6D-61-6C-6C-00-02-31-00-07-00-00-00-4D-65-64-69-75-6D-
+            // 00-02-32-00-06-00-00-00-4C-61-72-67-65-00-00-00
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            // deserialize product from BSON
+            BsonReader reader = new BsonReader(ms);
+            Product deserializedProduct = await serializer.DeserializeAsync<Product>(reader);
+
+            Console.WriteLine(deserializedProduct.Name);
+            // Carlos' Spicy Wieners
+
+            Assert.AreEqual("Carlos' Spicy Wieners", deserializedProduct.Name);
+            Assert.AreEqual(9.95m, deserializedProduct.Price);
+            Assert.AreEqual(3, deserializedProduct.Sizes.Length);
+        }
+
+        [Test]
+        public async Task WriteOidAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            byte[] oid = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("_oid");
+            writer.WriteObjectId(oid);
+            await writer.WriteEndObjectAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("17-00-00-00-07-5F-6F-69-64-00-01-02-03-04-05-06-07-08-09-0A-0B-0C-00", bson);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEquivalent(oid, (byte[])reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+        }
+
+        [Test]
+        public async Task WriteOidPlusContentAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("_id");
+            writer.WriteObjectId(HexToBytes("4ABBED9D1D8B0F0218000001"));
+            await writer.WritePropertyNameAsync("test");
+            await writer.WriteValueAsync("1234£56");
+            await writer.WriteEndObjectAsync();
+
+            byte[] expected = HexToBytes("29000000075F6964004ABBED9D1D8B0F02180000010274657374000900000031323334C2A335360000");
+
+            CollectionAssert.AreEquivalent(expected, ms.ToArray());
+        }
+
+        [Test]
+        public async Task WriteRegexPlusContentAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("regex");
+            writer.WriteRegex("abc", "i");
+            await writer.WritePropertyNameAsync("test");
+            writer.WriteRegex(string.Empty, null);
+            await writer.WriteEndObjectAsync();
+
+            byte[] expected = HexToBytes("1A-00-00-00-0B-72-65-67-65-78-00-61-62-63-00-69-00-0B-74-65-73-74-00-00-00-00");
+
+            CollectionAssert.AreEquivalent(expected, ms.ToArray());
+        }
+
+        [Test]
+        public async Task SerializeEmptyAndNullStringsAsync()
+        {
+            Product p = new Product();
+            p.ExpiryDate = DateTime.Parse("2009-04-05T14:45:00Z");
+            p.Name = null;
+            p.Price = 9.95m;
+            p.Sizes = new[] { "Small", "", null };
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            BsonWriter writer = new BsonWriter(ms);
+            await serializer.SerializeAsync(writer, p);
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            Product deserializedProduct = await serializer.DeserializeAsync<Product>(reader);
+
+            Console.WriteLine(deserializedProduct.Name);
+
+            Assert.AreEqual(null, deserializedProduct.Name);
+            Assert.AreEqual(9.95m, deserializedProduct.Price);
+            Assert.AreEqual(3, deserializedProduct.Sizes.Length);
+            Assert.AreEqual("Small", deserializedProduct.Sizes[0]);
+            Assert.AreEqual("", deserializedProduct.Sizes[1]);
+            Assert.AreEqual(null, deserializedProduct.Sizes[2]);
+        }
+
+        [Test]
+        public async Task WriteReadEmptyAndNullStringsAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync("Content!");
+            await writer.WriteValueAsync("");
+            await writer.WriteValueAsync((string)null);
+            await writer.WriteEndArrayAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("Content!", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Null, reader.TokenType);
+            Assert.AreEqual(null, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task WriteDateTimesAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            writer.DateTimeKindHandling = DateTimeKind.Unspecified;
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Utc));
+            await writer.WriteValueAsync(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Local));
+            await writer.WriteValueAsync(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Unspecified));
+            await writer.WriteEndArrayAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            reader.ReadRootValueAsArray = true;
+            reader.DateTimeKindHandling = DateTimeKind.Utc;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Utc), reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Utc), reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 10, 12, 20, 55, 0, DateTimeKind.Utc), reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task WriteValueOutsideOfObjectOrArrayAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                MemoryStream stream = new MemoryStream();
+
+                using (BsonWriter writer = new BsonWriter(stream))
+                {
+                    await writer.WriteValueAsync("test");
+                    await writer.FlushAsync();
+                }
+            }, "Error writing String value. BSON must start with an Object or Array. Path ''.");
+        }
+
+        [Test]
+        public async Task DateTimeZoneHandlingAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            JsonWriter writer = new BsonWriter(ms)
+            {
+                DateTimeZoneHandling = Json.DateTimeZoneHandling.Utc
+            };
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Unspecified));
+            await writer.WriteEndArrayAsync();
+
+            Assert.AreEqual("10-00-00-00-09-30-00-C8-88-07-6B-DC-00-00-00-00", (BitConverter.ToString(ms.ToArray())));
+        }
+
+        public class RegexTestClass
+        {
+            public Regex Regex { get; set; }
+        }
+
+        [Test]
+        public async Task SerializeDeserializeRegexAsync()
+        {
+            Regex r1 = new Regex("(hi)", RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
+            RegexTestClass c = new RegexTestClass { Regex = r1 };
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            BsonWriter writer = new BsonWriter(ms);
+            await serializer.SerializeAsync(writer, c);
+
+            string hex = BitConverter.ToString(ms.ToArray());
+
+            Assert.AreEqual("15-00-00-00-0B-52-65-67-65-78-00-28-68-69-29-00-69-75-78-00-00", hex);
+
+            JObject o = (JObject)await JObject.ReadFromAsync(new BsonReader(new MemoryStream(ms.ToArray())));
+
+            StringAssert.AreEqual(@"{
+  ""Regex"": ""/(hi)/iux""
+}", o.ToString());
+        }
+
+        [Test]
+        public async Task SerializeByteArray_ErrorWhenTopLevelAsync()
+        {
+            byte[] b = Encoding.UTF8.GetBytes("Hello world");
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            BsonWriter writer = new BsonWriter(ms);
+
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () => { await serializer.SerializeAsync(writer, b); }, "Error writing Binary value. BSON must start with an Object or Array. Path ''.");
+        }
+
+        public class GuidTestClass
+        {
+            public Guid AGuid { get; set; }
+        }
+
+        public class StringTestClass
+        {
+            public string AGuid { get; set; }
+        }
+
+        [Test]
+        public async Task WriteReadGuidAsync()
+        {
+            GuidTestClass c = new GuidTestClass();
+            c.AGuid = new Guid("af45dccf-df13-44fe-82be-6212c09eda84");
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            BsonWriter writer = new BsonWriter(ms);
+
+            await serializer.SerializeAsync(writer, c);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+
+            GuidTestClass c2 = await serializer.DeserializeAsync<GuidTestClass>(reader);
+
+            Assert.AreEqual(c.AGuid, c2.AGuid);
+        }
+
+        [Test]
+        public async Task WriteStringReadGuidAsync()
+        {
+            StringTestClass c = new StringTestClass();
+            c.AGuid = new Guid("af45dccf-df13-44fe-82be-6212c09eda84").ToString();
+
+            MemoryStream ms = new MemoryStream();
+            JsonSerializer serializer = new JsonSerializer();
+
+            BsonWriter writer = new BsonWriter(ms);
+
+            await serializer.SerializeAsync(writer, c);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+
+            GuidTestClass c2 = await serializer.DeserializeAsync<GuidTestClass>(reader);
+
+            Assert.AreEqual(c.AGuid, c2.AGuid.ToString());
+        }
+
+#if !(NET20 || NET35 || PORTABLE || PORTABLE40) || NETSTANDARD1_1
+        [Test]
+        public async Task WriteBigIntegerAsync()
+        {
+            BigInteger i = BigInteger.Parse("1999999999999999999999999999999999999999999999999999999999990");
+
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Blah");
+            await writer.WriteValueAsync(i);
+            await writer.WriteEndObjectAsync();
+
+            string bson = BytesToHex(ms.ToArray());
+            Assert.AreEqual("2A-00-00-00-05-42-6C-61-68-00-1A-00-00-00-00-F6-FF-FF-FF-FF-FF-FF-1F-B2-21-CB-28-59-84-C4-AE-03-8A-44-34-2F-4C-4E-9E-3E-01-00", bson);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            BsonReader reader = new BsonReader(ms);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Bytes, reader.TokenType);
+            CollectionAssert.AreEqual(new byte[] { 246, 255, 255, 255, 255, 255, 255, 31, 178, 33, 203, 40, 89, 132, 196, 174, 3, 138, 68, 52, 47, 76, 78, 158, 62, 1 }, (byte[])reader.Value);
+            Assert.AreEqual(i, new BigInteger((byte[])reader.Value));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+#endif
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Converters/KeyValuePairConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/KeyValuePairConverterTests.cs
@@ -23,7 +23,7 @@ namespace Newtonsoft.Json.Tests.Converters
             DefaultContractResolver contractResolver = new DefaultContractResolver();
             JsonObjectContract contract = (JsonObjectContract)contractResolver.ResolveContract(typeof(KeyValuePair<string, int>));
 
-            Assert.AreEqual(typeof(KeyValuePairConverter), contract.InternalConverter.GetType());
+            Assert.IsTrue(contract.InternalConverter is KeyValuePairConverter);
 
             IList<KeyValuePair<string, int>> values = new List<KeyValuePair<string, int>>
             {

--- a/Src/Newtonsoft.Json.Tests/JsonConvertAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertAsyncTests.cs
@@ -1,0 +1,679 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Text;
+using Newtonsoft.Json.Converters;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests
+{
+    [TestFixture]
+    public class JsonConvertAsyncTests : TestFixtureBase
+    {
+        public class NameTableTestClass
+        {
+            public string Value { get; set; }
+        }
+
+        public class NameTableTestClassConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                reader.Read();
+                reader.Read();
+
+                JsonTextReader jsonTextReader = (JsonTextReader)reader;
+                Assert.IsNotNull(jsonTextReader.NameTable);
+
+                string s = serializer.Deserialize<string>(reader);
+                Assert.AreEqual("hi", s);
+                Assert.IsNotNull(jsonTextReader.NameTable);
+
+                NameTableTestClass o = new NameTableTestClass
+                {
+                    Value = s
+                };
+
+                return o;
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(NameTableTestClass);
+            }
+        }
+
+        [Test]
+        public async Task NameTableTestAsync()
+        {
+            StringReader sr = new StringReader("{'property':'hi'}");
+            JsonTextReader jsonTextReader = new JsonTextReader(sr);
+
+            Assert.IsNull(jsonTextReader.NameTable);
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Converters.Add(new NameTableTestClassConverter());
+            NameTableTestClass o = await serializer.DeserializeAsync<NameTableTestClass>(jsonTextReader);
+
+            Assert.IsNull(jsonTextReader.NameTable);
+            Assert.AreEqual("hi", o.Value);
+        }
+
+        [Test]
+        public async Task DefaultSettings_CreateAsync()
+        {
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented
+                };
+
+                IList<int> l = new List<int> { 1, 2, 3 };
+
+                StringWriter sw = new StringWriter();
+                JsonSerializer serializer = JsonSerializer.CreateDefault();
+                await serializer.SerializeAsync(sw, l);
+
+                StringAssert.AreEqual(@"[
+  1,
+  2,
+  3
+]", sw.ToString());
+
+                sw = new StringWriter();
+                serializer.Formatting = Formatting.None;
+                await serializer.SerializeAsync(sw, l);
+
+                Assert.AreEqual(@"[1,2,3]", sw.ToString());
+
+                sw = new StringWriter();
+                serializer = new JsonSerializer();
+                await serializer.SerializeAsync(sw, l);
+
+                Assert.AreEqual(@"[1,2,3]", sw.ToString());
+
+                sw = new StringWriter();
+                serializer = JsonSerializer.Create();
+                await serializer.SerializeAsync(sw, l);
+
+                Assert.AreEqual(@"[1,2,3]", sw.ToString());
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = null;
+            }
+        }
+
+        [Test]
+        public async Task DefaultSettings_CreateWithSettingsAsync()
+        {
+            try
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented
+                };
+
+                IList<int> l = new List<int> { 1, 2, 3 };
+
+                StringWriter sw = new StringWriter();
+                JsonSerializer serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
+                {
+                    Converters = { new IntConverter() }
+                });
+                await serializer.SerializeAsync(sw, l);
+
+                StringAssert.AreEqual(@"[
+  2,
+  4,
+  6
+]", sw.ToString());
+
+                sw = new StringWriter();
+                serializer.Converters.Clear();
+                await serializer.SerializeAsync(sw, l);
+
+                StringAssert.AreEqual(@"[
+  1,
+  2,
+  3
+]", sw.ToString());
+
+                sw = new StringWriter();
+                serializer = JsonSerializer.Create(new JsonSerializerSettings { Formatting = Formatting.Indented });
+                await serializer.SerializeAsync(sw, l);
+
+                StringAssert.AreEqual(@"[
+  1,
+  2,
+  3
+]", sw.ToString());
+            }
+            finally
+            {
+                JsonConvert.DefaultSettings = null;
+            }
+        }
+
+        public class IntConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                int i = (int)value;
+                writer.WriteValue(i * 2);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(int);
+            }
+        }
+
+        [Test]
+        public async Task WriteDateTimeAsync()
+        {
+            await Task.WhenAll(
+                TestDateTimeFormatAsync(DateTime.MaxValue),
+                TestDateTimeFormatAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Local)),
+                TestDateTimeFormatAsync(new DateTime(2000, 1, 1, 1, 1, 1, 999, DateTimeKind.Local)),
+                TestDateTimeFormatAsync(new DateTime(634663873826822481, DateTimeKind.Local)),
+                TestDateTimeFormatAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Unspecified)),
+                TestDateTimeFormatAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc)),
+                TestDateTimeFormatAsync(new DateTime(621355968000000000, DateTimeKind.Utc)),
+                TestDateTimeFormatAsync(DateTime.MinValue),
+                TestDateTimeFormatAsync(default(DateTime)),
+                TestDateTimeFormatAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero)),
+                TestDateTimeFormatAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.FromHours(1))),
+                TestDateTimeFormatAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.FromHours(1.5))),
+                TestDateTimeFormatAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.FromHours(13))),
+                TestDateTimeFormatAsync(new DateTimeOffset(634663873826822481, TimeSpan.Zero)),
+                TestDateTimeFormatAsync(DateTimeOffset.MinValue),
+                TestDateTimeFormatAsync(DateTimeOffset.MaxValue),
+                TestDateTimeFormatAsync(default(DateTimeOffset))
+                );
+        }
+
+        private static async Task TestDateTimeFormatAsync<T>(T value)
+        {
+            JsonConverter converter = new IsoDateTimeConverter();
+            string date = await WriteAsync(value, converter);
+
+            Console.WriteLine(converter.GetType().Name + ": " + date);
+
+            T parsed = await ReadAsync<T>(date, converter);
+
+            try
+            {
+                Assert.AreEqual(value, parsed);
+            }
+            catch (Exception)
+            {
+                // JavaScript ticks aren't as precise, recheck after rounding
+                long valueTicks = GetTicks(value);
+                long parsedTicks = GetTicks(parsed);
+
+                valueTicks = valueTicks / 10000 * 10000;
+
+                Assert.AreEqual(valueTicks, parsedTicks);
+            }
+        }
+
+        public static long GetTicks(object value)
+        {
+            return value is DateTime ? ((DateTime)value).Ticks : ((DateTimeOffset)value).Ticks;
+        }
+
+        public static async Task<string> WriteAsync(object value, JsonConverter converter)
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            await converter.WriteJsonAsync(writer, value, null);
+
+            await writer.FlushAsync();
+            return sw.ToString();
+        }
+
+        public static async Task<T> ReadAsync<T>(string text, JsonConverter converter)
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(text));
+            await reader.ReadAsStringAsync();
+
+            return (T)await converter.ReadJsonAsync(reader, typeof(T), null, null);
+        }
+
+        [Test]
+        public async Task MaximumDateTimeOffsetLengthAsync()
+        {
+            DateTimeOffset dt = new DateTimeOffset(2000, 12, 31, 20, 59, 59, new TimeSpan(0, 11, 33, 0, 0));
+            dt = dt.AddTicks(9999999);
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+
+            await writer.WriteValueAsync(dt);
+            await writer.FlushAsync();
+
+            Assert.AreEqual(@"""2000-12-31T20:59:59.9999999+11:33""", sw.ToString());
+        }
+
+        [Test]
+        public async Task MaximumDateTimeLengthAsync()
+        {
+            DateTime dt = new DateTime(2000, 12, 31, 20, 59, 59, DateTimeKind.Local);
+            dt = dt.AddTicks(9999999);
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+
+            await writer.WriteValueAsync(dt);
+            await writer.FlushAsync();
+        }
+
+        [Test]
+        public async Task MaximumDateTimeMicrosoftDateFormatLengthAsync()
+        {
+            DateTime dt = DateTime.MaxValue;
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            writer.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
+
+            await writer.WriteValueAsync(dt);
+            await writer.FlushAsync();
+        }
+
+        [Test]
+        public async Task ParseIsoDateAsync()
+        {
+            StringReader sr = new StringReader(@"""2014-02-14T14:25:02-13:00""");
+
+            JsonReader jsonReader = new JsonTextReader(sr);
+
+            Assert.IsTrue(await jsonReader.ReadAsync());
+            Assert.AreEqual(typeof(DateTime), jsonReader.ValueType);
+        }
+
+        //[Test]
+        public async Task StackOverflowTestAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            int depth = 900;
+            for (int i = 0; i < depth; i++)
+            {
+                sb.Append("{'A':");
+            }
+
+            // invalid json
+            sb.Append("{***}");
+            for (int i = 0; i < depth; i++)
+            {
+                sb.Append("}");
+            }
+
+            string json = sb.ToString();
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.DeserializeAsync<Nest>(new JsonTextReader(new StringReader(json)));
+        }
+
+        public class Nest
+        {
+            public Nest A { get; set; }
+        }
+
+        public class ClobberMyProperties
+        {
+            [JsonConverter(typeof(ClobberingJsonConverter), "Uno", 1)]
+            public string One { get; set; }
+
+            [JsonConverter(typeof(ClobberingJsonConverter), "Dos", 2)]
+            public string Two { get; set; }
+
+            [JsonConverter(typeof(ClobberingJsonConverter), "Tres")]
+            public string Three { get; set; }
+
+            public string Four { get; set; }
+        }
+
+        public class ClobberingJsonConverter : JsonConverter
+        {
+            public string ClobberValueString { get; private set; }
+
+            public int ClobberValueInt { get; private set; }
+
+            public ClobberingJsonConverter(string clobberValueString, int clobberValueInt)
+            {
+                ClobberValueString = clobberValueString;
+                ClobberValueInt = clobberValueInt;
+            }
+
+            public ClobberingJsonConverter(string clobberValueString)
+                : this(clobberValueString, 1337)
+            {
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue(ClobberValueString + "-" + ClobberValueInt.ToString() + "-" + value.ToString());
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(string);
+            }
+        }
+
+        public class IncorrectJsonConvertParameters
+        {
+            /// <summary>
+            /// We deliberately use the wrong number/type of arguments for ClobberingJsonConverter to ensure an 
+            /// exception is thrown.
+            /// </summary>
+            [JsonConverter(typeof(ClobberingJsonConverter), "Uno", "Blammo")]
+            public string One { get; set; }
+        }
+        
+        public class OverloadsJsonConverterer : JsonConverter
+        {
+            private readonly string _type;
+            
+            // constructor with Type argument
+
+            public OverloadsJsonConverterer(Type typeParam)
+            {
+                _type = "Type";
+            }
+            
+            public OverloadsJsonConverterer(object objectParam)
+            {
+                _type = string.Format("object({0})", objectParam.GetType().FullName);
+            }
+
+            // primitive type conversions
+
+            public OverloadsJsonConverterer(byte byteParam)
+            {
+                _type = "byte";
+            }
+
+            public OverloadsJsonConverterer(short shortParam)
+            {
+                _type = "short";
+            }
+
+            public OverloadsJsonConverterer(int intParam)
+            {
+                _type = "int";
+            }
+
+            public OverloadsJsonConverterer(long longParam)
+            {
+                _type = "long";
+            }
+
+            public OverloadsJsonConverterer(double doubleParam)
+            {
+                _type = "double";
+            }
+
+            // params argument
+
+            public OverloadsJsonConverterer(params int[] intParams)
+            {
+                _type = "int[]";
+            }
+
+            public OverloadsJsonConverterer(bool[] intParams)
+            {
+                _type = "bool[]";
+            }
+
+            // closest type resolution
+
+            public OverloadsJsonConverterer(IEnumerable<string> iEnumerableParam)
+            {
+                _type = "IEnumerable<string>";
+            }
+
+            public OverloadsJsonConverterer(IList<string> iListParam)
+            {
+                _type = "IList<string>";
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue(_type);
+            }
+            
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(int);
+            }
+            
+        }
+
+        public class OverloadWithTypeParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), typeof(int))]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithUnhandledParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), "str")]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithIntParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithUIntParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1U)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithLongParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1L)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithULongParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1UL)]
+            public int Overload { get; set; }
+        }
+        
+        public class OverloadWithShortParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), (short)1)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithUShortParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), (ushort)1)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithSByteParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), (sbyte)1)]
+            public int Overload { get; set; }
+        }
+        
+        public class OverloadWithByteParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), (byte)1)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithCharParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 'a')]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithBoolParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), true)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithFloatParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1.5f)]
+            public int Overload { get; set; }
+        }
+
+        public class OverloadWithDoubleParameter
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), 1.5)]
+            public int Overload { get; set; }
+        }
+        
+        public class OverloadWithArrayParameters
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), new int[] { 1, 2, 3 })]
+            public int WithParams { get; set; }
+
+            [JsonConverter(typeof(OverloadsJsonConverterer), new bool[] { true, false })]
+            public int WithoutParams { get; set; }
+        }
+
+        public class OverloadWithBaseType
+        {
+            [JsonConverter(typeof(OverloadsJsonConverterer), new object[] { new string[] { "a", "b", "c" } })]
+            public int Overload { get; set; }
+        }
+
+        public class Measurements
+        {
+            [JsonProperty(ItemConverterType = typeof(RoundingJsonConverter))]
+            public List<double> Positions { get; set; }
+
+            [JsonProperty(ItemConverterType = typeof(RoundingJsonConverter), ItemConverterParameters = new object[] { 0, MidpointRounding.ToEven })]
+            public List<double> Loads { get; set; }
+
+            [JsonConverter(typeof(RoundingJsonConverter), 4)]
+            public double Gain { get; set; }
+        }
+
+        public class RoundingJsonConverter : JsonConverter
+        {
+            int _precision;
+            MidpointRounding _rounding;
+
+            public RoundingJsonConverter()
+                : this(2)
+            {
+            }
+
+            public RoundingJsonConverter(int precision)
+                : this(precision, MidpointRounding.AwayFromZero)
+            {
+            }
+
+            public RoundingJsonConverter(int precision, MidpointRounding rounding)
+            {
+                _precision = precision;
+                _rounding = rounding;
+            }
+
+            public override bool CanRead
+            {
+                get { return false; }
+            }
+
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(double);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue(Math.Round((double)value, _precision, _rounding));
+            }
+        }
+
+        public class GenericBaseClass<O, T>
+        {
+            public virtual T Data { get; set; }
+        }
+
+        public class GenericIntermediateClass<O> : GenericBaseClass<O, string>
+        {
+            public override string Data { get; set; }
+        }
+
+        public class NonGenericChildClass : GenericIntermediateClass<int>
+        {
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingAsyncTests.cs
@@ -1,0 +1,1006 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects.JsonTextReaderTests;
+
+namespace Newtonsoft.Json.Tests.JsonTextReaderTests
+{
+    [TestFixture]
+#if !DNXCORE50
+    [Category("JsonTextReaderTests")]
+#endif
+    public class ExceptionHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task UnexpectedEndAfterReadingNAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("n"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Unexpected end when reading JSON. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndAfterReadingNuAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("nu"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Unexpected end when reading JSON. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndAfterReadingNeAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("ne"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Unexpected end when reading JSON. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndOfHexAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"'h\u123"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end while parsing unicode character. Path '', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndOfControlCharacterAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"'h\"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unterminated string. Expected delimiter: '. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task ReadInvalidNonBase10NumberAsync()
+        {
+            string json = "0aq2dun13.hod";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected character encountered while parsing number: q. Path '', line 1, position 2.");
+
+            reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDecimalAsync(); }, "Unexpected character encountered while parsing number: q. Path '', line 1, position 2.");
+
+            reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsInt32Async(); }, "Unexpected character encountered while parsing number: q. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task ThrowErrorWhenParsingUnquoteStringThatStartsWithNEAsync()
+        {
+            const string json = @"{ ""ItemName"": ""value"", ""u"":netanelsalinger,""r"":9 }";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected content while parsing JSON. Path 'u', line 1, position 29.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndOfStringAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader("'hi"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unterminated string. Expected delimiter: '. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task UnexpectedEndTokenWhenParsingOddEndTokenAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"{}}"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Additional text encountered after finished reading JSON content: }. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task ResetJsonTextReaderErrorCountAsync()
+        {
+            ToggleReaderError toggleReaderError = new ToggleReaderError(new StringReader("{'first':1,'second':2,'third':3}"));
+            JsonTextReader jsonTextReader = new JsonTextReader(toggleReaderError);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+
+            toggleReaderError.Error = true;
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+
+            toggleReaderError.Error = false;
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual("first", jsonTextReader.Value);
+
+            toggleReaderError.Error = true;
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+
+            toggleReaderError.Error = false;
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(1L, jsonTextReader.Value);
+
+            toggleReaderError.Error = true;
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => await jsonTextReader.ReadAsync(), "Read error");
+
+            toggleReaderError.Error = false;
+        }
+
+        [Test]
+        public async Task MatchWithInsufficentCharactersAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"nul"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end when reading JSON. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task MatchWithWrongCharactersAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"nulz"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Error parsing null value. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task MatchWithNoTrailingSeparatorAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"nullz"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Error parsing null value. Path '', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task UnclosedCommentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"/* sdf"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end while parsing comment. Path '', line 1, position 6.");
+        }
+
+        [Test]
+        public async Task BadCommentStartAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"/sdf"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Error parsing comment. Expected: *, got s. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task MissingColonAsync()
+        {
+            string json = @"{
+    ""A"" : true,
+    ""B"" """;
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Boolean, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, @"Invalid character after parsing property name. Expected ':' but got: "". Path 'A', line 3, position 8.");
+        }
+
+        [Test]
+        public async Task ParseConstructorWithBadCharacterAsync()
+        {
+            string json = "new Date,()";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { Assert.IsTrue(await reader.ReadAsync()); }, "Unexpected character while parsing constructor: ,. Path '', line 1, position 8.");
+        }
+
+        [Test]
+        public async Task ParseConstructorWithUnexpectedEndAsync()
+        {
+            string json = "new Dat";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end while parsing constructor. Path '', line 1, position 7.");
+        }
+
+        [Test]
+        public async Task ParseConstructorWithUnexpectedCharacterAsync()
+        {
+            string json = "new Date !";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected character while parsing constructor: !. Path '', line 1, position 9.");
+        }
+
+        [Test]
+        public async Task ParseAdditionalContent_CommaAsync()
+        {
+            string json = @"[
+""Small"",
+""Medium"",
+""Large""
+],";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                while (await reader.ReadAsync())
+                {
+                }
+            }, "Additional text encountered after finished reading JSON content: ,. Path '', line 5, position 1.");
+        }
+
+        [Test]
+        public async Task ParseAdditionalContent_TextAsync()
+        {
+            string json = @"[
+""Small"",
+""Medium"",
+""Large""
+]content";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+#if DEBUG
+            reader.SetCharBuffer(new char[2]);
+#endif
+
+            await reader.ReadAsync();
+            Assert.AreEqual(1, reader.LineNumber);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(2, reader.LineNumber);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(3, reader.LineNumber);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(4, reader.LineNumber);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(5, reader.LineNumber);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Additional text encountered after finished reading JSON content: c. Path '', line 5, position 1.");
+        }
+
+        [Test]
+        public async Task ParseAdditionalContent_WhitespaceThenTextAsync()
+        {
+            string json = @"'hi' a";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                while (await reader.ReadAsync())
+                {
+                }
+            }, "Additional text encountered after finished reading JSON content: a. Path '', line 1, position 5.");
+        }
+
+        [Test]
+        public async Task ParseIncompleteCommentSeparatorAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("true/"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Error parsing boolean value. Path '', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task ReadBadCharInArrayAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"[}"));
+
+            await reader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected character encountered while parsing value: }. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsBytesNoContentWrappedObjectAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected end when reading JSON. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadBytesEmptyWrappedObjectAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{}"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Error reading bytes. Unexpected token: StartObject. Path '', line 1, position 2." );
+        }
+
+        [Test]
+        public async Task ReadIntegerWithErrorAsync()
+        {
+            string json = @"{
+    ChildId: 333333333333333333333333333333333333333
+}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, jsonTextReader.TokenType);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, jsonTextReader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await jsonTextReader.ReadAsInt32Async(), "JSON integer 333333333333333333333333333333333333333 is too large or small for an Int32. Path 'ChildId', line 2, position 52.");
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, jsonTextReader.TokenType);
+
+            Assert.IsFalse(await jsonTextReader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadIntegerWithErrorInArrayAsync()
+        {
+            string json = @"[
+  333333333333333333333333333333333333333,
+  3.3,
+  ,
+  0f
+]";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, jsonTextReader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await jsonTextReader.ReadAsInt32Async(), "JSON integer 333333333333333333333333333333333333333 is too large or small for an Int32. Path '[0]', line 2, position 41.");
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await jsonTextReader.ReadAsInt32Async(), "Input string '3.3' is not a valid integer. Path '[1]', line 3, position 5.");
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await jsonTextReader.ReadAsInt32Async(), "Unexpected character encountered while parsing value: ,. Path '[2]', line 4, position 3.");
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await jsonTextReader.ReadAsInt32Async(), "Input string '0f' is not a valid integer. Path '[3]', line 5, position 4.");
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, jsonTextReader.TokenType);
+
+            Assert.IsFalse(await jsonTextReader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadBytesWithErrorAsync()
+        {
+            string json = @"{
+    ChildId: '123'
+}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, jsonTextReader.TokenType);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, jsonTextReader.TokenType);
+
+            try
+            {
+                await jsonTextReader.ReadAsBytesAsync();
+            }
+            catch (FormatException)
+            {
+            }
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, jsonTextReader.TokenType);
+
+            Assert.IsFalse(await jsonTextReader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadInt32OverflowAsync()
+        {
+            long i = int.MaxValue;
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(i.ToString(CultureInfo.InvariantCulture)));
+            await reader.ReadAsync();
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            for (int j = 1; j < 1000; j++)
+            {
+                long total = j + i;
+                await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+                {
+                    reader = new JsonTextReader(new StringReader(total.ToString(CultureInfo.InvariantCulture)));
+                    await reader.ReadAsInt32Async();
+                }, "JSON integer " + total + " is too large or small for an Int32. Path '', line 1, position 10.");
+            }
+        }
+
+        [Test]
+        public async Task ReadInt32Overflow_NegativeAsync()
+        {
+            long i = int.MinValue;
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(i.ToString(CultureInfo.InvariantCulture)));
+            await reader.ReadAsync();
+            Assert.AreEqual(typeof(long), reader.ValueType);
+            Assert.AreEqual(i, reader.Value);
+
+            for (int j = 1; j < 1000; j++)
+            {
+                long total = -j + i;
+                await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+                {
+                    reader = new JsonTextReader(new StringReader(total.ToString(CultureInfo.InvariantCulture)));
+                    await reader.ReadAsInt32Async();
+                }, "JSON integer " + total + " is too large or small for an Int32. Path '', line 1, position 11.");
+            }
+        }
+
+#if !PORTABLE || NETSTANDARD1_1
+        [Test]
+        public async Task ReadInt64OverflowAsync()
+        {
+            BigInteger i = new BigInteger(long.MaxValue);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(i.ToString(CultureInfo.InvariantCulture)));
+            await reader.ReadAsync();
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            for (int j = 1; j < 1000; j++)
+            {
+                BigInteger total = i + j;
+
+                reader = new JsonTextReader(new StringReader(total.ToString(CultureInfo.InvariantCulture)));
+                await reader.ReadAsync();
+
+                Assert.AreEqual(typeof(BigInteger), reader.ValueType);
+            }
+        }
+
+        [Test]
+        public async Task ReadInt64Overflow_NegativeAsync()
+        {
+            BigInteger i = new BigInteger(long.MinValue);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(i.ToString(CultureInfo.InvariantCulture)));
+            await reader.ReadAsync();
+            Assert.AreEqual(typeof(long), reader.ValueType);
+
+            for (int j = 1; j < 1000; j++)
+            {
+                BigInteger total = i + -j;
+
+                reader = new JsonTextReader(new StringReader(total.ToString(CultureInfo.InvariantCulture)));
+                await reader.ReadAsync();
+
+                Assert.AreEqual(typeof(BigInteger), reader.ValueType);
+            }
+        }
+#endif
+
+        [Test]
+        public async Task ReadAsString_Null_AdditionalBadDataAsync()
+        {
+            string json = @"nullllll";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsStringAsync(); }, "Error parsing null value. Path '', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_AdditionalBadDataAsync()
+        {
+            string json = @"falseeeee";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBooleanAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 1, position 5.");
+        }
+
+        [Test]
+        public async Task ReadAsString_AdditionalBadDataAsync()
+        {
+            string json = @"falseeeee";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsStringAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 1, position 5.");
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_UnexpectedEndAsync()
+        {
+            string json = @"tru";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBooleanAsync(); }, "Unexpected end when reading JSON. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_BadDataAsync()
+        {
+            string json = @"pie";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBooleanAsync(); }, "Unexpected character encountered while parsing value: p. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsString_BadDataAsync()
+        {
+            string json = @"pie";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsStringAsync(); }, "Unexpected character encountered while parsing value: p. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsDouble_BadDataAsync()
+        {
+            string json = @"pie";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDoubleAsync(); }, "Unexpected character encountered while parsing value: p. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsDouble_BooleanAsync()
+        {
+            string json = @"true";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDoubleAsync(); }, "Unexpected character encountered while parsing value: t. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsBytes_BadDataAsync()
+        {
+            string json = @"pie";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected character encountered while parsing value: p. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsBytesIntegerArrayWithNoEndAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"[1"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected end when reading bytes. Path '[0]', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task ReadAsBytesArrayWithBadContentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"[1.0]"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected token when reading bytes: Float. Path '[0]', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task ReadAsBytesBadContentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"new Date()"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task ReadAsBytes_CommaErrorsAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("[,'']"));
+            await reader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsBytesAsync();
+            }, "Unexpected character encountered while parsing value: ,. Path '[0]', line 1, position 2.");
+
+            CollectionAssert.AreEquivalent(new byte[0], await reader.ReadAsBytesAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadAsBytes_InvalidEndArrayAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("]"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsBytesAsync();
+            }, "Unexpected character encountered while parsing value: ]. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsBytes_CommaErrors_MultipleAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("['',,'']"));
+            await reader.ReadAsync();
+            CollectionAssert.AreEquivalent(new byte[0], await reader.ReadAsBytesAsync());
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsBytesAsync();
+            }, "Unexpected character encountered while parsing value: ,. Path '[1]', line 1, position 5.");
+
+            CollectionAssert.AreEquivalent(new byte[0], await reader.ReadAsBytesAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadBytesWithBadCharacterAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"true"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unexpected character encountered while parsing value: t. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadBytesWithUnexpectedEndAsync()
+        {
+            string helloWorld = "Hello world!";
+            byte[] helloWorldData = Encoding.UTF8.GetBytes(helloWorld);
+
+            JsonReader reader = new JsonTextReader(new StringReader(@"'" + Convert.ToBase64String(helloWorldData)));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsBytesAsync(); }, "Unterminated string. Expected delimiter: '. Path '', line 1, position 17.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_BadDataAsync()
+        {
+            string json = @"pie";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDateTimeAsync(); }, "Unexpected character encountered while parsing value: p. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_BooleanAsync()
+        {
+            string json = @"true";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDateTimeAsync(); }, "Unexpected character encountered while parsing value: t. Path '', line 1, position 1.");
+        }
+
+#if !NET20
+        [Test]
+        public async Task ReadAsDateTimeOffsetBadContentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"new Date()"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDateTimeOffsetAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 1, position 2.");
+        }
+#endif
+
+        [Test]
+        public async Task ReadAsDecimalBadContentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"new Date()"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDecimalAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task ReadAsDecimalBadContent_SecondLineAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"
+new Date()"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDecimalAsync(); }, "Unexpected character encountered while parsing value: e. Path '', line 2, position 2.");
+        }
+
+        [Test]
+        public async Task ReadInt32WithBadCharacterAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"true"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsInt32Async(); }, "Unexpected character encountered while parsing value: t. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadNumberValue_CommaErrorsAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("[,1]"));
+            await reader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsInt32Async();
+            }, "Unexpected character encountered while parsing value: ,. Path '[0]', line 1, position 2.");
+
+            Assert.AreEqual(1, await reader.ReadAsInt32Async());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadNumberValue_InvalidEndArrayAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("]"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsInt32Async();
+            }, "Unexpected character encountered while parsing value: ]. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadNumberValue_CommaErrors_MultipleAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("[1,,1]"));
+            await reader.ReadAsync();
+            await reader.ReadAsInt32Async();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsInt32Async();
+            }, "Unexpected character encountered while parsing value: ,. Path '[1]', line 1, position 4.");
+
+            Assert.AreEqual(1, await reader.ReadAsInt32Async());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadAsString_UnexpectedEndAsync()
+        {
+            string json = @"tru";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsStringAsync(); }, "Unexpected end when reading JSON. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task ReadAsString_Null_UnexpectedEndAsync()
+        {
+            string json = @"nul";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsStringAsync(); }, "Unexpected end when reading JSON. Path '', line 1, position 3.");
+        }
+
+        [Test]
+        public async Task ReadStringValue_InvalidEndArrayAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("]"));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsDateTimeAsync();
+            }, "Unexpected character encountered while parsing value: ]. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ReadStringValue_CommaErrorsAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("[,'']"));
+            await reader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsStringAsync();
+            }, "Unexpected character encountered while parsing value: ,. Path '[0]', line 1, position 2.");
+
+            Assert.AreEqual(string.Empty, await reader.ReadAsStringAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadStringValue_CommaErrors_MultipleAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("['',,'']"));
+            await reader.ReadAsync();
+            await reader.ReadAsInt32Async();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsStringAsync();
+            }, "Unexpected character encountered while parsing value: ,. Path '[1]', line 1, position 5.");
+
+            Assert.AreEqual(string.Empty, await reader.ReadAsStringAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ReadStringValue_Numbers_NotStringAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("[56,56]"));
+            await reader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsDateTimeAsync();
+            }, "Unexpected character encountered while parsing value: 5. Path '', line 1, position 2.");
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsDateTimeAsync();
+            }, "Unexpected character encountered while parsing value: 6. Path '', line 1, position 3.");
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                await reader.ReadAsDateTimeAsync();
+            }, "Unexpected character encountered while parsing value: ,. Path '[0]', line 1, position 4.");
+
+            Assert.AreEqual(56, await reader.ReadAsInt32Async());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ErrorReadingCommentAsync()
+        {
+            string json = @"/";
+
+            JsonTextReader reader = new JsonTextReader(new StreamReader(new SlowStream(json, new UTF8Encoding(false), 1)));
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end while parsing comment. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task EscapedPathInExceptionMessageAsync()
+        {
+            string json = @"{
+  ""frameworks"": {
+    ""dnxcore50"": {
+      ""dependencies"": {
+        ""System.Xml.ReaderWriter"": {
+          ""source"": !!! !!!
+        }
+      }
+    }
+  }
+}";
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(
+                async () =>
+                {
+                    JsonTextReader reader = new JsonTextReader(new StringReader(json));
+                    while (await reader.ReadAsync())
+                    {
+                    }
+                },
+                "Unexpected character encountered while parsing value: !. Path 'frameworks.dnxcore50.dependencies['System.Xml.ReaderWriter'].source', line 6, position 20.");
+        }
+
+        [Test]
+        public async Task MaxDepthAsync()
+        {
+            string json = "[[]]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json))
+            {
+                MaxDepth = 1
+            };
+
+            Assert.IsTrue(await reader.ReadAsync());
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { Assert.IsTrue(await reader.ReadAsync()); }, "The reader's MaxDepth of 1 has been exceeded. Path '[0]', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task MaxDepthDoesNotRecursivelyErrorAsync()
+        {
+            string json = "[[[[]]],[[]]]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json))
+            {
+                MaxDepth = 1
+            };
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(0, reader.Depth);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { Assert.IsTrue(await reader.ReadAsync()); }, "The reader's MaxDepth of 1 has been exceeded. Path '[0]', line 1, position 2.");
+            Assert.AreEqual(1, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(2, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(3, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(3, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(2, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(1, reader.Depth);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { Assert.IsTrue(await reader.ReadAsync()); }, "The reader's MaxDepth of 1 has been exceeded. Path '[1]', line 1, position 9.");
+            Assert.AreEqual(1, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(2, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(2, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(1, reader.Depth);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(0, reader.Depth);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task UnexpectedEndWhenParsingUnquotedPropertyAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"{aww"));
+            Assert.IsTrue(await reader.ReadAsync());
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsync(); }, "Unexpected end while parsing unquoted property name. Path '', line 1, position 4.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/FloatAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/FloatAsyncTests.cs
@@ -1,0 +1,352 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.JsonTextReaderTests
+{
+    [TestFixture]
+#if !DNXCORE50
+    [Category("JsonTextReaderTests")]
+#endif
+    public class FloatAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task Float_ReadAsString_ExactAsync()
+        {
+            const string testJson = "{float: 0.0620}";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(testJson));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            string s = await reader.ReadAsStringAsync();
+            Assert.AreEqual("0.0620", s);
+        }
+
+        [Test]
+        public async Task Float_NaN_ReadAsync()
+        {
+            const string testJson = "{float: NaN}";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(testJson));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(double.NaN, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task Float_NaN_ReadAsInt32Async()
+        {
+            const string testJson = "{float: NaN}";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(testJson));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await  reader.ReadAsInt32Async(), "Cannot read NaN value. Path 'float', line 1, position 11.");
+        }
+
+        [Test]
+        public async Task Float_NaNAndInifinity_ReadAsDoubleAsync()
+        {
+            const string testJson = @"[
+  NaN,
+  Infinity,
+  -Infinity
+]"; ;
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(testJson));
+
+            Assert.IsTrue(await reader.ReadAsync());
+
+            Assert.AreEqual(double.NaN, reader.ReadAsDouble());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(double.NaN, reader.Value);
+
+            Assert.AreEqual(double.PositiveInfinity, reader.ReadAsDouble());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(double.PositiveInfinity, reader.Value);
+
+            Assert.AreEqual(double.NegativeInfinity, reader.ReadAsDouble());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(double.NegativeInfinity, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task Float_NaNAndInifinity_ReadAsStringAsync()
+        {
+            const string testJson = @"[
+  NaN,
+  Infinity,
+  -Infinity
+]"; ;
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(testJson));
+
+            Assert.IsTrue(await reader.ReadAsync());
+
+            Assert.AreEqual(JsonConvert.NaN, reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(JsonConvert.NaN, reader.Value);
+
+            Assert.AreEqual(JsonConvert.PositiveInfinity, reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(JsonConvert.PositiveInfinity, reader.Value);
+
+            Assert.AreEqual(JsonConvert.NegativeInfinity, reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(JsonConvert.NegativeInfinity, reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task FloatParseHandling_ReadAsStringAsync()
+        {
+            string json = "[9223372036854775807, 1.7976931348623157E+308, 792281625142643375935439503.35, 792281625142643375935555555555555555555555555555555555555555555555555439503.35]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.AreEqual("9223372036854775807", reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("9223372036854775807", reader.Value);
+
+            Assert.AreEqual("1.7976931348623157E+308", reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("1.7976931348623157E+308", reader.Value);
+
+            Assert.AreEqual("792281625142643375935439503.35", reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("792281625142643375935439503.35", reader.Value);
+
+            Assert.AreEqual("792281625142643375935555555555555555555555555555555555555555555555555439503.35", reader.ReadAsString());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual("792281625142643375935555555555555555555555555555555555555555555555555439503.35", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task FloatParseHandlingAsync()
+        {
+            string json = "[1.0,1,9.9,1E-06]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(1.0m, reader.Value);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(1L, reader.Value);
+            Assert.AreEqual(typeof(long), reader.ValueType);
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(9.9m, reader.Value);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(Convert.ToDecimal(1E-06), reader.Value);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task FloatParseHandling_NaNAsync()
+        {
+            string json = "[NaN]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Cannot read NaN value. Path '', line 1, position 4.");
+        }
+
+        [Test]
+        public async Task FloatingPointNonFiniteNumbersAsync()
+        {
+            string input = @"[
+  NaN,
+  Infinity,
+  -Infinity
+]";
+
+            StringReader sr = new StringReader(input);
+
+            using (JsonReader jsonReader = new JsonTextReader(sr))
+            {
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.StartArray);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.Float);
+                Assert.AreEqual(jsonReader.Value, double.NaN);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.Float);
+                Assert.AreEqual(jsonReader.Value, double.PositiveInfinity);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.Float);
+                Assert.AreEqual(jsonReader.Value, double.NegativeInfinity);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.EndArray);
+            }
+        }
+
+        [Test]
+        public async Task ReadFloatingPointNumberAsync()
+        {
+            string json =
+                @"[0.0,0.0,0.1,1.0,1.000001,1E-06,4.94065645841247E-324,Infinity,-Infinity,NaN,1.7976931348623157E+308,-1.7976931348623157E+308,Infinity,-Infinity,NaN,0e-10,0.25e-5,0.3e10]";
+
+            using (JsonReader jsonReader = new JsonTextReader(new StringReader(json)))
+            {
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.StartArray, jsonReader.TokenType);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(0.0, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(0.0, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(0.1, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(1.0, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(1.000001, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(1E-06, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(4.94065645841247E-324, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.PositiveInfinity, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.NegativeInfinity, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.NaN, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.MaxValue, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.MinValue, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.PositiveInfinity, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.NegativeInfinity, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(double.NaN, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(0d, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(0.0000025d, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Float, jsonReader.TokenType);
+                Assert.AreEqual(3000000000d, jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.EndArray, jsonReader.TokenType);
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/MiscAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/MiscAsyncTests.cs
@@ -1,0 +1,990 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Text;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects.JsonTextReaderTests;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Tests.JsonTextReaderTests
+{
+    [TestFixture]
+#if !DNXCORE50
+    [Category("JsonTextReaderTests")]
+#endif
+    public class MiscAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task LineInfoAndNewLinesAsync()
+        {
+            string json = "{}";
+
+            JsonTextReader jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, jsonTextReader.TokenType);
+            Assert.AreEqual(1, jsonTextReader.LineNumber);
+            Assert.AreEqual(1, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+
+            Assert.AreEqual(JsonToken.EndObject, jsonTextReader.TokenType);
+            Assert.AreEqual(1, jsonTextReader.LineNumber);
+            Assert.AreEqual(2, jsonTextReader.LinePosition);
+
+            json = "\n{\"a\":\"bc\"}";
+
+            jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(1, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(5, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(9, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(10, jsonTextReader.LinePosition);
+
+            json = "\n{\"a\":\n\"bc\",\"d\":true\n}";
+
+            jsonTextReader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(1, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, jsonTextReader.TokenType);
+            Assert.AreEqual(2, jsonTextReader.LineNumber);
+            Assert.AreEqual(5, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, jsonTextReader.TokenType);
+            Assert.AreEqual(3, jsonTextReader.LineNumber);
+            Assert.AreEqual(4, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, jsonTextReader.TokenType);
+            Assert.AreEqual(3, jsonTextReader.LineNumber);
+            Assert.AreEqual(9, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.Boolean, jsonTextReader.TokenType);
+            Assert.AreEqual(3, jsonTextReader.LineNumber);
+            Assert.AreEqual(13, jsonTextReader.LinePosition);
+
+            Assert.IsTrue(await jsonTextReader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, jsonTextReader.TokenType);
+            Assert.AreEqual(4, jsonTextReader.LineNumber);
+            Assert.AreEqual(1, jsonTextReader.LinePosition);
+        }
+
+        [Test]
+        public async Task UnescapeDoubleQuotesAsync()
+        {
+            string json = @"{""recipe_id"":""12"",""recipe_name"":""Apocalypse Leather Armors"",""recipe_text"":""#C16------------------------------\r\n#C12Ingredients #C20\r\n#C16------------------------------\r\n\r\na piece of Leather Armor\r\n( ie #L \""Enhanced Leather Armor Boots\"" \""85644\"" )\r\n<img src=rdb:\/\/13264>\r\n\r\n#L \""Hacker Tool\"" \""87814\""\r\n<img src=rdb:\/\/99282>\r\n\r\n#L \""Clanalizer\"" \""208313\""\r\n<img src=rdb:\/\/156479>\r\n\r\n#C16------------------------------\r\n#C12Recipe #C16\r\n#C16------------------------------#C20\r\n\r\nHacker Tool\r\n#C15+#C20\r\na piece of Leather Armor\r\n#C15=#C20\r\n<img src=rdb:\/\/13264>\r\na piece of Hacked Leather Armor\r\n( ie : #L \""Hacked Leather Armor Boots\"" \""245979\"" )\r\n#C16Skills: |  BE  |#C20\r\n\r\n#C14------------------------------#C20\r\n\r\nClanalizer\r\n#C15+#C20\r\na piece of Hacked Leather Armor\r\n#C15=#C20\r\n<img src=rdb:\/\/13264>\r\na piece of Apocalypse Leather Armor\r\n( ie : #L \""Apocalypse Leather Armor Boots\"" \""245966\"" )\r\n#C16Skills: |  ??  |#C20\r\n\r\n#C16------------------------------\r\n#C12Details#C16\r\n#C16------------------------------#C20\r\n\r\n#L \""Apocalypse Leather Armor Boots\"" \""245967\""\r\n#L \""Apocalypse Leather Armor Gloves\"" \""245969\""\r\n#L \""Apocalypse Leather Armor Helmet\"" \""245975\""\r\n#L \""Apocalypse Leather Armor Pants\"" \""245971\""\r\n#L \""Apocalypse Leather Armor Sleeves\"" \""245973\""\r\n#L \""Apocalypse Leather Body Armor\"" \""245965\""\r\n\r\n#C16------------------------------\r\n#C12Comments#C16\r\n#C16------------------------------#C20\r\n\r\nNice froob armor.. but ugleh!\r\n\r\n"",""recipe_author"":null}";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("recipe_text", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.AreEqual("#C16------------------------------\r\n#C12Ingredients #C20\r\n#C16------------------------------\r\n\r\na piece of Leather Armor\r\n( ie #L \"Enhanced Leather Armor Boots\" \"85644\" )\r\n<img src=rdb://13264>\r\n\r\n#L \"Hacker Tool\" \"87814\"\r\n<img src=rdb://99282>\r\n\r\n#L \"Clanalizer\" \"208313\"\r\n<img src=rdb://156479>\r\n\r\n#C16------------------------------\r\n#C12Recipe #C16\r\n#C16------------------------------#C20\r\n\r\nHacker Tool\r\n#C15+#C20\r\na piece of Leather Armor\r\n#C15=#C20\r\n<img src=rdb://13264>\r\na piece of Hacked Leather Armor\r\n( ie : #L \"Hacked Leather Armor Boots\" \"245979\" )\r\n#C16Skills: |  BE  |#C20\r\n\r\n#C14------------------------------#C20\r\n\r\nClanalizer\r\n#C15+#C20\r\na piece of Hacked Leather Armor\r\n#C15=#C20\r\n<img src=rdb://13264>\r\na piece of Apocalypse Leather Armor\r\n( ie : #L \"Apocalypse Leather Armor Boots\" \"245966\" )\r\n#C16Skills: |  ??  |#C20\r\n\r\n#C16------------------------------\r\n#C12Details#C16\r\n#C16------------------------------#C20\r\n\r\n#L \"Apocalypse Leather Armor Boots\" \"245967\"\r\n#L \"Apocalypse Leather Armor Gloves\" \"245969\"\r\n#L \"Apocalypse Leather Armor Helmet\" \"245975\"\r\n#L \"Apocalypse Leather Armor Pants\" \"245971\"\r\n#L \"Apocalypse Leather Armor Sleeves\" \"245973\"\r\n#L \"Apocalypse Leather Body Armor\" \"245965\"\r\n\r\n#C16------------------------------\r\n#C12Comments#C16\r\n#C16------------------------------#C20\r\n\r\nNice froob armor.. but ugleh!\r\n\r\n", reader.Value);
+        }
+
+        [Test]
+        public async Task SurrogatePairValidAsync()
+        {
+            string json = @"{ ""MATHEMATICAL ITALIC CAPITAL ALPHA"": ""\uD835\uDEE2"" }";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            string s = reader.Value.ToString();
+            Assert.AreEqual(2, s.Length);
+
+            StringInfo stringInfo = new StringInfo(s);
+            Assert.AreEqual(1, stringInfo.LengthInTextElements);
+        }
+
+        [Test]
+        public async Task SurrogatePairReplacementAsync()
+        {
+            // existing good surrogate pair
+            Assert.AreEqual("ABC \ud800\udc00 DEF", await ReadStringAsync("ABC \\ud800\\udc00 DEF"));
+
+            // invalid surrogates (two high back-to-back)
+            Assert.AreEqual("ABC \ufffd\ufffd DEF", await ReadStringAsync("ABC \\ud800\\ud800 DEF"));
+
+            // invalid surrogates (two high back-to-back)
+            Assert.AreEqual("ABC \ufffd\ufffd\u1234 DEF", await ReadStringAsync("ABC \\ud800\\ud800\\u1234 DEF"));
+
+            // invalid surrogates (three high back-to-back)
+            Assert.AreEqual("ABC \ufffd\ufffd\ufffd DEF", await ReadStringAsync("ABC \\ud800\\ud800\\ud800 DEF"));
+
+            // invalid surrogates (high followed by a good surrogate pair)
+            Assert.AreEqual("ABC \ufffd\ud800\udc00 DEF", await ReadStringAsync("ABC \\ud800\\ud800\\udc00 DEF"));
+
+            // invalid high surrogate at end of string
+            Assert.AreEqual("ABC \ufffd", await ReadStringAsync("ABC \\ud800"));
+
+            // high surrogate not followed by low surrogate
+            Assert.AreEqual("ABC \ufffd DEF", await ReadStringAsync("ABC \\ud800 DEF"));
+
+            // low surrogate not preceded by high surrogate
+            Assert.AreEqual("ABC \ufffd\ufffd DEF", await ReadStringAsync("ABC \\udc00\\ud800 DEF"));
+
+            // make sure unencoded invalid surrogate characters don't make it through
+            Assert.AreEqual("\ufffd\ufffd\ufffd", await ReadStringAsync("\udc00\ud800\ud800"));
+
+            Assert.AreEqual("ABC \ufffd\b", await ReadStringAsync("ABC \\ud800\\b"));
+            Assert.AreEqual("ABC \ufffd ", await ReadStringAsync("ABC \\ud800 "));
+            Assert.AreEqual("ABC \b\ufffd", await ReadStringAsync("ABC \\b\\ud800"));
+        }
+
+        private async Task<string> ReadStringAsync(string input)
+        {
+            MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(@"""" + input + @""""));
+
+            JsonTextReader reader = new JsonTextReader(new StreamReader(ms));
+            await reader.ReadAsync();
+
+            return (string)reader.Value;
+        }
+
+        [Test]
+        public async Task YahooFinanceAsync()
+        {
+            string input = @"{
+""matches"" : [
+{""t"":""C"", ""n"":""Citigroup Inc."", ""e"":""NYSE"", ""id"":""662713""}
+,{""t"":""CHL"", ""n"":""China Mobile Ltd. (ADR)"", ""e"":""NYSE"", ""id"":""660998""}
+,{""t"":""PTR"", ""n"":""PetroChina Company Limited (ADR)"", ""e"":""NYSE"", ""id"":""664536""}
+,{""t"":""RIO"", ""n"":""Companhia Vale do Rio Doce (ADR)"", ""e"":""NYSE"", ""id"":""671472""}
+,{""t"":""RIOPR"", ""n"":""Companhia Vale do Rio Doce (ADR)"", ""e"":""NYSE"", ""id"":""3512643""}
+,{""t"":""CSCO"", ""n"":""Cisco Systems, Inc."", ""e"":""NASDAQ"", ""id"":""99624""}
+,{""t"":""CVX"", ""n"":""Chevron Corporation"", ""e"":""NYSE"", ""id"":""667226""}
+,{""t"":""TM"", ""n"":""Toyota Motor Corporation (ADR)"", ""e"":""NYSE"", ""id"":""655880""}
+,{""t"":""JPM"", ""n"":""JPMorgan Chase \\x26 Co."", ""e"":""NYSE"", ""id"":""665639""}
+,{""t"":""COP"", ""n"":""ConocoPhillips"", ""e"":""NYSE"", ""id"":""1691168""}
+,{""t"":""LFC"", ""n"":""China Life Insurance Company Ltd. (ADR)"", ""e"":""NYSE"", ""id"":""688679""}
+,{""t"":""NOK"", ""n"":""Nokia Corporation (ADR)"", ""e"":""NYSE"", ""id"":""657729""}
+,{""t"":""KO"", ""n"":""The Coca-Cola Company"", ""e"":""NYSE"", ""id"":""6550""}
+,{""t"":""VZ"", ""n"":""Verizon Communications Inc."", ""e"":""NYSE"", ""id"":""664887""}
+,{""t"":""AMX"", ""n"":""America Movil S.A.B de C.V. (ADR)"", ""e"":""NYSE"", ""id"":""665834""}],
+""all"" : false
+}
+";
+
+            using (JsonReader jsonReader = new JsonTextReader(new StringReader(input)))
+            {
+                while (await jsonReader.ReadAsync())
+                {
+                }
+            }
+        }
+
+        [Test]
+        public async Task DepthAsync()
+        {
+            string input = @"{
+  value:'Purple',
+  array:[1,2,new Date(1)],
+  subobject:{prop:1,proparray:[1]}
+}";
+
+            StringReader sr = new StringReader(input);
+
+            using (JsonReader reader = new JsonTextReader(sr))
+            {
+                Assert.AreEqual(0, reader.Depth);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.StartObject);
+                Assert.AreEqual(0, reader.Depth);
+                Assert.AreEqual("", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("value", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.String);
+                Assert.AreEqual(reader.Value, @"Purple");
+                Assert.AreEqual(reader.QuoteChar, '\'');
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("value", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("array", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.StartArray);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("array", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.Integer);
+                Assert.AreEqual(1L, reader.Value);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("array[0]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.Integer);
+                Assert.AreEqual(2L, reader.Value);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("array[1]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.StartConstructor);
+                Assert.AreEqual("Date", reader.Value);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("array[2]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.Integer);
+                Assert.AreEqual(1L, reader.Value);
+                Assert.AreEqual(3, reader.Depth);
+                Assert.AreEqual("array[2][0]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.EndConstructor);
+                Assert.AreEqual(null, reader.Value);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("array[2]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.EndArray);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("array", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("subobject", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.StartObject);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("subobject", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("subobject.prop", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.Integer);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("subobject.prop", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("subobject.proparray", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.StartArray);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("subobject.proparray", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.Integer);
+                Assert.AreEqual(3, reader.Depth);
+                Assert.AreEqual("subobject.proparray[0]", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.EndArray);
+                Assert.AreEqual(2, reader.Depth);
+                Assert.AreEqual("subobject.proparray", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.EndObject);
+                Assert.AreEqual(1, reader.Depth);
+                Assert.AreEqual("subobject", reader.Path);
+
+                await reader.ReadAsync();
+                Assert.AreEqual(reader.TokenType, JsonToken.EndObject);
+                Assert.AreEqual(0, reader.Depth);
+                Assert.AreEqual("", reader.Path);
+            }
+        }
+
+        [Test]
+        public async Task AppendCharsWhileReadingNullAsync()
+        {
+            string json = @"[
+  {
+    ""$id"": ""1"",
+    ""Name"": ""e1"",
+    ""Manager"": null
+  },
+  {
+    ""$id"": ""2"",
+    ""Name"": ""e2"",
+    ""Manager"": null
+  },
+  {
+    ""$ref"": ""1""
+  },
+  {
+    ""$ref"": ""2""
+  }
+]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+#if DEBUG
+            reader.SetCharBuffer(new char[129]);
+#endif
+
+            for (int i = 0; i < 15; i++)
+            {
+                await reader.ReadAsync();
+            }
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Null, reader.TokenType);
+        }
+
+        [Test]
+        public async Task AppendCharsWhileReadingNewLineAsync()
+        {
+            string json = @"
+{
+  ""description"": ""A person"",
+  ""type"": ""object"",
+  ""properties"":
+  {
+    ""name"": {""type"":""string""},
+    ""hobbies"": {
+      ""type"": ""array"",
+      ""items"": {""type"":""string""}
+    }
+  }
+}
+";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+#if DEBUG
+            reader.SetCharBuffer(new char[129]);
+#endif
+
+            for (int i = 0; i < 14; i++)
+            {
+                Assert.IsTrue(await reader.ReadAsync());
+            }
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("type", reader.Value);
+        }
+
+        [Test]
+        public async Task BufferTestAsync()
+        {
+            string json = @"{
+              ""CPU"": ""Intel"",
+              ""Description"": ""Amazing!\nBuy now!"",
+              ""Drives"": [
+                ""DVD read/writer"",
+                ""500 gigabyte hard drive"",
+                ""Amazing Drive" + new string('!', 9000) + @"""
+              ]
+            }";
+
+            FakeArrayPool arrayPool = new FakeArrayPool();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                using (JsonTextReader reader = new JsonTextReader(new StringReader(json)))
+                {
+                    reader.ArrayPool = arrayPool;
+
+                    while (await reader.ReadAsync())
+                    {
+                    }
+                }
+
+                if ((i + 1) % 100 == 0)
+                {
+                    Console.WriteLine("Allocated buffers: " + arrayPool.FreeArrays.Count);
+                }
+            }
+
+            Assert.AreEqual(0, arrayPool.UsedArrays.Count);
+            Assert.AreEqual(6, arrayPool.FreeArrays.Count);
+        }
+
+        [Test]
+        public async Task BufferTest_WithErrorAsync()
+        {
+            string json = @"{
+              ""CPU"": ""Intel?\nYes"",
+              ""Description"": ""Amazin";
+
+            FakeArrayPool arrayPool = new FakeArrayPool();
+
+            try
+            {
+                // dispose will free used buffers
+                using (JsonTextReader reader = new JsonTextReader(new StringReader(json)))
+                {
+                    reader.ArrayPool = arrayPool;
+
+                    while (await reader.ReadAsync())
+                    {
+                    }
+                }
+
+                Assert.Fail();
+            }
+            catch
+            {
+            }
+
+            Assert.AreEqual(0, arrayPool.UsedArrays.Count);
+            Assert.AreEqual(2, arrayPool.FreeArrays.Count);
+        }
+
+        [Test]
+        public async Task WriteReadWriteAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw)
+            {
+                Formatting = Formatting.Indented
+            })
+            {
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(true);
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("integer");
+                await jsonWriter.WriteValueAsync(99);
+                await jsonWriter.WritePropertyNameAsync("string");
+                await jsonWriter.WriteValueAsync("how now brown cow?");
+                await jsonWriter.WritePropertyNameAsync("array");
+
+                await jsonWriter.WriteStartArrayAsync();
+                for (int i = 0; i < 5; i++)
+                {
+                    await jsonWriter.WriteValueAsync(i);
+                }
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("decimal");
+                await jsonWriter.WriteValueAsync(990.00990099m);
+                await jsonWriter.WriteEndObjectAsync();
+
+                await jsonWriter.WriteValueAsync(5);
+                await jsonWriter.WriteEndArrayAsync();
+
+                await jsonWriter.WriteEndObjectAsync();
+
+                await jsonWriter.WriteValueAsync("This is a string.");
+                await jsonWriter.WriteNullAsync();
+                await jsonWriter.WriteNullAsync();
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string json = sb.ToString();
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            object jsonObject = await serializer.DeserializeAsync(new JsonTextReader(new StringReader(json)));
+
+            sb = new StringBuilder();
+            sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw)
+            {
+                Formatting = Formatting.Indented
+            })
+            {
+                await serializer.SerializeAsync(jsonWriter, jsonObject);
+            }
+
+            Assert.AreEqual(json, sb.ToString());
+        }
+
+        [Test]
+        public async Task LongStringTestAsync()
+        {
+            int length = 20000;
+            string json = @"[""" + new string(' ', length) + @"""]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+            Assert.AreEqual(20000, reader.Value.ToString().Length);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.None, reader.TokenType);
+        }
+
+        [Test]
+        public async Task EscapedUnicodeTextAsync()
+        {
+            string json = @"[""\u003c"",""\u5f20""]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+#if DEBUG
+            reader.SetCharBuffer(new char[2]);
+#endif
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual("<", reader.Value);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(24352, Convert.ToInt32(Convert.ToChar((string)reader.Value)));
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task SupportMultipleContentAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{'prop1':[1]} 1 2 ""name"" [][]null {}{} 1.1"));
+            reader.SupportMultipleContent = true;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Null, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task SingleLineCommentsAsync()
+        {
+            string json = @"//comment*//*hi*/
+{//comment
+Name://comment
+true//comment after true" + StringUtils.CarriageReturn +
+                          @",//comment after comma" + StringUtils.CarriageReturnLineFeed +
+                          @"""ExpiryDate""://comment" + StringUtils.LineFeed +
+                          @"new " + StringUtils.LineFeed +
+                          @"Date
+(//comment
+null//comment
+),
+        ""Price"": 3.99,
+        ""Sizes"": //comment
+[//comment
+
+          ""Small""//comment
+]//comment
+}//comment 
+//comment 1 ";
+
+            JsonTextReader reader = new JsonTextReader(new StreamReader(new SlowStream(json, new UTF8Encoding(false), 1)));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment*//*hi*/", reader.Value);
+            Assert.AreEqual(1, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(2, reader.LineNumber);
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual(2, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("Name", reader.Value);
+            Assert.AreEqual(3, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual(3, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Boolean, reader.TokenType);
+            Assert.AreEqual(true, reader.Value);
+            Assert.AreEqual(4, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment after true", reader.Value);
+            Assert.AreEqual(4, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment after comma", reader.Value);
+            Assert.AreEqual(5, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("ExpiryDate", reader.Value);
+            Assert.AreEqual(6, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual(6, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartConstructor, reader.TokenType);
+            Assert.AreEqual(9, reader.LineNumber);
+            Assert.AreEqual("Date", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Null, reader.TokenType);
+            Assert.AreEqual(10, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual(10, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndConstructor, reader.TokenType);
+            Assert.AreEqual(11, reader.LineNumber);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("Price", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("Sizes", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment ", reader.Value);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment 1 ", reader.Value);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task JustSinglelineCommentAsync()
+        {
+            string json = @"//comment";
+
+            JsonTextReader reader = new JsonTextReader(new StreamReader(new SlowStream(json, new UTF8Encoding(false), 1)));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+            Assert.AreEqual("comment", reader.Value);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ScientificNotationAsync()
+        {
+            double d = Convert.ToDouble("6.0221418e23", CultureInfo.InvariantCulture);
+
+            Assert.AreEqual("6,0221418E+23", d.ToString(new CultureInfo("fr-FR")));
+            Assert.AreEqual("602214180000000000000000", d.ToString("0.#############################################################################"));
+
+            string json = @"[0e-10,0E-10,0.25e-5,0.3e10,6.0221418e23]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsync();
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0d, reader.Value);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0d, reader.Value);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0.0000025d, reader.Value);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(3000000000d, reader.Value);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(602214180000000000000000d, reader.Value);
+
+            await reader.ReadAsync();
+
+            reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsync();
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0m, reader.Value);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0m, reader.Value);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(0.0000025m, reader.Value);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(3000000000m, reader.Value);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(602214180000000000000000m, reader.Value);
+
+            await reader.ReadAsync();
+        }
+
+        [Test]
+        public async Task WriteReadBoundaryDecimalsAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(decimal.MaxValue);
+            await writer.WriteValueAsync(decimal.MinValue);
+            await writer.WriteEndArrayAsync();
+
+            string json = sw.ToString();
+
+            StringReader sr = new StringReader(json);
+            JsonTextReader reader = new JsonTextReader(sr);
+
+            Assert.IsTrue(await reader.ReadAsync());
+
+            decimal? max = await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(decimal.MaxValue, max);
+
+            decimal? min = await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(decimal.MinValue, min);
+
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+
+#if !DNXCORE50
+        [Test]
+        public async Task LinePositionOnNewLineAsync()
+        {
+            string json1 = "{'a':'bc'}";
+
+            JsonTextReader r = new JsonTextReader(new StringReader(json1));
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(1, r.LineNumber);
+            Assert.AreEqual(1, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(1, r.LineNumber);
+            Assert.AreEqual(5, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(1, r.LineNumber);
+            Assert.AreEqual(9, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(1, r.LineNumber);
+            Assert.AreEqual(10, r.LinePosition);
+
+            Assert.IsFalse(await r.ReadAsync());
+
+            string json2 = "\n{'a':'bc'}";
+
+            r = new JsonTextReader(new StringReader(json2));
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(2, r.LineNumber);
+            Assert.AreEqual(1, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(2, r.LineNumber);
+            Assert.AreEqual(5, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(2, r.LineNumber);
+            Assert.AreEqual(9, r.LinePosition);
+
+            Assert.IsTrue(await r.ReadAsync());
+            Assert.AreEqual(2, r.LineNumber);
+            Assert.AreEqual(10, r.LinePosition);
+
+            Assert.IsFalse(await r.ReadAsync());
+        }
+#endif
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ParseAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ParseAsyncTests.cs
@@ -1,0 +1,492 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Text;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects.JsonTextReaderTests;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Tests.JsonTextReaderTests
+{
+    [TestFixture]
+#if !DNXCORE50
+    [Category("JsonTextReaderTests")]
+#endif
+    public class ParseAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task ParseAdditionalContent_WhitespaceAsync()
+        {
+            string json = @"[
+""Small"",
+""Medium"",
+""Large""
+]   
+
+";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            while (await reader.ReadAsync())
+            {
+            }
+        }
+
+        [Test]
+        public async Task ParsingQuotedPropertyWithControlCharactersAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader(@"{'hi\r\nbye':1}"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("hi\r\nbye", reader.Value);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(1L, reader.Value);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ParseIntegersAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("1"));
+            Assert.AreEqual(1, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader("-1"));
+            Assert.AreEqual(-1, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader("0"));
+            Assert.AreEqual(0, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader("-0"));
+            Assert.AreEqual(0, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader(int.MaxValue.ToString()));
+            Assert.AreEqual(int.MaxValue, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader(int.MinValue.ToString()));
+            Assert.AreEqual(int.MinValue, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader(long.MaxValue.ToString()));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsInt32Async(), "JSON integer 9223372036854775807 is too large or small for an Int32. Path '', line 1, position 19.");
+
+            reader = new JsonTextReader(new StringReader("9999999999999999999999999999999999999999999999999999999999999999999999999999asdasdasd"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsInt32Async(), "Unexpected character encountered while parsing number: s. Path '', line 1, position 77.");
+
+            reader = new JsonTextReader(new StringReader("1E-06"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsInt32Async(), "Input string '1E-06' is not a valid integer. Path '', line 1, position 5.");
+
+            reader = new JsonTextReader(new StringReader("1.1"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsInt32Async(), "Input string '1.1' is not a valid integer. Path '', line 1, position 3.");
+
+            reader = new JsonTextReader(new StringReader(""));
+            Assert.AreEqual(null, await reader.ReadAsInt32Async());
+
+            reader = new JsonTextReader(new StringReader("-"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsInt32Async(), "Input string '-' is not a valid integer. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ParseDecimalsAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("1.1"));
+            Assert.AreEqual(1.1m, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader("-1.1"));
+            Assert.AreEqual(-1.1m, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader("0.0"));
+            Assert.AreEqual(0.0m, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader("-0.0"));
+            Assert.AreEqual(0, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader("9999999999999999999999999999999999999999999999999999999999999999999999999999asdasdasd"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsDecimalAsync(), "Unexpected character encountered while parsing number: s. Path '', line 1, position 77.");
+
+            reader = new JsonTextReader(new StringReader("9999999999999999999999999999999999999999999999999999999999999999999999999999asdasdasd"));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Unexpected character encountered while parsing number: s. Path '', line 1, position 77.");
+
+            reader = new JsonTextReader(new StringReader("1E-06"));
+            Assert.AreEqual(0.000001m, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader(""));
+            Assert.AreEqual(null, await reader.ReadAsDecimalAsync());
+
+            reader = new JsonTextReader(new StringReader("-"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsDecimalAsync(), "Input string '-' is not a valid decimal. Path '', line 1, position 1.");
+        }
+
+        [Test]
+        public async Task ParseDoublesAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("1.1"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(1.1d, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("-1.1"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(-1.1d, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("0.0"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(0.0d, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("-0.0"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(-0.0d, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("9999999999999999999999999999999999999999999999999999999999999999999999999999asdasdasd"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Unexpected character encountered while parsing number: s. Path '', line 1, position 77.");
+
+            reader = new JsonTextReader(new StringReader("1E-06"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(0.000001d, reader.Value);
+
+            reader = new JsonTextReader(new StringReader(""));
+            Assert.IsFalse(await reader.ReadAsync());
+
+            reader = new JsonTextReader(new StringReader("-"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Input string '-' is not a valid number. Path '', line 1, position 1.");
+
+            reader = new JsonTextReader(new StringReader("1.7976931348623157E+308"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(Double.MaxValue, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("-1.7976931348623157E+308"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(Double.MinValue, reader.Value);
+
+            reader = new JsonTextReader(new StringReader("1E+309"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Input string '1E+309' is not a valid number. Path '', line 1, position 6.");
+
+            reader = new JsonTextReader(new StringReader("-1E+5000"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Input string '-1E+5000' is not a valid number. Path '', line 1, position 8.");
+
+            reader = new JsonTextReader(new StringReader("5.1231231E"));
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await reader.ReadAsync(), "Input string '5.1231231E' is not a valid number. Path '', line 1, position 10.");
+
+            reader = new JsonTextReader(new StringReader("1E-23"));
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(typeof(double), reader.ValueType);
+            Assert.AreEqual(1e-23, reader.Value);
+        }
+
+        [Test]
+        public async Task ParseArrayWithMissingValuesAsync()
+        {
+            string json = "[,,, \n\r\n \0   \r  , ,    ]";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Undefined, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseBooleanWithNoExtraContentAsync()
+        {
+            string json = "[true ";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ParseContentDelimitedByNonStandardWhitespaceAsync()
+        {
+            string json = "\x00a0{\x00a0'h\x00a0i\x00a0'\x00a0:\x00a0[\x00a0true\x00a0,\x00a0new\x00a0Date\x00a0(\x00a0)\x00a0]\x00a0/*\x00a0comment\x00a0*/\x00a0}\x00a0";
+            JsonTextReader reader = new JsonTextReader(new StreamReader(new SlowStream(json, new UTF8Encoding(false), 1)));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Boolean, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartConstructor, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndConstructor, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Comment, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ParseObjectWithNoEndAsync()
+        {
+            string json = "{hi:1, ";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task ParseEmptyArrayAsync()
+        {
+            string json = "[]";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseEmptyObjectAsync()
+        {
+            string json = "{}";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseEmptyConstructorAsync()
+        {
+            string json = "new Date()";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartConstructor, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndConstructor, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseHexNumberAsync()
+        {
+            string json = @"0x20";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(32m, reader.Value);
+        }
+
+        [Test]
+        public async Task ParseNumbersAsync()
+        {
+            string json = @"[0,1,2 , 3]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartArray, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+
+            await reader.ReadAsync();
+            Assert.AreEqual(JsonToken.EndArray, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseLineFeedDelimitedConstructorAsync()
+        {
+            string json = "new Date\n()";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("Date", reader.Value);
+            Assert.AreEqual(JsonToken.StartConstructor, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndConstructor, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseNullStringConstructorAsync()
+        {
+            string json = "new Date\0()";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+#if DEBUG
+            reader.SetCharBuffer(new char[7]);
+#endif
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("Date", reader.Value);
+            Assert.AreEqual(JsonToken.StartConstructor, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndConstructor, reader.TokenType);
+        }
+
+        [Test]
+        public async Task ParseOctalNumberAsync()
+        {
+            string json = @"010";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(8m, reader.Value);
+        }
+
+        [Test]
+        public async Task DateParseHandlingAsync()
+        {
+            string json = @"[""1970-01-01T00:00:00Z"",""\/Date(0)\/""]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.DateParseHandling = DateParseHandling.DateTime;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(new DateTime(DateTimeUtils.InitialJavaScriptDateTicks, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(new DateTime(DateTimeUtils.InitialJavaScriptDateTicks, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+
+            reader = new JsonTextReader(new StringReader(json));
+            reader.DateParseHandling = DateParseHandling.DateTimeOffset;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, TimeSpan.Zero), reader.Value);
+            Assert.AreEqual(typeof(DateTimeOffset), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, TimeSpan.Zero), reader.Value);
+            Assert.AreEqual(typeof(DateTimeOffset), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+
+            reader = new JsonTextReader(new StringReader(json));
+            reader.DateParseHandling = DateParseHandling.None;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(@"1970-01-01T00:00:00Z", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(@"/Date(0)/", reader.Value);
+            Assert.AreEqual(typeof(string), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+
+            reader = new JsonTextReader(new StringReader(json));
+            reader.DateParseHandling = DateParseHandling.DateTime;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            await reader.ReadAsDateTimeOffsetAsync();
+            Assert.AreEqual(new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, TimeSpan.Zero), reader.Value);
+            Assert.AreEqual(typeof(DateTimeOffset), reader.ValueType);
+            await reader.ReadAsDateTimeOffsetAsync();
+            Assert.AreEqual(new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, TimeSpan.Zero), reader.Value);
+            Assert.AreEqual(typeof(DateTimeOffset), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+
+            reader = new JsonTextReader(new StringReader(json));
+            reader.DateParseHandling = DateParseHandling.DateTimeOffset;
+
+            Assert.IsTrue(await reader.ReadAsync());
+            await reader.ReadAsDateTimeAsync();
+            Assert.AreEqual(new DateTime(DateTimeUtils.InitialJavaScriptDateTicks, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+            await reader.ReadAsDateTimeAsync();
+            Assert.AreEqual(new DateTime(DateTimeUtils.InitialJavaScriptDateTicks, DateTimeKind.Utc), reader.Value);
+            Assert.AreEqual(typeof(DateTime), reader.ValueType);
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterAsyncTests.cs
@@ -1,0 +1,1659 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Tests.TestObjects.JsonTextReaderTests;
+using Newtonsoft.Json.Utilities;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests
+{
+    [TestFixture]
+    public class JsonTextWriterAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task BufferTestAsync()
+        {
+            FakeArrayPool arrayPool = new FakeArrayPool();
+
+            string longString = new string('A', 2000);
+            string longEscapedString = "Hello!" + new string('!', 50) + new string('\n', 1000) + "Good bye!";
+            string longerEscapedString = "Hello!" + new string('!', 2000) + new string('\n', 1000) + "Good bye!";
+
+            for (int i = 0; i < 1000; i++)
+            {
+                StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+
+                using (JsonTextWriter writer = new JsonTextWriter(sw))
+                {
+                    writer.ArrayPool = arrayPool;
+
+                    await writer.WriteStartObjectAsync();
+
+                    await writer.WritePropertyNameAsync("Prop1");
+                    await writer.WriteValueAsync(new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc));
+
+                    await writer.WritePropertyNameAsync("Prop2");
+                    await writer.WriteValueAsync(longString);
+
+                    await writer.WritePropertyNameAsync("Prop3");
+                    await writer.WriteValueAsync(longEscapedString);
+
+                    await writer.WritePropertyNameAsync("Prop4");
+                    await writer.WriteValueAsync(longerEscapedString);
+
+                    await writer.WriteEndObjectAsync();
+                }
+
+                if ((i + 1) % 100 == 0)
+                {
+                    Console.WriteLine("Allocated buffers: " + arrayPool.FreeArrays.Count);
+                }
+            }
+
+            Assert.AreEqual(0, arrayPool.UsedArrays.Count);
+            Assert.AreEqual(3, arrayPool.FreeArrays.Count);
+        }
+
+        [Test]
+        public async Task BufferTest_WithErrorAsync()
+        {
+            FakeArrayPool arrayPool = new FakeArrayPool();
+
+            StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+
+            try
+            {
+                // dispose will free used buffers
+                using (JsonTextWriter writer = new JsonTextWriter(sw))
+                {
+                    writer.ArrayPool = arrayPool;
+
+                    await writer.WriteStartObjectAsync();
+
+                    await writer.WritePropertyNameAsync("Prop1");
+                    await writer.WriteValueAsync(new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc));
+
+                    await writer.WritePropertyNameAsync("Prop2");
+                    await writer.WriteValueAsync("This is an escaped \n string!");
+
+                    await writer.WriteValueAsync("Error!");
+                }
+
+
+                Assert.Fail();
+            }
+            catch
+            {
+            }
+
+            Assert.AreEqual(0, arrayPool.UsedArrays.Count);
+            Assert.AreEqual(1, arrayPool.FreeArrays.Count);
+        }
+
+#if !(NET40 || PORTABLE || DNXCORE50)
+        [Test]
+        public async Task BufferErroringWithInvalidSizeAsync()
+        {
+            JObject o = new JObject
+            {
+                {"BodyHtml", "<h3>Title!</h3>" + Environment.NewLine + new string(' ', 100) + "<p>Content!</p>"}
+            };
+
+            JsonArrayPool arrayPool = new JsonArrayPool();
+
+            StringWriter sw = new StringWriter();
+            using (JsonTextWriter writer = new JsonTextWriter(sw))
+            {
+                writer.ArrayPool = arrayPool;
+
+                await o.WriteToAsync(writer);
+            }
+
+            string result = o.ToString();
+
+            Assert.AreEqual(@"{
+  ""BodyHtml"": ""<h3>Title!</h3>\r\n                                                                                                    <p>Content!</p>""
+}", result);
+        }
+#endif
+
+        [Test]
+        public async Task NewLineAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+
+            using (var streamWriter = new StreamWriter(ms, new UTF8Encoding(false)) { NewLine = "\n" })
+            using (var jsonWriter = new JsonTextWriter(streamWriter)
+            {
+                CloseOutput = true,
+                Indentation = 2,
+                Formatting = Formatting.Indented
+            })
+            {
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("prop");
+                await jsonWriter.WriteValueAsync(true);
+                await jsonWriter.WriteEndObjectAsync();
+            }
+
+            byte[] data = ms.ToArray();
+
+            string json = Encoding.UTF8.GetString(data, 0, data.Length);
+
+            Assert.AreEqual(@"{" + '\n' + @"  ""prop"": true" + '\n' + "}", json);
+        }
+
+        [Test]
+        public async Task QuoteNameAndStringsAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+            JsonTextWriter writer = new JsonTextWriter(sw) { QuoteName = false };
+
+            await writer.WriteStartObjectAsync();
+
+            await writer.WritePropertyNameAsync("name");
+            await writer.WriteValueAsync("value");
+
+            await writer.WriteEndObjectAsync();
+            await writer.FlushAsync();
+
+            Assert.AreEqual(@"{name:""value""}", sb.ToString());
+        }
+
+        [Test]
+        public async Task CloseOutputAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            JsonTextWriter writer = new JsonTextWriter(new StreamWriter(ms));
+
+            Assert.IsTrue(ms.CanRead);
+            await writer.CloseAsync();
+            Assert.IsFalse(ms.CanRead);
+
+            ms = new MemoryStream();
+            writer = new JsonTextWriter(new StreamWriter(ms)) { CloseOutput = false };
+
+            Assert.IsTrue(ms.CanRead);
+            await writer.CloseAsync();
+            Assert.IsTrue(ms.CanRead);
+        }
+
+#if !(PORTABLE)
+        [Test]
+        public async Task WriteIConvertableAsync()
+        {
+            var sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            await writer.WriteValueAsync(new ConvertibleInt(1));
+
+            Assert.AreEqual("1", sw.ToString());
+        }
+#endif
+
+        [Test]
+        public async Task ValueFormattingAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync('@');
+                await jsonWriter.WriteValueAsync("\r\n\t\f\b?{\\r\\n\"\'");
+                await jsonWriter.WriteValueAsync(true);
+                await jsonWriter.WriteValueAsync(10);
+                await jsonWriter.WriteValueAsync(10.99);
+                await jsonWriter.WriteValueAsync(0.99);
+                await jsonWriter.WriteValueAsync(0.000000000000000001d);
+                await jsonWriter.WriteValueAsync(0.000000000000000001m);
+                await jsonWriter.WriteValueAsync((string)null);
+                await jsonWriter.WriteValueAsync((object)null);
+                await jsonWriter.WriteValueAsync("This is a string.");
+                await jsonWriter.WriteNullAsync();
+                await jsonWriter.WriteUndefinedAsync();
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string expected = @"[""@"",""\r\n\t\f\b?{\\r\\n\""'"",true,10,10.99,0.99,1E-18,0.000000000000000001,null,null,""This is a string."",null,undefined]";
+            string result = sb.ToString();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task NullableValueFormattingAsync()
+        {
+            StringWriter sw = new StringWriter();
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync((char?)null);
+                await jsonWriter.WriteValueAsync((char?)'c');
+                await jsonWriter.WriteValueAsync((bool?)null);
+                await jsonWriter.WriteValueAsync((bool?)true);
+                await jsonWriter.WriteValueAsync((byte?)null);
+                await jsonWriter.WriteValueAsync((byte?)1);
+                await jsonWriter.WriteValueAsync((sbyte?)null);
+                await jsonWriter.WriteValueAsync((sbyte?)1);
+                await jsonWriter.WriteValueAsync((short?)null);
+                await jsonWriter.WriteValueAsync((short?)1);
+                await jsonWriter.WriteValueAsync((ushort?)null);
+                await jsonWriter.WriteValueAsync((ushort?)1);
+                await jsonWriter.WriteValueAsync((int?)null);
+                await jsonWriter.WriteValueAsync((int?)1);
+                await jsonWriter.WriteValueAsync((uint?)null);
+                await jsonWriter.WriteValueAsync((uint?)1);
+                await jsonWriter.WriteValueAsync((long?)null);
+                await jsonWriter.WriteValueAsync((long?)1);
+                await jsonWriter.WriteValueAsync((ulong?)null);
+                await jsonWriter.WriteValueAsync((ulong?)1);
+                await jsonWriter.WriteValueAsync((double?)null);
+                await jsonWriter.WriteValueAsync((double?)1.1);
+                await jsonWriter.WriteValueAsync((float?)null);
+                await jsonWriter.WriteValueAsync((float?)1.1);
+                await jsonWriter.WriteValueAsync((decimal?)null);
+                await jsonWriter.WriteValueAsync((decimal?)1.1m);
+                await jsonWriter.WriteValueAsync((DateTime?)null);
+                await jsonWriter.WriteValueAsync((DateTime?)new DateTime(DateTimeUtils.InitialJavaScriptDateTicks, DateTimeKind.Utc));
+#if !NET20
+                await jsonWriter.WriteValueAsync((DateTimeOffset?)null);
+                await jsonWriter.WriteValueAsync((DateTimeOffset?)new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, TimeSpan.Zero));
+#endif
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string json = sw.ToString();
+            string expected;
+
+#if !NET20
+            expected = @"[null,""c"",null,true,null,1,null,1,null,1,null,1,null,1,null,1,null,1,null,1,null,1.1,null,1.1,null,1.1,null,""1970-01-01T00:00:00Z"",null,""1970-01-01T00:00:00+00:00""]";
+#else
+      expected = @"[null,""c"",null,true,null,1,null,1,null,1,null,1,null,1,null,1,null,1,null,1,null,1.1,null,1.1,null,1.1,null,""1970-01-01T00:00:00Z""]";
+#endif
+
+            Assert.AreEqual(expected, json);
+        }
+
+        [Test]
+        public async Task WriteValueObjectWithNullableAsync()
+        {
+            StringWriter sw = new StringWriter();
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                char? value = 'c';
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync((object)value);
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string json = sw.ToString();
+            string expected = @"[""c""]";
+
+            Assert.AreEqual(expected, json);
+        }
+
+        [Test]
+        public async Task WriteValueObjectWithUnsupportedValueAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                StringWriter sw = new StringWriter();
+                using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+                {
+                    await jsonWriter.WriteStartArrayAsync();
+                    await jsonWriter.WriteValueAsync(new Version(1, 1, 1, 1));
+                    await jsonWriter.WriteEndArrayAsync();
+                }
+            }, @"Unsupported type: System.Version. Use the JsonSerializer class to get the object's JSON representation. Path ''.");
+        }
+
+        [Test]
+        public async Task StringEscapingAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(@"""These pretzels are making me thirsty!""");
+                await jsonWriter.WriteValueAsync("Jeff's house was burninated.");
+                await jsonWriter.WriteValueAsync("1. You don't talk about fight club.\r\n2. You don't talk about fight club.");
+                await jsonWriter.WriteValueAsync("35% of\t statistics\n are made\r up.");
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string expected = @"[""\""These pretzels are making me thirsty!\"""",""Jeff's house was burninated."",""1. You don't talk about fight club.\r\n2. You don't talk about fight club."",""35% of\t statistics\n are made\r up.""]";
+            string result = sb.ToString();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteEndAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                await jsonWriter.WriteValueAsync("Intel");
+                await jsonWriter.WritePropertyNameAsync("PSU");
+                await jsonWriter.WriteValueAsync("500W");
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                await jsonWriter.WriteCommentAsync("(broken)");
+                await jsonWriter.WriteValueAsync("500 gigabyte hard drive");
+                await jsonWriter.WriteValueAsync("200 gigabype hard drive");
+                await jsonWriter.WriteEndObjectAsync();
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+            }
+
+            string expected = @"{
+  ""CPU"": ""Intel"",
+  ""PSU"": ""500W"",
+  ""Drives"": [
+    ""DVD read/writer""
+    /*(broken)*/,
+    ""500 gigabyte hard drive"",
+    ""200 gigabype hard drive""
+  ]
+}";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task CloseWithRemainingContentAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                await jsonWriter.WriteValueAsync("Intel");
+                await jsonWriter.WritePropertyNameAsync("PSU");
+                await jsonWriter.WriteValueAsync("500W");
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                await jsonWriter.WriteCommentAsync("(broken)");
+                await jsonWriter.WriteValueAsync("500 gigabyte hard drive");
+                await jsonWriter.WriteValueAsync("200 gigabype hard drive");
+                await jsonWriter.CloseAsync();
+            }
+
+            string expected = @"{
+  ""CPU"": ""Intel"",
+  ""PSU"": ""500W"",
+  ""Drives"": [
+    ""DVD read/writer""
+    /*(broken)*/,
+    ""500 gigabyte hard drive"",
+    ""200 gigabype hard drive""
+  ]
+}";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task IndentingAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                await jsonWriter.WriteValueAsync("Intel");
+                await jsonWriter.WritePropertyNameAsync("PSU");
+                await jsonWriter.WriteValueAsync("500W");
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                await jsonWriter.WriteCommentAsync("(broken)");
+                await jsonWriter.WriteValueAsync("500 gigabyte hard drive");
+                await jsonWriter.WriteValueAsync("200 gigabype hard drive");
+                await jsonWriter.WriteEndAsync();
+                await jsonWriter.WriteEndObjectAsync();
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+            }
+
+            // {
+            //   "CPU": "Intel",
+            //   "PSU": "500W",
+            //   "Drives": [
+            //     "DVD read/writer"
+            //     /*(broken)*/,
+            //     "500 gigabyte hard drive",
+            //     "200 gigabype hard drive"
+            //   ]
+            // }
+
+            string expected = @"{
+  ""CPU"": ""Intel"",
+  ""PSU"": ""500W"",
+  ""Drives"": [
+    ""DVD read/writer""
+    /*(broken)*/,
+    ""500 gigabyte hard drive"",
+    ""200 gigabype hard drive""
+  ]
+}";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task StateAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+
+                await jsonWriter.WriteStartObjectAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual("", jsonWriter.Path);
+
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+                Assert.AreEqual("CPU", jsonWriter.Path);
+
+                await jsonWriter.WriteValueAsync("Intel");
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual("CPU", jsonWriter.Path);
+
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+                Assert.AreEqual("Drives", jsonWriter.Path);
+
+                await jsonWriter.WriteStartArrayAsync();
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+                Assert.AreEqual("Drives[0]", jsonWriter.Path);
+
+                await jsonWriter.WriteEndAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual("Drives", jsonWriter.Path);
+
+                await jsonWriter.WriteEndObjectAsync();
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+                Assert.AreEqual("", jsonWriter.Path);
+            }
+        }
+
+        [Test]
+        public async Task FloatingPointNonFiniteNumbers_SymbolAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.Symbol;
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteValueAsync(double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(float.NaN);
+                await jsonWriter.WriteValueAsync(float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(float.NegativeInfinity);
+                await jsonWriter.WriteEndArrayAsync();
+
+                await jsonWriter.FlushAsync();
+            }
+
+            string expected = @"[
+  NaN,
+  Infinity,
+  -Infinity,
+  NaN,
+  Infinity,
+  -Infinity
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task FloatingPointNonFiniteNumbers_ZeroAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.DefaultValue;
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteValueAsync(double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(float.NaN);
+                await jsonWriter.WriteValueAsync(float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(float.NegativeInfinity);
+                await jsonWriter.WriteValueAsync((double?)double.NaN);
+                await jsonWriter.WriteValueAsync((double?)double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync((double?)double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync((float?)float.NaN);
+                await jsonWriter.WriteValueAsync((float?)float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync((float?)float.NegativeInfinity);
+                await jsonWriter.WriteEndArrayAsync();
+
+                await jsonWriter.FlushAsync();
+            }
+
+            string expected = @"[
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  0.0,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task FloatingPointNonFiniteNumbers_StringAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.String;
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteValueAsync(double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(float.NaN);
+                await jsonWriter.WriteValueAsync(float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(float.NegativeInfinity);
+                await jsonWriter.WriteEndArrayAsync();
+
+                await jsonWriter.FlushAsync();
+            }
+
+            string expected = @"[
+  ""NaN"",
+  ""Infinity"",
+  ""-Infinity"",
+  ""NaN"",
+  ""Infinity"",
+  ""-Infinity""
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task FloatingPointNonFiniteNumbers_QuoteCharAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.String;
+                jsonWriter.QuoteChar = '\'';
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteValueAsync(double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(float.NaN);
+                await jsonWriter.WriteValueAsync(float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(float.NegativeInfinity);
+                await jsonWriter.WriteEndArrayAsync();
+
+                await jsonWriter.FlushAsync();
+            }
+
+            string expected = @"[
+  'NaN',
+  'Infinity',
+  '-Infinity',
+  'NaN',
+  'Infinity',
+  '-Infinity'
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteRawInStartAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.Symbol;
+
+                await jsonWriter.WriteRawAsync("[1,2,3,4,5]");
+                await jsonWriter.WriteWhitespaceAsync("  ");
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string expected = @"[1,2,3,4,5]  [
+  NaN
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteRawInArrayAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.Symbol;
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteRawAsync(",[1,2,3,4,5]");
+                await jsonWriter.WriteRawAsync(",[1,2,3,4,5]");
+                await jsonWriter.WriteValueAsync(float.NaN);
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string expected = @"[
+  NaN,[1,2,3,4,5],[1,2,3,4,5],
+  NaN
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteRawInObjectAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WriteRawAsync(@"""PropertyName"":[1,2,3,4,5]");
+                await jsonWriter.WriteEndAsync();
+            }
+
+            string expected = @"{""PropertyName"":[1,2,3,4,5]}";
+            string result = sb.ToString();
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteTokenAsync()
+        {
+            CancellationToken cancel = CancellationToken.None;
+            JsonTextReader reader = new JsonTextReader(new StringReader("[1,2,3,4,5]"));
+            reader.Read();
+            reader.Read();
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            await writer.WriteTokenAsync(reader, cancel);
+
+            Assert.AreEqual("1", sw.ToString());
+        }
+
+        [Test]
+        public async Task WriteRawValueAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                int i = 0;
+                string rawJson = "[1,2]";
+
+                await jsonWriter.WriteStartObjectAsync();
+
+                while (i < 3)
+                {
+                    await jsonWriter.WritePropertyNameAsync("d" + i);
+                    await jsonWriter.WriteRawValueAsync(rawJson);
+
+                    i++;
+                }
+
+                await jsonWriter.WriteEndObjectAsync();
+            }
+
+            Assert.AreEqual(@"{""d0"":[1,2],""d1"":[1,2],""d2"":[1,2]}", sb.ToString());
+        }
+
+        [Test]
+        public async Task WriteObjectNestedInConstructorAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("con");
+
+                await jsonWriter.WriteStartConstructorAsync("Ext.data.JsonStore");
+                await jsonWriter.WriteStartObjectAsync();
+                await jsonWriter.WritePropertyNameAsync("aa");
+                await jsonWriter.WriteValueAsync("aa");
+                await jsonWriter.WriteEndObjectAsync();
+                await jsonWriter.WriteEndConstructorAsync();
+
+                await jsonWriter.WriteEndObjectAsync();
+            }
+
+            Assert.AreEqual(@"{""con"":new Ext.data.JsonStore({""aa"":""aa""})}", sb.ToString());
+        }
+
+        [Test]
+        public async Task WriteFloatingPointNumberAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.Symbol;
+
+                await jsonWriter.WriteStartArrayAsync();
+
+                await jsonWriter.WriteValueAsync(0.0);
+                await jsonWriter.WriteValueAsync(0f);
+                await jsonWriter.WriteValueAsync(0.1);
+                await jsonWriter.WriteValueAsync(1.0);
+                await jsonWriter.WriteValueAsync(1.000001);
+                await jsonWriter.WriteValueAsync(0.000001);
+                await jsonWriter.WriteValueAsync(double.Epsilon);
+                await jsonWriter.WriteValueAsync(double.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(double.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(double.NaN);
+                await jsonWriter.WriteValueAsync(double.MaxValue);
+                await jsonWriter.WriteValueAsync(double.MinValue);
+                await jsonWriter.WriteValueAsync(float.PositiveInfinity);
+                await jsonWriter.WriteValueAsync(float.NegativeInfinity);
+                await jsonWriter.WriteValueAsync(float.NaN);
+
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            Assert.AreEqual(@"[0.0,0.0,0.1,1.0,1.000001,1E-06,4.94065645841247E-324,Infinity,-Infinity,NaN,1.7976931348623157E+308,-1.7976931348623157E+308,Infinity,-Infinity,NaN]", sb.ToString());
+        }
+
+        [Test]
+        public async Task WriteIntegerNumberAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw) { Formatting = Formatting.Indented })
+            {
+                await jsonWriter.WriteStartArrayAsync();
+
+                await jsonWriter.WriteValueAsync(int.MaxValue);
+                await jsonWriter.WriteValueAsync(int.MinValue);
+                await jsonWriter.WriteValueAsync(0);
+                await jsonWriter.WriteValueAsync(-0);
+                await jsonWriter.WriteValueAsync(9L);
+                await jsonWriter.WriteValueAsync(9UL);
+                await jsonWriter.WriteValueAsync(long.MaxValue);
+                await jsonWriter.WriteValueAsync(long.MinValue);
+                await jsonWriter.WriteValueAsync(ulong.MaxValue);
+                await jsonWriter.WriteValueAsync(ulong.MinValue);
+
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            Console.WriteLine(sb.ToString());
+
+            StringAssert.AreEqual(@"[
+  2147483647,
+  -2147483648,
+  0,
+  0,
+  9,
+  9,
+  9223372036854775807,
+  -9223372036854775808,
+  18446744073709551615,
+  0
+]", sb.ToString());
+        }
+
+        [Test]
+        public async Task WriteTokenDirectAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteTokenAsync(JsonToken.StartArray);
+                await jsonWriter.WriteTokenAsync(JsonToken.Integer, 1);
+                await jsonWriter.WriteTokenAsync(JsonToken.StartObject);
+                await jsonWriter.WriteTokenAsync(JsonToken.PropertyName, "string");
+                await jsonWriter.WriteTokenAsync(JsonToken.Integer, int.MaxValue);
+                await jsonWriter.WriteTokenAsync(JsonToken.EndObject);
+                await jsonWriter.WriteTokenAsync(JsonToken.EndArray);
+            }
+
+            Assert.AreEqual(@"[1,{""string"":2147483647}]", sb.ToString());
+        }
+
+        [Test]
+        public async Task WriteTokenDirect_BadValueAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                await jsonWriter.WriteTokenAsync(JsonToken.StartArray);
+
+                await ExceptionAssert.ThrowsAsync<FormatException>(async () => { await jsonWriter.WriteTokenAsync(JsonToken.Integer, "three"); }, "Input string was not in a correct format.");
+
+                await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => { await jsonWriter.WriteTokenAsync(JsonToken.Integer); }, @"Value cannot be null.
+Parameter name: value");
+            }
+        }
+
+        [Test]
+        public async Task WriteTokenNullCheckAsync()
+        {
+            using (JsonWriter jsonWriter = new JsonTextWriter(new StringWriter()))
+            {
+                await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => { await jsonWriter.WriteTokenAsync(null); });
+                await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => { await jsonWriter.WriteTokenAsync(null, true); });
+            }
+        }
+
+        [Test]
+        public async Task TokenTypeOutOfRangeAsync()
+        {
+            using (JsonWriter jsonWriter = new JsonTextWriter(new StringWriter()))
+            {
+                ArgumentOutOfRangeException ex = await ExceptionAssert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await jsonWriter.WriteTokenAsync((JsonToken)int.MinValue));
+                Assert.AreEqual("token", ex.ParamName);
+
+                ex = await ExceptionAssert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await jsonWriter.WriteTokenAsync((JsonToken)int.MinValue, "test"));
+                Assert.AreEqual("token", ex.ParamName);
+            }
+        }
+
+        [Test]
+        public async Task BadWriteEndArrayAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonWriterException>(async () =>
+            {
+                StringBuilder sb = new StringBuilder();
+                StringWriter sw = new StringWriter(sb);
+
+                using (JsonWriter jsonWriter = new JsonTextWriter(sw))
+                {
+                    await jsonWriter.WriteStartArrayAsync();
+
+                    await jsonWriter.WriteValueAsync(0.0);
+
+                    await jsonWriter.WriteEndArrayAsync();
+                    await jsonWriter.WriteEndArrayAsync();
+                }
+            }, "No token to close. Path ''.");
+        }
+
+        [Test]
+        public async Task IndentationAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                jsonWriter.FloatFormatHandling = FloatFormatHandling.Symbol;
+
+                Assert.AreEqual(Formatting.Indented, jsonWriter.Formatting);
+
+                jsonWriter.Indentation = 5;
+                Assert.AreEqual(5, jsonWriter.Indentation);
+                jsonWriter.IndentChar = '_';
+                Assert.AreEqual('_', jsonWriter.IndentChar);
+                jsonWriter.QuoteName = true;
+                Assert.AreEqual(true, jsonWriter.QuoteName);
+                jsonWriter.QuoteChar = '\'';
+                Assert.AreEqual('\'', jsonWriter.QuoteChar);
+
+                await jsonWriter.WriteStartObjectAsync();
+
+                await jsonWriter.WritePropertyNameAsync("propertyName");
+                await jsonWriter.WriteValueAsync(double.NaN);
+
+                jsonWriter.IndentChar = '?';
+                Assert.AreEqual('?', jsonWriter.IndentChar);
+                jsonWriter.Indentation = 6;
+                Assert.AreEqual(6, jsonWriter.Indentation);
+
+                await jsonWriter.WritePropertyNameAsync("prop2");
+                await jsonWriter.WriteValueAsync(123);
+
+                await jsonWriter.WriteEndObjectAsync();
+            }
+
+            string expected = @"{
+_____'propertyName': NaN,
+??????'prop2': 123
+}";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task WriteSingleBytesAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            string text = "Hello world.";
+            byte[] data = Encoding.UTF8.GetBytes(text);
+
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                Assert.AreEqual(Formatting.Indented, jsonWriter.Formatting);
+
+                await jsonWriter.WriteValueAsync(data);
+            }
+
+            string expected = @"""SGVsbG8gd29ybGQu""";
+            string result = sb.ToString();
+
+            Assert.AreEqual(expected, result);
+
+            byte[] d2 = Convert.FromBase64String(result.Trim('"'));
+
+            Assert.AreEqual(text, Encoding.UTF8.GetString(d2, 0, d2.Length));
+        }
+
+        [Test]
+        public async Task WriteBytesInArrayAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            string text = "Hello world.";
+            byte[] data = Encoding.UTF8.GetBytes(text);
+
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                Assert.AreEqual(Formatting.Indented, jsonWriter.Formatting);
+
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync(data);
+                await jsonWriter.WriteValueAsync(data);
+                await jsonWriter.WriteValueAsync((object)data);
+                await jsonWriter.WriteValueAsync((byte[])null);
+                await jsonWriter.WriteValueAsync((Uri)null);
+                await jsonWriter.WriteEndArrayAsync();
+            }
+
+            string expected = @"[
+  ""SGVsbG8gd29ybGQu"",
+  ""SGVsbG8gd29ybGQu"",
+  ""SGVsbG8gd29ybGQu"",
+  null,
+  null
+]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public async Task PathAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            string text = "Hello world.";
+            byte[] data = Encoding.UTF8.GetBytes(text);
+
+            using (JsonTextWriter writer = new JsonTextWriter(sw))
+            {
+                writer.Formatting = Formatting.Indented;
+
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("", writer.Path);
+                await writer.WriteStartObjectAsync();
+                Assert.AreEqual("[0]", writer.Path);
+                await writer.WritePropertyNameAsync("Property1");
+                Assert.AreEqual("[0].Property1", writer.Path);
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("[0].Property1", writer.Path);
+                await writer.WriteValueAsync(1);
+                Assert.AreEqual("[0].Property1[0]", writer.Path);
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("[0].Property1[1]", writer.Path);
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("[0].Property1[1][0]", writer.Path);
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("[0].Property1[1][0][0]", writer.Path);
+                await writer.WriteEndObjectAsync();
+                Assert.AreEqual("[0]", writer.Path);
+                await writer.WriteStartObjectAsync();
+                Assert.AreEqual("[1]", writer.Path);
+                await writer.WritePropertyNameAsync("Property2");
+                Assert.AreEqual("[1].Property2", writer.Path);
+                await writer.WriteStartConstructorAsync("Constructor1");
+                Assert.AreEqual("[1].Property2", writer.Path);
+                await writer.WriteNullAsync();
+                Assert.AreEqual("[1].Property2[0]", writer.Path);
+                await writer.WriteStartArrayAsync();
+                Assert.AreEqual("[1].Property2[1]", writer.Path);
+                await writer.WriteValueAsync(1);
+                Assert.AreEqual("[1].Property2[1][0]", writer.Path);
+                await writer.WriteEndAsync();
+                Assert.AreEqual("[1].Property2[1]", writer.Path);
+                await writer.WriteEndObjectAsync();
+                Assert.AreEqual("[1]", writer.Path);
+                await writer.WriteEndArrayAsync();
+                Assert.AreEqual("", writer.Path);
+            }
+
+            StringAssert.AreEqual(@"[
+  {
+    ""Property1"": [
+      1,
+      [
+        [
+          []
+        ]
+      ]
+    ]
+  },
+  {
+    ""Property2"": new Constructor1(
+      null,
+      [
+        1
+      ]
+    )
+  }
+]", sb.ToString());
+        }
+
+        [Test]
+        public async Task DateTimeZoneHandlingAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw)
+            {
+                DateTimeZoneHandling = Json.DateTimeZoneHandling.Utc
+            };
+
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Unspecified));
+
+            Assert.AreEqual(@"""2000-01-01T01:01:01Z""", sw.ToString());
+        }
+
+        [Test]
+        public async Task HtmlStringEscapeHandlingAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw)
+            {
+                StringEscapeHandling = StringEscapeHandling.EscapeHtml
+            };
+
+            string script = @"<script type=""text/javascript"">alert('hi');</script>";
+
+            await writer.WriteValueAsync(script);
+
+            string json = sw.ToString();
+
+            Assert.AreEqual(@"""\u003cscript type=\u0022text/javascript\u0022\u003ealert(\u0027hi\u0027);\u003c/script\u003e""", json);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.AreEqual(script, reader.ReadAsString());
+        }
+
+        [Test]
+        public async Task NonAsciiStringEscapeHandlingAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw)
+            {
+                StringEscapeHandling = StringEscapeHandling.EscapeNonAscii
+            };
+
+            string unicode = "\u5f20";
+
+            await writer.WriteValueAsync(unicode);
+
+            string json = sw.ToString();
+
+            Assert.AreEqual(8, json.Length);
+            Assert.AreEqual(@"""\u5f20""", json);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            Assert.AreEqual(unicode, reader.ReadAsString());
+
+            sw = new StringWriter();
+            writer = new JsonTextWriter(sw)
+            {
+                StringEscapeHandling = StringEscapeHandling.Default
+            };
+
+            await writer.WriteValueAsync(unicode);
+
+            json = sw.ToString();
+
+            Assert.AreEqual(3, json.Length);
+            Assert.AreEqual("\"\u5f20\"", json);
+        }
+
+        [Test]
+        public async Task WriteEndOnPropertyAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            writer.QuoteChar = '\'';
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Blah");
+            await writer.WriteEndAsync();
+
+            Assert.AreEqual("{'Blah':null}", sw.ToString());
+        }
+
+#if !NET20
+        [Test]
+        public async Task QuoteCharAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            writer.Formatting = Formatting.Indented;
+            writer.QuoteChar = '\'';
+
+            await writer.WriteStartArrayAsync();
+
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            await writer.WriteValueAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero));
+
+            writer.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            await writer.WriteValueAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero));
+
+            writer.DateFormatString = "yyyy gg";
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            await writer.WriteValueAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero));
+
+            await writer.WriteValueAsync(new byte[] { 1, 2, 3 });
+            await writer.WriteValueAsync(TimeSpan.Zero);
+            await writer.WriteValueAsync(new Uri("http://www.google.com/"));
+            await writer.WriteValueAsync(Guid.Empty);
+
+            await writer.WriteEndAsync();
+
+            StringAssert.AreEqual(@"[
+  '2000-01-01T01:01:01Z',
+  '2000-01-01T01:01:01+00:00',
+  '\/Date(946688461000)\/',
+  '\/Date(946688461000+0000)\/',
+  '2000 A.D.',
+  '2000 A.D.',
+  'AQID',
+  '00:00:00',
+  'http://www.google.com/',
+  '00000000-0000-0000-0000-000000000000'
+]", sw.ToString());
+        }
+
+        [Test]
+        public async Task CultureAsync()
+        {
+            CultureInfo culture = new CultureInfo("en-NZ");
+            culture.DateTimeFormat.AMDesignator = "a.m.";
+            culture.DateTimeFormat.PMDesignator = "p.m.";
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter writer = new JsonTextWriter(sw);
+            writer.Formatting = Formatting.Indented;
+            writer.DateFormatString = "yyyy tt";
+            writer.Culture = culture;
+            writer.QuoteChar = '\'';
+
+            await writer.WriteStartArrayAsync();
+
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc));
+            await writer.WriteValueAsync(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero));
+
+            await writer.WriteEndAsync();
+
+            StringAssert.AreEqual(@"[
+  '2000 a.m.',
+  '2000 a.m.'
+]", sw.ToString());
+        }
+#endif
+
+        [Test]
+        public async Task CompareNewStringEscapingWithOldAsync()
+        {
+            char c = (char)0;
+
+            do
+            {
+                StringWriter swNew = new StringWriter();
+                char[] buffer = null;
+                buffer = await JavaScriptUtils.WriteEscapedJavaScriptStringAsync(swNew, c.ToString(), '"', true, JavaScriptUtils.DoubleQuoteCharEscapeFlags, StringEscapeHandling.Default, null, buffer);
+
+                StringWriter swOld = new StringWriter();
+                WriteEscapedJavaScriptStringOld(swOld, c.ToString(), '"', true);
+
+                string newText = swNew.ToString();
+                string oldText = swOld.ToString();
+
+                if (newText != oldText)
+                {
+                    throw new Exception("Difference for char '{0}' (value {1}). Old text: {2}, New text: {3}".FormatWith(CultureInfo.InvariantCulture, c, (int)c, oldText, newText));
+                }
+
+                c++;
+            } while (c != char.MaxValue);
+        }
+
+        private const string EscapedUnicodeText = "!";
+
+        private static void WriteEscapedJavaScriptStringOld(TextWriter writer, string s, char delimiter, bool appendDelimiters)
+        {
+            // leading delimiter
+            if (appendDelimiters)
+            {
+                writer.Write(delimiter);
+            }
+
+            if (s != null)
+            {
+                char[] chars = null;
+                char[] unicodeBuffer = null;
+                int lastWritePosition = 0;
+
+                for (int i = 0; i < s.Length; i++)
+                {
+                    var c = s[i];
+
+                    // don't escape standard text/numbers except '\' and the text delimiter
+                    if (c >= ' ' && c < 128 && c != '\\' && c != delimiter)
+                    {
+                        continue;
+                    }
+
+                    string escapedValue;
+
+                    switch (c)
+                    {
+                        case '\t':
+                            escapedValue = @"\t";
+                            break;
+                        case '\n':
+                            escapedValue = @"\n";
+                            break;
+                        case '\r':
+                            escapedValue = @"\r";
+                            break;
+                        case '\f':
+                            escapedValue = @"\f";
+                            break;
+                        case '\b':
+                            escapedValue = @"\b";
+                            break;
+                        case '\\':
+                            escapedValue = @"\\";
+                            break;
+                        case '\u0085': // Next Line
+                            escapedValue = @"\u0085";
+                            break;
+                        case '\u2028': // Line Separator
+                            escapedValue = @"\u2028";
+                            break;
+                        case '\u2029': // Paragraph Separator
+                            escapedValue = @"\u2029";
+                            break;
+                        case '\'':
+                            // this charater is being used as the delimiter
+                            escapedValue = @"\'";
+                            break;
+                        case '"':
+                            // this charater is being used as the delimiter
+                            escapedValue = "\\\"";
+                            break;
+                        default:
+                            if (c <= '\u001f')
+                            {
+                                if (unicodeBuffer == null)
+                                {
+                                    unicodeBuffer = new char[6];
+                                }
+
+                                StringUtils.ToCharAsUnicode(c, unicodeBuffer);
+
+                                // slightly hacky but it saves multiple conditions in if test
+                                escapedValue = EscapedUnicodeText;
+                            }
+                            else
+                            {
+                                escapedValue = null;
+                            }
+                            break;
+                    }
+
+                    if (escapedValue == null)
+                    {
+                        continue;
+                    }
+
+                    if (i > lastWritePosition)
+                    {
+                        if (chars == null)
+                        {
+                            chars = s.ToCharArray();
+                        }
+
+                        // write unchanged chars before writing escaped text
+                        writer.Write(chars, lastWritePosition, i - lastWritePosition);
+                    }
+
+                    lastWritePosition = i + 1;
+                    if (!string.Equals(escapedValue, EscapedUnicodeText))
+                    {
+                        writer.Write(escapedValue);
+                    }
+                    else
+                    {
+                        writer.Write(unicodeBuffer);
+                    }
+                }
+
+                if (lastWritePosition == 0)
+                {
+                    // no escaped text, write entire string
+                    writer.Write(s);
+                }
+                else
+                {
+                    if (chars == null)
+                    {
+                        chars = s.ToCharArray();
+                    }
+
+                    // write remaining text
+                    writer.Write(chars, lastWritePosition, s.Length - lastWritePosition);
+                }
+            }
+
+            // trailing delimiter
+            if (appendDelimiters)
+            {
+                writer.Write(delimiter);
+            }
+        }
+
+        [Test]
+        public async Task CustomJsonTextWriterTestsAsync()
+        {
+            StringWriter sw = new StringWriter();
+            CustomJsonTextWriter writer = new CustomAsyncJsonTextWriter(sw) { Formatting = Formatting.Indented };
+            await writer.WriteStartObjectAsync();
+            Assert.AreEqual(WriteState.Object, writer.WriteState);
+            await writer.WritePropertyNameAsync("Property1");
+            Assert.AreEqual(WriteState.Property, writer.WriteState);
+            Assert.AreEqual("Property1", writer.Path);
+            await writer.WriteNullAsync();
+            Assert.AreEqual(WriteState.Object, writer.WriteState);
+            await writer.WriteEndObjectAsync();
+            Assert.AreEqual(WriteState.Start, writer.WriteState);
+
+            StringAssert.AreEqual(@"{{{
+  ""1ytreporP"": NULL!!!
+}}}", sw.ToString());
+        }
+
+        [Test]
+        public async Task QuoteDictionaryNamesAsync()
+        {
+            var d = new Dictionary<string, int>
+            {
+                { "a", 1 },
+            };
+            var jsonSerializerSettings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+            };
+            var serializer = JsonSerializer.Create(jsonSerializerSettings);
+            using (var stringWriter = new StringWriter())
+            {
+                using (var writer = new JsonTextWriter(stringWriter) { QuoteName = false })
+                {
+                    serializer.Serialize(writer, d);
+                    await writer.CloseAsync();
+                }
+
+                StringAssert.AreEqual(@"{
+  a: 1
+}", stringWriter.ToString());
+            }
+        }
+
+        [Test]
+        public async Task WriteCommentsAsync()
+        {
+            string json = @"//comment*//*hi*/
+{//comment
+Name://comment
+true//comment after true" + StringUtils.CarriageReturn + @"
+,//comment after comma" + StringUtils.CarriageReturnLineFeed + @"
+""ExpiryDate""://comment" + StringUtils.LineFeed + @"
+new
+" + StringUtils.LineFeed +
+                          @"Constructor
+(//comment
+null//comment
+),
+        ""Price"": 3.99,
+        ""Sizes"": //comment
+[//comment
+
+          ""Small""//comment
+]//comment
+}//comment 
+//comment 1 ";
+
+            JsonTextReader r = new JsonTextReader(new StringReader(json));
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter w = new JsonTextWriter(sw);
+            w.Formatting = Formatting.Indented;
+
+            await w.WriteTokenAsync(r, true);
+
+            StringAssert.AreEqual(@"/*comment*//*hi*/*/{/*comment*/
+  ""Name"": /*comment*/ true/*comment after true*//*comment after comma*/,
+  ""ExpiryDate"": /*comment*/ new Constructor(
+    /*comment*/,
+    null
+    /*comment*/
+  ),
+  ""Price"": 3.99,
+  ""Sizes"": /*comment*/ [
+    /*comment*/
+    ""Small""
+    /*comment*/
+  ]/*comment*/
+}/*comment *//*comment 1 */", sw.ToString());
+        }
+
+    }
+
+    public class CustomAsyncJsonTextWriter : CustomJsonTextWriter
+    {
+        public CustomAsyncJsonTextWriter(TextWriter textWriter) : base(textWriter)
+        {
+        }
+
+        public override Task WritePropertyNameAsync(string name, CancellationToken cancellationToken)
+        {
+            return WritePropertyNameAsync(name, true, cancellationToken);
+        }
+
+        public override async Task WritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken)
+        {
+            await SetWriteStateAsync(JsonToken.PropertyName, name, cancellationToken);
+
+            if (QuoteName)
+            {
+                await _writer.WriteAsync(QuoteChar);
+            }
+
+            await _writer.WriteAsync(new string(name.ToCharArray().Reverse().ToArray()));
+
+            if (QuoteName)
+            {
+                await _writer.WriteAsync(QuoteChar);
+            }
+
+            await _writer.WriteAsync(':');
+        }
+
+        public override async Task WriteNullAsync(CancellationToken cancellationToken)
+        {
+            await SetWriteStateAsync(JsonToken.Null, null, cancellationToken);
+
+            await _writer.WriteAsync("NULL!!!");
+        }
+
+        public override async Task WriteStartObjectAsync(CancellationToken cancellationToken)
+        {
+            await SetWriteStateAsync(JsonToken.StartObject, null, cancellationToken);
+
+            await _writer.WriteAsync("{{{");
+        }
+
+        public override Task WriteEndObjectAsync(CancellationToken cancellationToken)
+        {
+            return SetWriteStateAsync(JsonToken.EndObject, null, cancellationToken);
+        }
+
+        protected override Task WriteEndAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            if (token == JsonToken.EndObject)
+            {
+                return _writer.WriteAsync("}}}");
+            }
+            else
+            {
+                return base.WriteEndAsync(token, cancellationToken);
+            }
+        }
+    }
+}
+#endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -1649,7 +1649,7 @@ null//comment
 
     public class CustomJsonTextWriter : JsonTextWriter
     {
-        private readonly TextWriter _writer;
+        protected readonly TextWriter _writer;
 
         public CustomJsonTextWriter(TextWriter textWriter) : base(textWriter)
         {

--- a/Src/Newtonsoft.Json.Tests/Linq/JConstructoAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JConstructoAsyncTests.cs
@@ -1,0 +1,58 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JConstructoAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task LoadAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader("new Date(123)"));
+            await reader.ReadAsync();
+
+            JConstructor constructor = await JConstructor.LoadAsync(reader);
+            Assert.AreEqual("Date", constructor.Name);
+            Assert.IsTrue(JToken.DeepEquals(new JValue(123), constructor.Values().ElementAt(0)));
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectAsyncTests.cs
@@ -1,0 +1,189 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Tests.TestObjects;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JObjectAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task ReadWithSupportMultipleContentAsync()
+        {
+            string json = @"{ 'name': 'Admin' }{ 'name': 'Publisher' }";
+
+            IList<JObject> roles = new List<JObject>();
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.SupportMultipleContent = true;
+
+            while (true)
+            {
+                JObject role = (JObject)await JToken.ReadFromAsync(reader);
+
+                roles.Add(role);
+
+                if (!await reader.ReadAsync())
+                {
+                    break;
+                }
+            }
+
+            Assert.AreEqual(2, roles.Count);
+            Assert.AreEqual("Admin", (string)roles[0]["name"]);
+            Assert.AreEqual("Publisher", (string)roles[1]["name"]);
+        }
+
+        [Test]
+        public async Task JTokenReaderAsync()
+        {
+            PersonRaw raw = new PersonRaw
+            {
+                FirstName = "FirstNameValue",
+                RawContent = new JRaw("[1,2,3,4,5]"),
+                LastName = "LastNameValue"
+            };
+
+            JObject o = JObject.FromObject(raw);
+
+            JsonReader reader = new JTokenReader(o);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.Raw, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.String, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            Assert.IsFalse(await reader.ReadAsync());
+        }
+
+        [Test]
+        public async Task DeserializeFromRawAsync()
+        {
+            PersonRaw raw = new PersonRaw
+            {
+                FirstName = "FirstNameValue",
+                RawContent = new JRaw("[1,2,3,4,5]"),
+                LastName = "LastNameValue"
+            };
+
+            JObject o = JObject.FromObject(raw);
+
+            JsonReader reader = new JTokenReader(o);
+            JsonSerializer serializer = new JsonSerializer();
+            raw = (PersonRaw)await serializer.DeserializeAsync(reader, typeof(PersonRaw));
+
+            Assert.AreEqual("FirstNameValue", raw.FirstName);
+            Assert.AreEqual("LastNameValue", raw.LastName);
+            Assert.AreEqual("[1,2,3,4,5]", raw.RawContent.Value);
+        }
+
+        [Test]
+        public async Task LoadFromNestedObjectAsync()
+        {
+            string jsonText = @"{
+  ""short"":
+  {
+    ""error"":
+    {
+      ""code"":0,
+      ""msg"":""No action taken""
+    }
+  }
+}";
+
+            JsonReader reader = new JsonTextReader(new StringReader(jsonText));
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+            Assert.IsNotNull(o);
+            StringAssert.AreEqual(@"{
+  ""code"": 0,
+  ""msg"": ""No action taken""
+}", o.ToString(Formatting.Indented));
+        }
+
+        [Test]
+        public async Task LoadFromNestedObjectIncompleteAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                string jsonText = @"{
+  ""short"":
+  {
+    ""error"":
+    {
+      ""code"":0";
+
+                JsonReader reader = new JsonTextReader(new StringReader(jsonText));
+                await reader.ReadAsync();
+                await reader.ReadAsync();
+                await reader.ReadAsync();
+                await reader.ReadAsync();
+                await reader.ReadAsync();
+
+                await JToken.ReadFromAsync(reader);
+            }, "Unexpected end of content while loading JObject. Path 'short.error.code', line 6, position 14.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JPropertyAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JPropertyAsyncTests.cs
@@ -1,0 +1,74 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JPropertyAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task LoadAsync()
+        {
+            JsonReader reader = new JsonTextReader(new StringReader("{'propertyname':['value1']}"));
+            await reader.ReadAsync();
+
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            await reader.ReadAsync();
+
+            JProperty property = await JProperty.LoadAsync(reader);
+            Assert.AreEqual("propertyname", property.Name);
+            Assert.IsTrue(JToken.DeepEquals(JArray.Parse("['value1']"), property.Value));
+
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+
+            reader = new JsonTextReader(new StringReader("{'propertyname':null}"));
+            await reader.ReadAsync();
+
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            await reader.ReadAsync();
+
+            property = await JProperty.LoadAsync(reader);
+            Assert.AreEqual("propertyname", property.Name);
+            Assert.IsTrue(JToken.DeepEquals(JValue.CreateNull(), property.Value));
+
+            Assert.AreEqual(JsonToken.EndObject, reader.TokenType);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenAsyncTests.cs
@@ -1,0 +1,124 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JTokenAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task ReadFromAsync()
+        {
+            JObject o = (JObject)await JToken.ReadFromAsync(new JsonTextReader(new StringReader("{'pie':true}")));
+            Assert.AreEqual(true, (bool)o["pie"]);
+
+            JArray a = (JArray)await JToken.ReadFromAsync(new JsonTextReader(new StringReader("[1,2,3]")));
+            Assert.AreEqual(1, (int)a[0]);
+            Assert.AreEqual(2, (int)a[1]);
+            Assert.AreEqual(3, (int)a[2]);
+
+            JsonReader reader = new JsonTextReader(new StringReader("{'pie':true}"));
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+
+            JProperty p = (JProperty)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual("pie", p.Name);
+            Assert.AreEqual(true, (bool)p.Value);
+
+            JConstructor c = (JConstructor)await JToken.ReadFromAsync(new JsonTextReader(new StringReader("new Date(1)")));
+            Assert.AreEqual("Date", c.Name);
+            Assert.IsTrue(JToken.DeepEquals(new JValue(1), c.Values().ElementAt(0)));
+
+            JValue v = (JValue)await JToken.ReadFromAsync(new JsonTextReader(new StringReader(@"""stringvalue""")));
+            Assert.AreEqual("stringvalue", (string)v);
+
+            v = (JValue)await JToken.ReadFromAsync(new JsonTextReader(new StringReader(@"1")));
+            Assert.AreEqual(1, (int)v);
+
+            v = (JValue)await JToken.ReadFromAsync(new JsonTextReader(new StringReader(@"1.1")));
+            Assert.AreEqual(1.1, (double)v);
+
+            v = (JValue)await JToken.ReadFromAsync(new JsonTextReader(new StringReader(@"""1970-01-01T00:00:00+12:31"""))
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            });
+            Assert.AreEqual(typeof(DateTimeOffset), v.Value.GetType());
+            Assert.AreEqual(new DateTimeOffset(DateTimeUtils.InitialJavaScriptDateTicks, new TimeSpan(12, 31, 0)), v.Value);
+        }
+
+        [Test]
+        public async Task LoadAsync()
+        {
+            JObject o = (JObject)await JToken.LoadAsync(new JsonTextReader(new StringReader("{'pie':true}")));
+            Assert.AreEqual(true, (bool)o["pie"]);
+        }
+
+        [Test]
+        public async Task CreateWriterAsync()
+        {
+            JArray a =
+                new JArray(
+                    5,
+                    new JArray(1),
+                    new JArray(1, 2),
+                    new JArray(1, 2, 3)
+                    );
+
+            JsonWriter writer = a.CreateWriter();
+            Assert.IsNotNull(writer);
+            Assert.AreEqual(4, a.Count());
+
+            await writer.WriteValueAsync("String");
+            Assert.AreEqual(5, a.Count());
+            Assert.AreEqual("String", (string)a[4]);
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Property");
+            await writer.WriteValueAsync("PropertyValue");
+            await writer.WriteEndAsync();
+
+            Assert.AreEqual(6, a.Count());
+            Assert.IsTrue(JToken.DeepEquals(new JObject(new JProperty("Property", "PropertyValue")), a[5]));
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenReaderAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenReaderAsyncTests.cs
@@ -1,0 +1,993 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Tests.Serialization;
+using Newtonsoft.Json.Tests.TestObjects;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JTokenReaderAsyncTests : TestFixtureBase
+    {
+#if !PORTABLE || NETSTANDARD1_1
+        [Test]
+        public async Task ConvertBigIntegerToDoubleAsync()
+        {
+            var jObject = JObject.Parse("{ maxValue:10000000000000000000}");
+
+            JsonReader reader = jObject.CreateReader();
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(10000000000000000000d, await reader.ReadAsDoubleAsync());
+            Assert.IsTrue(await reader.ReadAsync());
+        }
+#endif
+
+        [Test]
+        public async Task ErrorTokenIndexAsync()
+        {
+            JObject json = JObject.Parse(@"{""IntList"":[1, ""two""]}");
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () =>
+            {
+                JsonSerializer serializer = new JsonSerializer();
+
+                await serializer.DeserializeAsync<TraceTestObject>(json.CreateReader());
+            }, "Could not convert string to integer: two. Path 'IntList[1]', line 1, position 20.");
+        }
+
+        [Test]
+        public async Task YahooFinanceAsync()
+        {
+            JObject o =
+                new JObject(
+                    new JProperty("Test1", new DateTime(2000, 10, 15, 5, 5, 5, DateTimeKind.Utc)),
+                    new JProperty("Test2", new DateTimeOffset(2000, 10, 15, 5, 5, 5, new TimeSpan(11, 11, 0))),
+                    new JProperty("Test3", "Test3Value"),
+                    new JProperty("Test4", null)
+                    );
+
+            using (JTokenReader jsonReader = new JTokenReader(o))
+            {
+                IJsonLineInfo lineInfo = jsonReader;
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.StartObject, jsonReader.TokenType);
+                Assert.AreEqual(false, lineInfo.HasLineInfo());
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test1", jsonReader.Value);
+                Assert.AreEqual(false, lineInfo.HasLineInfo());
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Date, jsonReader.TokenType);
+                Assert.AreEqual(new DateTime(2000, 10, 15, 5, 5, 5, DateTimeKind.Utc), jsonReader.Value);
+                Assert.AreEqual(false, lineInfo.HasLineInfo());
+                Assert.AreEqual(0, lineInfo.LinePosition);
+                Assert.AreEqual(0, lineInfo.LineNumber);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test2", jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Date, jsonReader.TokenType);
+                Assert.AreEqual(new DateTimeOffset(2000, 10, 15, 5, 5, 5, new TimeSpan(11, 11, 0)), jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test3", jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.String, jsonReader.TokenType);
+                Assert.AreEqual("Test3Value", jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test4", jsonReader.Value);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.Null, jsonReader.TokenType);
+                Assert.AreEqual(null, jsonReader.Value);
+
+                Assert.IsTrue(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.EndObject, jsonReader.TokenType);
+
+                Assert.IsFalse(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.None, jsonReader.TokenType);
+            }
+
+            using (JsonReader jsonReader = new JTokenReader(o.Property("Test2")))
+            {
+                Assert.IsTrue(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test2", jsonReader.Value);
+
+                Assert.IsTrue(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.Date, jsonReader.TokenType);
+                Assert.AreEqual(new DateTimeOffset(2000, 10, 15, 5, 5, 5, new TimeSpan(11, 11, 0)), jsonReader.Value);
+
+                Assert.IsFalse(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.None, jsonReader.TokenType);
+            }
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffsetBadStringAsync()
+        {
+            string json = @"{""Offset"":""blablahbla""}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDateTimeOffsetAsync(); }, "Could not convert string to DateTimeOffset: blablahbla. Path 'Offset', line 1, position 22.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffsetBooleanAsync()
+        {
+            string json = @"{""Offset"":true}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDateTimeOffsetAsync(); }, "Error reading date. Unexpected token: Boolean. Path 'Offset', line 1, position 14.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffsetStringAsync()
+        {
+            string json = @"{""Offset"":""2012-01-24T03:50Z""}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await reader.ReadAsDateTimeOffsetAsync();
+            Assert.AreEqual(JsonToken.Date, reader.TokenType);
+            Assert.AreEqual(typeof(DateTimeOffset), reader.ValueType);
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 24, 3, 50, 0, TimeSpan.Zero), reader.Value);
+        }
+
+        [Test]
+        public async Task ReadLineInfoAsync()
+        {
+            string input = @"{
+  CPU: 'Intel',
+  Drives: [
+    'DVD read/writer',
+    ""500 gigabyte hard drive""
+  ]
+}";
+
+            JObject o = JObject.Parse(input);
+
+            using (JTokenReader jsonReader = new JTokenReader(o))
+            {
+                IJsonLineInfo lineInfo = jsonReader;
+
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.None);
+                Assert.AreEqual(0, lineInfo.LineNumber);
+                Assert.AreEqual(0, lineInfo.LinePosition);
+                Assert.AreEqual(false, lineInfo.HasLineInfo());
+                Assert.AreEqual(null, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.StartObject);
+                Assert.AreEqual(1, lineInfo.LineNumber);
+                Assert.AreEqual(1, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(jsonReader.Value, "CPU");
+                Assert.AreEqual(2, lineInfo.LineNumber);
+                Assert.AreEqual(6, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o.Property("CPU"), jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.String);
+                Assert.AreEqual(jsonReader.Value, "Intel");
+                Assert.AreEqual(2, lineInfo.LineNumber);
+                Assert.AreEqual(14, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o.Property("CPU").Value, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.PropertyName);
+                Assert.AreEqual(jsonReader.Value, "Drives");
+                Assert.AreEqual(3, lineInfo.LineNumber);
+                Assert.AreEqual(9, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o.Property("Drives"), jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.StartArray);
+                Assert.AreEqual(3, lineInfo.LineNumber);
+                Assert.AreEqual(11, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o.Property("Drives").Value, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.String);
+                Assert.AreEqual(jsonReader.Value, "DVD read/writer");
+                Assert.AreEqual(4, lineInfo.LineNumber);
+                Assert.AreEqual(21, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o["Drives"][0], jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.String);
+                Assert.AreEqual(jsonReader.Value, "500 gigabyte hard drive");
+                Assert.AreEqual(5, lineInfo.LineNumber);
+                Assert.AreEqual(29, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o["Drives"][1], jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.EndArray);
+                Assert.AreEqual(3, lineInfo.LineNumber);
+                Assert.AreEqual(11, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o["Drives"], jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.EndObject);
+                Assert.AreEqual(1, lineInfo.LineNumber);
+                Assert.AreEqual(1, lineInfo.LinePosition);
+                Assert.AreEqual(true, lineInfo.HasLineInfo());
+                Assert.AreEqual(o, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.None);
+                Assert.AreEqual(null, jsonReader.CurrentToken);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(jsonReader.TokenType, JsonToken.None);
+                Assert.AreEqual(null, jsonReader.CurrentToken);
+            }
+        }
+
+        [Test]
+        public async Task ReadBytesAsync()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("Hello world!");
+
+            JObject o =
+                new JObject(
+                    new JProperty("Test1", data)
+                    );
+
+            using (JTokenReader jsonReader = new JTokenReader(o))
+            {
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.StartObject, jsonReader.TokenType);
+
+                await jsonReader.ReadAsync();
+                Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                Assert.AreEqual("Test1", jsonReader.Value);
+
+                byte[] readBytes = await jsonReader.ReadAsBytesAsync();
+                Assert.AreEqual(data, readBytes);
+
+                Assert.IsTrue(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.EndObject, jsonReader.TokenType);
+
+                Assert.IsFalse(await jsonReader.ReadAsync());
+                Assert.AreEqual(JsonToken.None, jsonReader.TokenType);
+            }
+        }
+
+        [Test]
+        public async Task ReadBytesFailureAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () =>
+            {
+                JObject o =
+                    new JObject(
+                        new JProperty("Test1", 1)
+                        );
+
+                using (JTokenReader jsonReader = new JTokenReader(o))
+                {
+                    await jsonReader.ReadAsync();
+                    Assert.AreEqual(JsonToken.StartObject, jsonReader.TokenType);
+
+                    await jsonReader.ReadAsync();
+                    Assert.AreEqual(JsonToken.PropertyName, jsonReader.TokenType);
+                    Assert.AreEqual("Test1", jsonReader.Value);
+
+                    await jsonReader.ReadAsBytesAsync();
+                }
+            }, "Error reading bytes. Unexpected token: Integer. Path 'Test1'.");
+        }
+
+        public class HasBytes
+        {
+            public byte[] Bytes { get; set; }
+        }
+
+        [Test]
+        public async Task ReadBytesFromStringAsync()
+        {
+            var bytes = new HasBytes { Bytes = new byte[] { 1, 2, 3, 4 } };
+            var json = JsonConvert.SerializeObject(bytes);
+
+            TextReader textReader = new StringReader(json);
+            JsonReader jsonReader = new JsonTextReader(textReader);
+
+            var jToken = await JToken.ReadFromAsync(jsonReader);
+
+            jsonReader = new JTokenReader(jToken);
+
+            var result2 = (HasBytes)await JsonSerializer.Create(null)
+                .DeserializeAsync(jsonReader, typeof(HasBytes));
+
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, result2.Bytes);
+        }
+
+        [Test]
+        public async Task ReadBytesFromEmptyStringAsync()
+        {
+            var bytes = new HasBytes { Bytes = new byte[0] };
+            var json = JsonConvert.SerializeObject(bytes);
+
+            TextReader textReader = new StringReader(json);
+            JsonReader jsonReader = new JsonTextReader(textReader);
+
+            var jToken = await JToken.ReadFromAsync(jsonReader);
+
+            jsonReader = new JTokenReader(jToken);
+
+            var result2 = (HasBytes)await JsonSerializer.Create(null)
+                .DeserializeAsync(jsonReader, typeof(HasBytes));
+
+            CollectionAssert.AreEquivalent(new byte[0], result2.Bytes);
+        }
+
+        public class ReadAsBytesTestObject
+        {
+            public byte[] Data;
+        }
+
+        [Test]
+        public async Task ReadAsBytesNullAsync()
+        {
+            JsonSerializer s = new JsonSerializer();
+
+            JToken nullToken = await JToken.ReadFromAsync(new JsonTextReader(new StringReader("{ Data: null }")));
+            ReadAsBytesTestObject x = await s.DeserializeAsync<ReadAsBytesTestObject>(new JTokenReader(nullToken));
+            Assert.IsNull(x.Data);
+        }
+
+        [Test]
+        public async Task DeserializeByteArrayWithTypeNameHandlingAsync()
+        {
+            TestObject test = new TestObject("Test", new byte[] { 72, 63, 62, 71, 92, 55 });
+
+            string json = JsonConvert.SerializeObject(test, Formatting.Indented, new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All
+            });
+
+            JObject o = JObject.Parse(json);
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.TypeNameHandling = TypeNameHandling.All;
+
+            using (JsonReader nodeReader = o.CreateReader())
+            {
+                // Get exception here
+                TestObject newObject = (TestObject)await serializer.DeserializeAsync(nodeReader);
+
+                Assert.AreEqual("Test", newObject.Name);
+                CollectionAssert.AreEquivalent(new byte[] { 72, 63, 62, 71, 92, 55 }, newObject.Data);
+            }
+        }
+
+        [Test]
+        public async Task DeserializeStringIntAsync()
+        {
+            string json = @"{
+  ""PreProperty"": ""99"",
+  ""PostProperty"": ""-1""
+}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            using (JsonReader nodeReader = o.CreateReader())
+            {
+                MyClass c = await serializer.DeserializeAsync<MyClass>(nodeReader);
+
+                Assert.AreEqual(99, c.PreProperty);
+                Assert.AreEqual(-1, c.PostProperty);
+            }
+        }
+
+        [Test]
+        public async Task ReadAsDecimalIntAsync()
+        {
+            string json = @"{""Name"":1}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+            Assert.AreEqual(1m, reader.Value);
+        }
+
+        [Test]
+        public async Task ReadAsInt32IntAsync()
+        {
+            string json = @"{""Name"":1}";
+
+            JObject o = JObject.Parse(json);
+
+            JTokenReader reader = (JTokenReader)o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            Assert.AreEqual(o, reader.CurrentToken);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual(o.Property("Name"), reader.CurrentToken);
+
+            await reader.ReadAsInt32Async();
+            Assert.AreEqual(o["Name"], reader.CurrentToken);
+            Assert.AreEqual(JsonToken.Integer, reader.TokenType);
+            Assert.AreEqual(typeof(int), reader.ValueType);
+            Assert.AreEqual(1, reader.Value);
+        }
+
+        [Test]
+        public async Task ReadAsInt32BadStringAsync()
+        {
+            string json = @"{""Name"":""hi""}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsInt32Async(); }, "Could not convert string to integer: hi. Path 'Name', line 1, position 12.");
+        }
+
+        [Test]
+        public async Task ReadAsInt32BooleanAsync()
+        {
+            string json = @"{""Name"":true}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsInt32Async(); }, "Error reading integer. Unexpected token: Boolean. Path 'Name', line 1, position 12.");
+        }
+
+        [Test]
+        public async Task ReadAsDecimalStringAsync()
+        {
+            string json = @"{""Name"":""1.1""}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, reader.TokenType);
+            Assert.AreEqual(typeof(decimal), reader.ValueType);
+            Assert.AreEqual(1.1m, reader.Value);
+        }
+
+        [Test]
+        public async Task ReadAsDecimalBadStringAsync()
+        {
+            string json = @"{""Name"":""blah""}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDecimalAsync(); }, "Could not convert string to decimal: blah. Path 'Name', line 1, position 14.");
+        }
+
+        [Test]
+        public async Task ReadAsDecimalBooleanAsync()
+        {
+            string json = @"{""Name"":true}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await reader.ReadAsDecimalAsync(); }, "Error reading decimal. Unexpected token: Boolean. Path 'Name', line 1, position 12.");
+        }
+
+        [Test]
+        public async Task ReadAsDecimalNullAsync()
+        {
+            string json = @"{""Name"":null}";
+
+            JObject o = JObject.Parse(json);
+
+            JsonReader reader = o.CreateReader();
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+
+            await reader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Null, reader.TokenType);
+            Assert.AreEqual(null, reader.ValueType);
+            Assert.AreEqual(null, reader.Value);
+        }
+
+        [Test]
+        public async Task InitialPath_PropertyBase_PropertyTokenAsync()
+        {
+            JObject o = new JObject
+            {
+                { "prop1", true }
+            };
+
+            JTokenReader reader = new JTokenReader(o, "baseprop");
+
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop.prop1", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop.prop1", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+        }
+
+        [Test]
+        public async Task InitialPath_ArrayBase_PropertyTokenAsync()
+        {
+            JObject o = new JObject
+            {
+                { "prop1", true }
+            };
+
+            JTokenReader reader = new JTokenReader(o, "[0]");
+
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0].prop1", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0].prop1", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+        }
+
+        [Test]
+        public async Task InitialPath_PropertyBase_ArrayTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a, "baseprop");
+
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop[0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop[1]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual("baseprop", reader.Path);
+        }
+
+        [Test]
+        public async Task InitialPath_ArrayBase_ArrayTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a, "[0]");
+
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0][0]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0][1]", reader.Path);
+
+            Assert.IsTrue(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+
+            Assert.IsFalse(await reader.ReadAsync());
+            Assert.AreEqual("[0]", reader.Path);
+        }
+
+        [Test]
+        public async Task ReadAsDouble_InvalidTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(
+                async () => { await reader.ReadAsDoubleAsync(); },
+                "Error reading double. Unexpected token: StartArray. Path ''.");
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_InvalidTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(
+                async () => { await reader.ReadAsBooleanAsync(); },
+                "Error reading boolean. Unexpected token: StartArray. Path ''.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_InvalidTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(
+                async () => { await reader.ReadAsDateTimeAsync(); },
+                "Error reading date. Unexpected token: StartArray. Path ''.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffset_InvalidTokenAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a);
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(
+                async () => { await reader.ReadAsDateTimeOffsetAsync(); },
+                "Error reading date. Unexpected token: StartArray. Path ''.");
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffset_DateTimeAsync()
+        {
+            JValue v = new JValue(new DateTime(2001, 12, 12, 12, 12, 12, DateTimeKind.Utc));
+
+            JTokenReader reader = new JTokenReader(v);
+
+            Assert.AreEqual(new DateTimeOffset(2001, 12, 12, 12, 12, 12, TimeSpan.Zero), await reader.ReadAsDateTimeOffsetAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffset_StringAsync()
+        {
+            JValue v = new JValue("2012-01-24T03:50Z");
+
+            JTokenReader reader = new JTokenReader(v);
+
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 24, 3, 50, 0, TimeSpan.Zero), await reader.ReadAsDateTimeOffsetAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_DateTimeOffsetAsync()
+        {
+            JValue v = new JValue(new DateTimeOffset(2012, 1, 24, 3, 50, 0, TimeSpan.Zero));
+
+            JTokenReader reader = new JTokenReader(v);
+
+            Assert.AreEqual(new DateTime(2012, 1, 24, 3, 50, 0, DateTimeKind.Utc), await reader.ReadAsDateTimeAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_StringAsync()
+        {
+            JValue v = new JValue("2012-01-24T03:50Z");
+
+            JTokenReader reader = new JTokenReader(v);
+
+            Assert.AreEqual(new DateTime(2012, 1, 24, 3, 50, 0, DateTimeKind.Utc), await reader.ReadAsDateTimeAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDouble_String_SuccessAsync()
+        {
+            JValue s = JValue.CreateString("123.4");
+
+            JTokenReader reader = new JTokenReader(s);
+
+            Assert.AreEqual(123.4d, await reader.ReadAsDoubleAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDouble_Null_SuccessAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsDoubleAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDouble_Integer_SuccessAsync()
+        {
+            JValue n = new JValue(1);
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(1d, await reader.ReadAsDoubleAsync());
+        }
+
+#if !PORTABLE || NETSTANDARD1_1
+        [Test]
+        public async Task ReadAsBoolean_BigInteger_SuccessAsync()
+        {
+            JValue s = new JValue(BigInteger.Parse("99999999999999999999999999999999999999999999999999999999999999999999999999"));
+
+            JTokenReader reader = new JTokenReader(s);
+
+            Assert.AreEqual(true, await reader.ReadAsBooleanAsync());
+        }
+#endif
+
+        [Test]
+        public async Task ReadAsBoolean_String_SuccessAsync()
+        {
+            JValue s = JValue.CreateString("true");
+
+            JTokenReader reader = new JTokenReader(s);
+
+            Assert.AreEqual(true, await reader.ReadAsBooleanAsync());
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_Null_SuccessAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsBooleanAsync());
+        }
+
+        [Test]
+        public async Task ReadAsBoolean_Integer_SuccessAsync()
+        {
+            JValue n = new JValue(1);
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(true, await reader.ReadAsBooleanAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDateTime_Null_SuccessAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsDateTimeAsync());
+        }
+
+        [Test]
+        public async Task ReadAsDateTimeOffset_Null_SuccessAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsDateTimeOffsetAsync());
+        }
+
+        [Test]
+        public async Task ReadAsString_Integer_SuccessAsync()
+        {
+            JValue n = new JValue(1);
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual("1", await reader.ReadAsStringAsync());
+        }
+
+        [Test]
+        public async Task ReadAsString_Guid_SuccessAsync()
+        {
+            JValue n = new JValue(new Uri("http://www.test.com"));
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual("http://www.test.com", await reader.ReadAsStringAsync());
+        }
+
+        [Test]
+        public async Task ReadAsBytes_Integer_SuccessAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsBytesAsync());
+        }
+
+        [Test]
+        public async Task ReadAsBytes_ArrayAsync()
+        {
+            JArray a = new JArray
+            {
+                1, 2
+            };
+
+            JTokenReader reader = new JTokenReader(a);
+
+            byte[] bytes = await reader.ReadAsBytesAsync();
+
+            Assert.AreEqual(2, bytes.Length);
+            Assert.AreEqual(1, bytes[0]);
+            Assert.AreEqual(2, bytes[1]);
+        }
+
+        [Test]
+        public async Task ReadAsBytes_NullAsync()
+        {
+            JValue n = JValue.CreateNull();
+
+            JTokenReader reader = new JTokenReader(n);
+
+            Assert.AreEqual(null, await reader.ReadAsBytesAsync());
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterAsyncTests.cs
@@ -1,0 +1,391 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JTokenWriterAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task ValueFormattingAsync()
+        {
+            byte[] data = Encoding.UTF8.GetBytes("Hello world.");
+
+            JToken root;
+            using (JTokenWriter jsonWriter = new JTokenWriter())
+            {
+                await jsonWriter.WriteStartArrayAsync();
+                await jsonWriter.WriteValueAsync('@');
+                await jsonWriter.WriteValueAsync("\r\n\t\f\b?{\\r\\n\"\'");
+                await jsonWriter.WriteValueAsync(true);
+                await jsonWriter.WriteValueAsync(10);
+                await jsonWriter.WriteValueAsync(10.99);
+                await jsonWriter.WriteValueAsync(0.99);
+                await jsonWriter.WriteValueAsync(0.000000000000000001d);
+                await jsonWriter.WriteValueAsync(0.000000000000000001m);
+                await jsonWriter.WriteValueAsync((string)null);
+                await jsonWriter.WriteValueAsync("This is a string.");
+                await jsonWriter.WriteNullAsync();
+                await jsonWriter.WriteUndefinedAsync();
+                await jsonWriter.WriteValueAsync(data);
+                await jsonWriter.WriteEndArrayAsync();
+
+                root = jsonWriter.Token;
+            }
+
+            CustomAssert.IsInstanceOfType(typeof(JArray), root);
+            Assert.AreEqual(13, root.Children().Count());
+            Assert.AreEqual("@", (string)root[0]);
+            Assert.AreEqual("\r\n\t\f\b?{\\r\\n\"\'", (string)root[1]);
+            Assert.AreEqual(true, (bool)root[2]);
+            Assert.AreEqual(10, (int)root[3]);
+            Assert.AreEqual(10.99, (double)root[4]);
+            Assert.AreEqual(0.99, (double)root[5]);
+            Assert.AreEqual(0.000000000000000001d, (double)root[6]);
+            Assert.AreEqual(0.000000000000000001m, (decimal)root[7]);
+            Assert.AreEqual(null, (string)root[8]);
+            Assert.AreEqual("This is a string.", (string)root[9]);
+            Assert.AreEqual(null, ((JValue)root[10]).Value);
+            Assert.AreEqual(null, ((JValue)root[11]).Value);
+            Assert.AreEqual(data, (byte[])root[12]);
+        }
+
+        [Test]
+        public async Task StateAsync()
+        {
+            using (JsonWriter jsonWriter = new JTokenWriter())
+            {
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+
+                await jsonWriter.WriteStartObjectAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+
+                await jsonWriter.WriteValueAsync("Intel");
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+
+                await jsonWriter.WriteStartArrayAsync();
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+
+#if !PORTABLE || NETSTANDARD1_1
+                await jsonWriter.WriteValueAsync(new BigInteger(123));
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+#endif
+
+                await jsonWriter.WriteValueAsync(new byte[0]);
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+
+                await jsonWriter.WriteEndAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+
+                await jsonWriter.WriteEndObjectAsync();
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+            }
+        }
+
+        [Test]
+        public async Task CurrentTokenAsync()
+        {
+            using (JTokenWriter jsonWriter = new JTokenWriter())
+            {
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+                Assert.AreEqual(null, jsonWriter.CurrentToken);
+
+                await jsonWriter.WriteStartObjectAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual(jsonWriter.Token, jsonWriter.CurrentToken);
+
+                JObject o = (JObject)jsonWriter.Token;
+
+                await jsonWriter.WritePropertyNameAsync("CPU");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+                Assert.AreEqual(o.Property("CPU"), jsonWriter.CurrentToken);
+
+                await jsonWriter.WriteValueAsync("Intel");
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual(o["CPU"], jsonWriter.CurrentToken);
+
+                await jsonWriter.WritePropertyNameAsync("Drives");
+                Assert.AreEqual(WriteState.Property, jsonWriter.WriteState);
+                Assert.AreEqual(o.Property("Drives"), jsonWriter.CurrentToken);
+
+                await jsonWriter.WriteStartArrayAsync();
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+                Assert.AreEqual(o["Drives"], jsonWriter.CurrentToken);
+
+                JArray a = (JArray)jsonWriter.CurrentToken;
+
+                await jsonWriter.WriteValueAsync("DVD read/writer");
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+                Assert.AreEqual(a[a.Count - 1], jsonWriter.CurrentToken);
+
+#if !PORTABLE || NETSTANDARD1_1
+                await jsonWriter.WriteValueAsync(new BigInteger(123));
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+                Assert.AreEqual(a[a.Count - 1], jsonWriter.CurrentToken);
+#endif
+
+                await jsonWriter.WriteValueAsync(new byte[0]);
+                Assert.AreEqual(WriteState.Array, jsonWriter.WriteState);
+                Assert.AreEqual(a[a.Count - 1], jsonWriter.CurrentToken);
+
+                await jsonWriter.WriteEndAsync();
+                Assert.AreEqual(WriteState.Object, jsonWriter.WriteState);
+                Assert.AreEqual(a, jsonWriter.CurrentToken);
+
+                await jsonWriter.WriteEndObjectAsync();
+                Assert.AreEqual(WriteState.Start, jsonWriter.WriteState);
+                Assert.AreEqual(o, jsonWriter.CurrentToken);
+            }
+        }
+
+        [Test]
+        public async Task WriteCommentAsync()
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteCommentAsync("fail");
+            await writer.WriteEndArrayAsync();
+
+            StringAssert.AreEqual(@"[
+  /*fail*/]", writer.Token.ToString());
+        }
+
+#if !PORTABLE || NETSTANDARD1_1
+        [Test]
+        public async Task WriteBigIntegerAsync()
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync(new BigInteger(123));
+            await writer.WriteEndArrayAsync();
+
+            JValue i = (JValue)writer.Token[0];
+
+            Assert.AreEqual(new BigInteger(123), i.Value);
+            Assert.AreEqual(JTokenType.Integer, i.Type);
+
+            StringAssert.AreEqual(@"[
+  123
+]", writer.Token.ToString());
+        }
+#endif
+
+        [Test]
+        public async Task WriteRawAsync()
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteRawAsync("fail");
+            await writer.WriteRawAsync("fail");
+            await writer.WriteEndArrayAsync();
+
+            // this is a bug. See non-async equivalent test.
+            StringAssert.AreEqual(@"[
+  fail,
+  fail
+]", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteTokenWithParentAsync()
+        {
+            JObject o = new JObject
+            {
+                ["prop1"] = new JArray(1),
+                ["prop2"] = 1
+            };
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+
+            await writer.WriteTokenAsync(o.CreateReader());
+
+            Assert.AreEqual(WriteState.Array, writer.WriteState);
+
+            await writer.WriteEndArrayAsync();
+
+            Console.WriteLine(writer.Token.ToString());
+
+            StringAssert.AreEqual(@"[
+  {
+    ""prop1"": [
+      1
+    ],
+    ""prop2"": 1
+  }
+]", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteTokenWithPropertyParentAsync()
+        {
+            JValue v = new JValue(1);
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartObjectAsync();
+            await writer.WritePropertyNameAsync("Prop1");
+
+            await writer.WriteTokenAsync(v.CreateReader());
+
+            Assert.AreEqual(WriteState.Object, writer.WriteState);
+
+            await writer.WriteEndObjectAsync();
+
+            StringAssert.AreEqual(@"{
+  ""Prop1"": 1
+}", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteValueTokenWithParentAsync()
+        {
+            JValue v = new JValue(1);
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+
+            await writer.WriteTokenAsync(v.CreateReader());
+
+            Assert.AreEqual(WriteState.Array, writer.WriteState);
+
+            await writer.WriteEndArrayAsync();
+
+            StringAssert.AreEqual(@"[
+  1
+]", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteEmptyTokenAsync()
+        {
+            JObject o = new JObject();
+            JsonReader reader = o.CreateReader();
+            while (reader.Read())
+            {   
+            }
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+
+            await writer.WriteTokenAsync(reader);
+
+            Assert.AreEqual(WriteState.Array, writer.WriteState);
+
+            await writer.WriteEndArrayAsync();
+
+            StringAssert.AreEqual(@"[]", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteRawValueAsync()
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartArrayAsync();
+            await writer.WriteRawValueAsync("fail");
+            await writer.WriteRawValueAsync("fail");
+            await writer.WriteEndArrayAsync();
+
+            StringAssert.AreEqual(@"[
+  fail,
+  fail
+]", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task WriteDuplicatePropertyNameAsync()
+        {
+            JTokenWriter writer = new JTokenWriter();
+
+            await writer.WriteStartObjectAsync();
+
+            await writer.WritePropertyNameAsync("prop1");
+            await writer.WriteStartObjectAsync();
+            await writer.WriteEndObjectAsync();
+
+            await writer.WritePropertyNameAsync("prop1");
+            await writer.WriteStartArrayAsync();
+            await writer.WriteEndArrayAsync();
+
+            await writer.WriteEndObjectAsync();
+
+            StringAssert.AreEqual(@"{
+  ""prop1"": []
+}", writer.Token.ToString());
+        }
+
+        [Test]
+        public async Task DateTimeZoneHandlingAsync()
+        {
+            JTokenWriter writer = new JTokenWriter
+            {
+                DateTimeZoneHandling = Json.DateTimeZoneHandling.Utc
+            };
+
+            await writer.WriteValueAsync(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Unspecified));
+
+            JValue value = (JValue)writer.Token;
+            DateTime dt = (DateTime)value.Value;
+
+            Assert.AreEqual(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc), dt);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/JValueAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JValueAsyncTests.cs
@@ -1,0 +1,162 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Linq;
+using System.Globalization;
+using System.Linq;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class JValueAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task FloatParseHandlingAsync()
+        {
+            JValue v = (JValue)await JToken.ReadFromAsync(
+                new JsonTextReader(new StringReader("9.9"))
+                {
+                    FloatParseHandling = Json.FloatParseHandling.Decimal
+                });
+
+            Assert.AreEqual(9.9m, v.Value);
+            Assert.AreEqual(typeof(decimal), v.Value.GetType());
+        }
+
+        public class Rate
+        {
+            public decimal Compoundings { get; set; }
+        }
+
+        private readonly Rate rate = new Rate { Compoundings = 12.166666666666666666666666667m };
+
+        [Test]
+        public async Task WriteFullDecimalPrecisionAsync()
+        {
+            var jTokenWriter = new JTokenWriter();
+            await new JsonSerializer().SerializeAsync(jTokenWriter, rate);
+            string json = jTokenWriter.Token.ToString();
+            StringAssert.AreEqual(@"{
+  ""Compoundings"": 12.166666666666666666666666667
+}", json);
+        }
+
+        [Test]
+        public async Task RoundTripDecimalAsync()
+        {
+            var jTokenWriter = new JTokenWriter();
+            await new JsonSerializer().SerializeAsync(jTokenWriter, rate);
+            var rate2 = await new JsonSerializer().DeserializeAsync<Rate>(new JTokenReader(jTokenWriter.Token));
+
+            Assert.AreEqual(rate.Compoundings, rate2.Compoundings);
+        }
+
+        [Test]
+        public async Task ParseAndConvertDateTimeOffsetAsync()
+        {
+            var json = @"{ d: ""\/Date(0+0100)\/"" }";
+
+            using (var stringReader = new StringReader(json))
+            using (var jsonReader = new JsonTextReader(stringReader))
+            {
+                jsonReader.DateParseHandling = DateParseHandling.DateTimeOffset;
+
+                var obj = await JObject.LoadAsync(jsonReader);
+                var d = (JValue)obj["d"];
+
+                CustomAssert.IsInstanceOfType(typeof(DateTimeOffset), d.Value);
+                TimeSpan offset = ((DateTimeOffset)d.Value).Offset;
+                Assert.AreEqual(TimeSpan.FromHours(1), offset);
+
+                DateTimeOffset dateTimeOffset = (DateTimeOffset)d;
+                Assert.AreEqual(TimeSpan.FromHours(1), dateTimeOffset.Offset);
+            }
+        }
+
+#if !PORTABLE
+
+        [Test]
+        public async Task ExpicitConversionTestAsync()
+        {
+            const string example = "Hello";
+            dynamic obj = new
+            {
+                data = Encoding.UTF8.GetBytes(example)
+            };
+            byte[] bytes;
+            using (var ms = new MemoryStream())
+            {
+                using (TextWriter tw = new StreamWriter(ms))
+                {
+                    await JsonSerializer.Create().SerializeAsync(tw, obj);
+                    await tw.FlushAsync();
+                    bytes = ms.ToArray();
+                }
+            }
+            dynamic o = JObject.Parse(Encoding.UTF8.GetString(bytes));
+            byte[] dataBytes = (byte[])o.data;
+            Assert.AreEqual(example, Encoding.UTF8.GetString(dataBytes));
+        }
+
+#endif
+
+        [Test]
+        public async Task ParseIsoTimeZonesAsync()
+        {
+            DateTimeOffset expectedDate = new DateTimeOffset(2013, 08, 14, 4, 38, 31, TimeSpan.FromHours(12).Add(TimeSpan.FromMinutes(30)));
+            JsonTextReader reader = new JsonTextReader(new StringReader("'2013-08-14T04:38:31.000+1230'"));
+            reader.DateParseHandling = DateParseHandling.DateTimeOffset;
+            JValue date = (JValue)await JToken.ReadFromAsync(reader);
+            Assert.AreEqual(expectedDate, date.Value);
+
+            DateTimeOffset expectedDate2 = new DateTimeOffset(2013, 08, 14, 4, 38, 31, TimeSpan.FromHours(12));
+            JsonTextReader reader2 = new JsonTextReader(new StringReader("'2013-08-14T04:38:31.000+12'"));
+            reader2.DateParseHandling = DateParseHandling.DateTimeOffset;
+            JValue date2 = (JValue)await JToken.ReadFromAsync(reader2);
+            Assert.AreEqual(expectedDate2, date2.Value);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Linq/LinqToJsonAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/LinqToJsonAsyncTests.cs
@@ -1,0 +1,331 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Tests.TestObjects.Organization;
+using System.Linq;
+using System.IO;
+
+namespace Newtonsoft.Json.Tests.Linq
+{
+    [TestFixture]
+    public class LinqToJsonAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task CommentsAndReadFromAsync()
+        {
+            StringReader textReader = new StringReader(@"[
+    // hi
+    1,
+    2,
+    3
+]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            JArray a = (JArray)await JToken.ReadFromAsync(jsonReader, new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Load
+            });
+
+            Assert.AreEqual(4, a.Count);
+            Assert.AreEqual(JTokenType.Comment, a[0].Type);
+            Assert.AreEqual(" hi", ((JValue)a[0]).Value);
+        }
+
+        [Test]
+        public async Task CommentsAndReadFrom_IgnoreCommentsAsync()
+        {
+            StringReader textReader = new StringReader(@"[
+    // hi
+    1,
+    2,
+    3
+]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            JArray a = (JArray)await JToken.ReadFromAsync(jsonReader);
+
+            Assert.AreEqual(3, a.Count);
+            Assert.AreEqual(JTokenType.Integer, a[0].Type);
+            Assert.AreEqual(1L, ((JValue)a[0]).Value);
+        }
+
+        [Test]
+        public async Task StartingCommentAndReadFromAsync()
+        {
+            StringReader textReader = new StringReader(@"
+// hi
+[
+    1,
+    2,
+    3
+]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            JValue v = (JValue)await JToken.ReadFromAsync(jsonReader, new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Load
+            });
+
+            Assert.AreEqual(JTokenType.Comment, v.Type);
+
+            IJsonLineInfo lineInfo = v;
+            Assert.AreEqual(true, lineInfo.HasLineInfo());
+            Assert.AreEqual(2, lineInfo.LineNumber);
+            Assert.AreEqual(5, lineInfo.LinePosition);
+        }
+
+        [Test]
+        public async Task StartingCommentAndReadFrom_IgnoreCommentsAsync()
+        {
+            StringReader textReader = new StringReader(@"
+// hi
+[
+    1,
+    2,
+    3
+]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            JArray a = (JArray)await JToken.ReadFromAsync(jsonReader, new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Ignore
+            });
+
+            Assert.AreEqual(JTokenType.Array, a.Type);
+
+            IJsonLineInfo lineInfo = a;
+            Assert.AreEqual(true, lineInfo.HasLineInfo());
+            Assert.AreEqual(3, lineInfo.LineNumber);
+            Assert.AreEqual(1, lineInfo.LinePosition);
+        }
+
+        [Test]
+        public async Task StartingUndefinedAndReadFromAsync()
+        {
+            StringReader textReader = new StringReader(@"
+undefined
+[
+    1,
+    2,
+    3
+]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            JValue v = (JValue)await JToken.ReadFromAsync(jsonReader);
+
+            Assert.AreEqual(JTokenType.Undefined, v.Type);
+
+            IJsonLineInfo lineInfo = v;
+            Assert.AreEqual(true, lineInfo.HasLineInfo());
+            Assert.AreEqual(2, lineInfo.LineNumber);
+            Assert.AreEqual(9, lineInfo.LinePosition);
+        }
+
+        [Test]
+        public async Task StartingEndArrayAndReadFromAsync()
+        {
+            StringReader textReader = new StringReader(@"[]");
+
+            JsonTextReader jsonReader = new JsonTextReader(textReader);
+            await jsonReader.ReadAsync();
+            await jsonReader.ReadAsync();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => await JToken.ReadFromAsync(jsonReader), @"Error reading JToken from JsonReader. Unexpected token: EndArray. Path '', line 1, position 2.");
+        }
+
+        [Test]
+        public async Task LinqToJsonDeserializeAsync()
+        {
+            JObject o = new JObject(
+                new JProperty("Name", "John Smith"),
+                new JProperty("BirthDate", new DateTime(1983, 3, 20))
+                );
+
+            JsonSerializer serializer = new JsonSerializer();
+            Person p = (Person)await serializer.DeserializeAsync(new JTokenReader(o), typeof(Person));
+
+            Assert.AreEqual("John Smith", p.Name);
+        }
+
+        [Test]
+        public async Task ToStringJsonConverterAsync()
+        {
+            JObject o =
+                new JObject(
+                    new JProperty("Test1", new DateTime(2000, 10, 15, 5, 5, 5, DateTimeKind.Utc)),
+                    new JProperty("Test2", new DateTimeOffset(2000, 10, 15, 5, 5, 5, new TimeSpan(11, 11, 0))),
+                    new JProperty("Test3", "Test3Value"),
+                    new JProperty("Test4", null)
+                    );
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Converters.Add(new JavaScriptDateTimeConverter());
+            StringWriter sw = new StringWriter();
+            JsonWriter writer = new JsonTextWriter(sw);
+            writer.Formatting = Formatting.Indented;
+            await serializer.SerializeAsync(writer, o);
+
+            string json = sw.ToString();
+
+            StringAssert.AreEqual(@"{
+  ""Test1"": new Date(
+    971586305000
+  ),
+  ""Test2"": new Date(
+    971546045000
+  ),
+  ""Test3"": ""Test3Value"",
+  ""Test4"": null
+}", json);
+        }
+
+        [Test]
+        public async Task DateTimeOffsetAsync()
+        {
+            List<DateTimeOffset> testDates = new List<DateTimeOffset>
+            {
+                new DateTimeOffset(new DateTime(100, 1, 1, 1, 1, 1, DateTimeKind.Utc)),
+                new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero),
+                new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.FromHours(13)),
+                new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.FromHours(-3.5)),
+            };
+
+            JsonSerializer jsonSerializer = new JsonSerializer();
+
+            JTokenWriter jsonWriter;
+            using (jsonWriter = new JTokenWriter())
+            {
+                await jsonSerializer.SerializeAsync(jsonWriter, testDates);
+            }
+
+            Assert.AreEqual(4, jsonWriter.Token.Children().Count());
+        }
+
+        [Test]
+        public async Task SerializeWithNoRedundentIdPropertiesTestAsync()
+        {
+            Dictionary<string, object> dic1 = new Dictionary<string, object>();
+            Dictionary<string, object> dic2 = new Dictionary<string, object>();
+            Dictionary<string, object> dic3 = new Dictionary<string, object>();
+            List<object> list1 = new List<object>();
+            List<object> list2 = new List<object>();
+
+            dic1.Add("list1", list1);
+            dic1.Add("list2", list2);
+            dic1.Add("dic1", dic1);
+            dic1.Add("dic2", dic2);
+            dic1.Add("dic3", dic3);
+            dic1.Add("integer", 12345);
+
+            list1.Add("A string!");
+            list1.Add(dic1);
+            list1.Add(new List<object>());
+
+            dic3.Add("dic3", dic3);
+
+            string json = await SerializeWithNoRedundentIdPropertiesAsync(dic1);
+
+            StringAssert.AreEqual(@"{
+  ""$id"": ""1"",
+  ""list1"": [
+    ""A string!"",
+    {
+      ""$ref"": ""1""
+    },
+    []
+  ],
+  ""list2"": [],
+  ""dic1"": {
+    ""$ref"": ""1""
+  },
+  ""dic2"": {},
+  ""dic3"": {
+    ""$id"": ""3"",
+    ""dic3"": {
+      ""$ref"": ""3""
+    }
+  },
+  ""integer"": 12345
+}", json);
+        }
+
+        private static async Task<string> SerializeWithNoRedundentIdPropertiesAsync(object o)
+        {
+            JTokenWriter writer = new JTokenWriter();
+            JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+                PreserveReferencesHandling = PreserveReferencesHandling.Objects
+            });
+            await serializer.SerializeAsync(writer, o);
+
+            JToken t = writer.Token;
+
+            if (t is JContainer)
+            {
+                JContainer c = t as JContainer;
+
+                // find all the $id properties in the JSON
+                IList<JProperty> ids = c.Descendants().OfType<JProperty>().Where(d => d.Name == "$id").ToList();
+
+                if (ids.Count > 0)
+                {
+                    // find all the $ref properties in the JSON
+                    IList<JProperty> refs = c.Descendants().OfType<JProperty>().Where(d => d.Name == "$ref").ToList();
+
+                    foreach (JProperty idProperty in ids)
+                    {
+                        // check whether the $id property is used by a $ref
+                        bool idUsed = refs.Any(r => idProperty.Value.ToString() == r.Value.ToString());
+
+                        if (!idUsed)
+                        {
+                            // remove unused $id
+                            idProperty.Remove();
+                        }
+                    }
+                }
+            }
+
+            return t.ToString();
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -49,7 +49,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bson\BsonReaderAsyncTests.cs" />
     <Compile Include="Bson\BsonReaderTests.cs" />
+    <Compile Include="Bson\BsonWriterAsyncTests.cs" />
     <Compile Include="Bson\BsonWriterTests.cs" />
     <Compile Include="Converters\BinaryConverterTests.cs" />
     <Compile Include="Converters\CustomCreationConverterTests.cs" />
@@ -221,10 +223,37 @@
     </Compile>
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="JsonArrayAttributeTests.cs" />
+    <Compile Include="JsonConvertAsyncTests.cs" />
     <Compile Include="JsonConvertTest.cs" />
+    <Compile Include="JsonTextReaderTests\ExceptionHandlingAsyncTests.cs" />
+    <Compile Include="JsonTextReaderTests\FloatAsyncTests.cs" />
+    <Compile Include="JsonTextReaderTests\MiscAsyncTests.cs" />
     <Compile Include="JsonTextReaderTests\MiscTests.cs" />
     <Compile Include="JsonTextReaderTests\ExceptionHandlingTests.cs" />
     <Compile Include="TestObjects\JsonReaderStubWithIsClosed.cs" />
+    <Compile Include="JsonTextReaderTests\ParseAsyncTests.cs" />
+    <Compile Include="JsonTextWriterAsyncTests.cs" />
+    <Compile Include="Linq\JConstructoAsyncTests.cs" />
+    <Compile Include="Linq\JObjectAsyncTests.cs" />
+    <Compile Include="Linq\JPropertyAsyncTests.cs" />
+    <Compile Include="Linq\JTokenReaderAsyncTests.cs" />
+    <Compile Include="Linq\JTokenAsyncTests.cs" />
+    <Compile Include="Linq\JTokenWriterAsyncTests.cs" />
+    <Compile Include="Linq\JValueAsyncTests.cs" />
+    <Compile Include="Linq\LinqToJsonAsyncTests.cs" />
+    <Compile Include="Serialization\CamelCaseNamingStrategyAsyncTests.cs" />
+    <Compile Include="Serialization\CamelCasePropertyNamesContractResolverAsyncTests.cs" />
+    <Compile Include="Serialization\ContractResolverAsyncTests.cs" />
+    <Compile Include="Serialization\ExtensionDataAsyncTests.cs" />
+    <Compile Include="Serialization\JsonSerializerCollectionsAsyncTests.cs" />
+    <Compile Include="Serialization\JsonSerializerAsyncTest.cs" />
+    <Compile Include="Serialization\MissingMemberHandlingAsyncTests.cs" />
+    <Compile Include="Serialization\NullValueHandlingAsyncTests.cs" />
+    <Compile Include="Serialization\PopulateAsyncTests.cs" />
+    <Compile Include="Serialization\PreserveReferencesHandlingAsyncTests.cs" />
+    <Compile Include="Serialization\SerializationErrorHandlingAsyncTests.cs" />
+    <Compile Include="Serialization\TraceWriterAsyncTests.cs" />
+    <Compile Include="Serialization\TypeNameHandlingAsyncTests.cs" />
     <Compile Include="TestObjects\JsonTextReaderTests\FakeArrayPool.cs" />
     <Compile Include="JsonTextReaderTests\FloatTests.cs" />
     <Compile Include="JsonTextReaderTests\ParseTests.cs" />
@@ -478,6 +507,7 @@
     <Compile Include="TestObjects\WidgetId1.cs" />
     <Compile Include="TestObjects\WidgetIdJsonConverter.cs" />
     <Compile Include="TestObjects\WithEnums.cs" />
+    <Compile Include="Utilities\DateTimeUtilsAsyncTests.cs" />
     <Compile Include="Utilities\DateTimeUtilsTests.cs" />
     <Compile Include="Utilities\DynamicReflectionDelegateFactoryTests.cs" />
     <Compile Include="Utilities\ExpressionReflectionDelegateFactoryTests.cs" />

--- a/Src/Newtonsoft.Json.Tests/Serialization/CamelCaseNamingStrategyAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/CamelCaseNamingStrategyAsyncTests.cs
@@ -1,0 +1,75 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using Newtonsoft.Json.Serialization;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Tests.TestObjects;
+using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class CamelCaseNamingStrategyAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task JTokenWriter_OverrideSpecifiedNameAsync()
+        {
+            JsonIgnoreAttributeOnClassTestClass ignoreAttributeOnClassTestClass = new JsonIgnoreAttributeOnClassTestClass();
+            ignoreAttributeOnClassTestClass.Field = int.MinValue;
+
+            DefaultContractResolver contractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy
+                {
+                    OverrideSpecifiedNames = true
+                }
+            };
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.ContractResolver = contractResolver;
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await serializer.SerializeAsync(writer, ignoreAttributeOnClassTestClass);
+
+            JObject o = (JObject)writer.Token;
+            JProperty p = o.Property("theField");
+
+            Assert.IsNotNull(p);
+            Assert.AreEqual(int.MinValue, (int)p.Value);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverAsyncTests.cs
@@ -1,0 +1,69 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using Newtonsoft.Json.Serialization;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Tests.TestObjects;
+using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class CamelCasePropertyNamesContractResolverAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task JTokenWriterAsync()
+        {
+            JsonIgnoreAttributeOnClassTestClass ignoreAttributeOnClassTestClass = new JsonIgnoreAttributeOnClassTestClass();
+            ignoreAttributeOnClassTestClass.Field = int.MinValue;
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
+
+            JTokenWriter writer = new JTokenWriter();
+
+            await serializer.SerializeAsync(writer, ignoreAttributeOnClassTestClass);
+
+            JObject o = (JObject)writer.Token;
+            JProperty p = o.Property("theField");
+
+            Assert.IsNotNull(p);
+            Assert.AreEqual(int.MinValue, (int)p.Value);
+
+            string json = o.ToString();
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverAsyncTests.cs
@@ -1,0 +1,97 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.IO;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class ContractResolverAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task SerializeWithEscapedPropertyNameAsync()
+        {
+            string json = JsonConvert.SerializeObject(
+                new AddressWithDataMember
+                {
+                    AddressLine1 = "value!"
+                },
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new EscapedPropertiesContractResolver
+                    {
+                        PropertySuffix = @"-'-""-"
+                    }
+                });
+
+            Assert.AreEqual(@"{""AddressLine1-'-\""-"":""value!""}", json);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+
+            Assert.AreEqual(@"AddressLine1-'-""-", reader.Value);
+        }
+
+        [Test]
+        public async Task SerializeWithHtmlEscapedPropertyNameAsync()
+        {
+            string json = JsonConvert.SerializeObject(
+                new AddressWithDataMember
+                {
+                    AddressLine1 = "value!"
+                },
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new EscapedPropertiesContractResolver
+                    {
+                        PropertyPrefix = "<b>",
+                        PropertySuffix = "</b>"
+                    },
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                });
+
+            Assert.AreEqual(@"{""\u003cb\u003eAddressLine1\u003c/b\u003e"":""value!""}", json);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            await reader.ReadAsync();
+            await reader.ReadAsync();
+
+            Assert.AreEqual(@"<b>AddressLine1</b>", reader.Value);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/ExtensionDataAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ExtensionDataAsyncTests.cs
@@ -1,0 +1,109 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class ExtensionDataAsyncTests : TestFixtureBase
+    {
+        public class Item
+        {
+            [JsonExtensionData]
+            public IDictionary<string, JToken> ExtensionData;
+
+            public IEnumerable<string> Foo
+            {
+                get { yield return "foo"; yield return "bar"; }
+            }
+        }
+
+        [Test]
+        public async Task Deserialize_WriteJsonDirectlyToJTokenAsync()
+        {
+            JsonSerializer jsonSerializer = new JsonSerializer
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+            StringWriter stringWriter = new StringWriter();
+            await jsonSerializer.SerializeAsync(stringWriter, new Item());
+            string str = stringWriter.GetStringBuilder().ToString();
+            Item deserialize = await jsonSerializer.DeserializeAsync<Item>(new JsonTextReader(new StringReader(str)));
+
+            JToken value = deserialize.ExtensionData["Foo"]["$type"];
+            Assert.AreEqual(JTokenType.String, value.Type);
+            Assert.AreEqual("foo", (string)deserialize.ExtensionData["Foo"]["$values"][0]);
+            Assert.AreEqual("bar", (string)deserialize.ExtensionData["Foo"]["$values"][1]);
+        }
+
+        public class ItemWithConstructor
+        {
+            [JsonExtensionData]
+            public IDictionary<string, JToken> ExtensionData;
+
+            public ItemWithConstructor(string temp)
+            {
+            }
+
+            public IEnumerable<string> Foo
+            {
+                get { yield return "foo"; yield return "bar"; }
+            }
+        }
+
+        [Test]
+        public async Task DeserializeWithConstructor_WriteJsonDirectlyToJToken()
+        {
+            JsonSerializer jsonSerializer = new JsonSerializer
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+            StringWriter stringWriter = new StringWriter();
+            await jsonSerializer.SerializeAsync(stringWriter, new ItemWithConstructor(null));
+            string str = stringWriter.GetStringBuilder().ToString();
+            Item deserialize = await jsonSerializer.DeserializeAsync<Item>(new JsonTextReader(new StringReader(str)));
+
+            JToken value = deserialize.ExtensionData["Foo"]["$type"];
+            Assert.AreEqual(JTokenType.String, value.Type);
+            Assert.AreEqual("foo", (string)deserialize.ExtensionData["Foo"]["$values"][0]);
+            Assert.AreEqual("bar", (string)deserialize.ExtensionData["Foo"]["$values"][1]);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerAsyncTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerAsyncTest.cs
@@ -1,0 +1,599 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+using System.ComponentModel.DataAnnotations;
+#endif
+using System.IO;
+using System.Xml;
+using System.Diagnostics;
+using Newtonsoft.Json.Bson;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Tests.TestObjects;
+using System.Runtime.Serialization;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Linq;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class JsonSerializerAsyncTest : TestFixtureBase
+    {
+        public class ErroringClass
+        {
+            public DateTime Tags { get; set; }
+        }
+
+        [Test]
+        public async Task DontCloseInputOnDeserializeErrorAsync()
+        {
+            using (var s = System.IO.File.OpenRead("large.json"))
+            {
+                try
+                {
+                    using (JsonTextReader reader = new JsonTextReader(new StreamReader(s)))
+                    {
+                        reader.SupportMultipleContent = true;
+                        reader.CloseInput = false;
+
+                        // read into array
+                        await reader.ReadAsync();
+
+                        var ser = new JsonSerializer();
+                        ser.CheckAdditionalContent = false;
+
+                        await ser.DeserializeAsync<IList<ErroringClass>>(reader);
+                    }
+
+                    Assert.Fail();
+                }
+                catch (Exception)
+                {
+                    Assert.IsTrue(s.Position > 0);
+
+                    s.Seek(0, SeekOrigin.Begin);
+
+                    Assert.AreEqual(0, s.Position);
+                }
+            }
+        }
+
+        [Test]
+        public async Task PopulateResetSettingsAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"[""2000-01-01T01:01:01+00:00""]"));
+            Assert.AreEqual(DateParseHandling.DateTime, reader.DateParseHandling);
+
+            JsonSerializer serializer = new JsonSerializer
+            {
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+
+            IList<object> l = new List<object>();
+            await serializer.PopulateAsync(reader, l);
+
+            Assert.AreEqual(typeof(DateTimeOffset), l[0].GetType());
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 1, 1, 1, TimeSpan.Zero), l[0]);
+
+            Assert.AreEqual(DateParseHandling.DateTime, reader.DateParseHandling);
+        }
+
+        [Test]
+        public async Task ConversionOperatorAsync()
+        {
+            // Creating a simple dictionary that has a non-string key
+            var dictStore = new Dictionary<DictionaryKeyCast, int>();
+            for (var i = 0; i < 800; i++)
+            {
+                dictStore.Add(new DictionaryKeyCast(i.ToString(CultureInfo.InvariantCulture), i), i);
+            }
+            var settings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+            var jsonSerializer = JsonSerializer.Create(settings);
+            var ms = new MemoryStream();
+
+            var streamWriter = new StreamWriter(ms);
+            await jsonSerializer.SerializeAsync(streamWriter, dictStore);
+            await streamWriter.FlushAsync();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var stopWatch = Stopwatch.StartNew();
+            var deserialize = await jsonSerializer.DeserializeAsync(new StreamReader(ms), typeof(Dictionary<DictionaryKeyCast, int>));
+            stopWatch.Stop();
+        }
+
+        internal class DictionaryKeyCast
+        {
+            private string _name;
+            private int _number;
+
+            public DictionaryKeyCast(string name, int number)
+            {
+                _name = name;
+                _number = number;
+            }
+
+            public override string ToString()
+            {
+                return _name + " " + _number;
+            }
+
+            public static implicit operator DictionaryKeyCast(string dictionaryKey)
+            {
+                var strings = dictionaryKey.Split(' ');
+                return new DictionaryKeyCast(strings[0], Convert.ToInt32(strings[1]));
+            }
+        }
+
+        [Test]
+        public async Task ObjectCreationHandlingReplaceAsync()
+        {
+            string json = "{bar:[1,2,3], foo:'hello'}";
+
+            JsonSerializer s = new JsonSerializer();
+            s.ObjectCreationHandling = ObjectCreationHandling.Replace;
+
+            ClassWithArray wibble = (ClassWithArray)await s.DeserializeAsync(new StringReader(json), typeof(ClassWithArray));
+
+            Assert.AreEqual("hello", wibble.Foo);
+
+            Assert.AreEqual(1, wibble.Bar.Count);
+        }
+
+        private class MyClass
+        {
+            public byte[] Prop1 { get; set; }
+
+            public MyClass()
+            {
+                Prop1 = new byte[0];
+            }
+        }
+
+        [Test]
+        public async Task DeserializeByteArrayAsync()
+        {
+            JsonSerializer serializer1 = new JsonSerializer();
+            serializer1.Converters.Add(new IsoDateTimeConverter());
+            serializer1.NullValueHandling = NullValueHandling.Ignore;
+
+            string json = @"[{""Prop1"":""""},{""Prop1"":""""}]";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+
+            MyClass[] z = (MyClass[])await serializer1.DeserializeAsync(reader, typeof(MyClass[]));
+            Assert.AreEqual(2, z.Length);
+            Assert.AreEqual(0, z[0].Prop1.Length);
+            Assert.AreEqual(0, z[1].Prop1.Length);
+        }
+
+        public class TimeZoneOffsetObject
+        {
+            public DateTimeOffset Offset { get; set; }
+        }
+
+        [Test]
+        public async Task ReadWriteTimeZoneOffsetIsoAsync()
+        {
+            var serializeObject = JsonConvert.SerializeObject(new TimeZoneOffsetObject
+            {
+                Offset = new DateTimeOffset(new DateTime(2000, 1, 1), TimeSpan.FromHours(6))
+            });
+
+            Assert.AreEqual("{\"Offset\":\"2000-01-01T00:00:00+06:00\"}", serializeObject);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(serializeObject));
+            reader.DateParseHandling = DateParseHandling.None;
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            var deserializeObject = await serializer.DeserializeAsync<TimeZoneOffsetObject>(reader);
+
+            Assert.AreEqual(TimeSpan.FromHours(6), deserializeObject.Offset.Offset);
+            Assert.AreEqual(new DateTime(2000, 1, 1), deserializeObject.Offset.Date);
+        }
+
+        [Test]
+        public async Task ReadWriteTimeZoneOffsetMsAjaxAsync()
+        {
+            var serializeObject = JsonConvert.SerializeObject(new TimeZoneOffsetObject
+            {
+                Offset = new DateTimeOffset(new DateTime(2000, 1, 1), TimeSpan.FromHours(6))
+            }, Formatting.None, new JsonSerializerSettings { DateFormatHandling = DateFormatHandling.MicrosoftDateFormat });
+
+            Assert.AreEqual("{\"Offset\":\"\\/Date(946663200000+0600)\\/\"}", serializeObject);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(serializeObject));
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.DateParseHandling = DateParseHandling.None;
+
+            var deserializeObject = await serializer.DeserializeAsync<TimeZoneOffsetObject>(reader);
+
+            Assert.AreEqual(TimeSpan.FromHours(6), deserializeObject.Offset.Offset);
+            Assert.AreEqual(new DateTime(2000, 1, 1), deserializeObject.Offset.Date);
+        }
+
+        [Test]
+        public async Task DeserializeDecimalPropertyExactAsync()
+        {
+            string json = "{Amount:123456789876543.21}";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            Invoice i = await serializer.DeserializeAsync<Invoice>(reader);
+            Assert.AreEqual(123456789876543.21m, i.Amount);
+        }
+
+        [Test]
+        public async Task DeserializeDecimalDictionaryExactAsync()
+        {
+            string json = "{'Value':123456789876543.21}";
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            reader.FloatParseHandling = FloatParseHandling.Decimal;
+
+            JsonSerializer serializer = new JsonSerializer();
+
+            IDictionary<string, decimal> d = await serializer.DeserializeAsync<IDictionary<string, decimal>>(reader);
+            Assert.AreEqual(123456789876543.21m, d["Value"]);
+        }
+
+        [Test]
+        public async Task DeserializeByteArrayWithTypeNameHandlingAsync()
+        {
+            TestObject test = new TestObject("Test", new byte[] { 72, 63, 62, 71, 92, 55 });
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.TypeNameHandling = TypeNameHandling.All;
+
+            byte[] objectBytes;
+            using (MemoryStream stream = new MemoryStream())
+            using (JsonWriter jsonWriter = new JsonTextWriter(new StreamWriter(stream)))
+            {
+                await serializer.SerializeAsync(jsonWriter, test);
+                await jsonWriter.FlushAsync();
+
+                objectBytes = stream.ToArray();
+            }
+
+            using (MemoryStream stream = new MemoryStream(objectBytes))
+            using (JsonReader jsonReader = new JsonTextReader(new StreamReader(stream)))
+            {
+                // Get exception here
+                TestObject newObject = (TestObject)await serializer.DeserializeAsync(jsonReader);
+
+                Assert.AreEqual("Test", newObject.Name);
+                CollectionAssert.AreEquivalent(new byte[] { 72, 63, 62, 71, 92, 55 }, newObject.Data);
+            }
+        }
+
+        [Test]
+        public async Task DeserializeObjectDictionaryAsync()
+        {
+            var serializer = JsonSerializer.Create(new JsonSerializerSettings());
+            var dict = await serializer.DeserializeAsync<Dictionary<string, string>>(new JsonTextReader(new StringReader("{'k1':'','k2':'v2'}")));
+
+            Assert.AreEqual("", dict["k1"]);
+            Assert.AreEqual("v2", dict["k2"]);
+        }
+
+        public class MultipleItemsClass
+        {
+            public string Name { get; set; }
+        }
+
+        [Test]
+        public async Task MultipleItemsAsync()
+        {
+            IList<MultipleItemsClass> values = new List<MultipleItemsClass>();
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{ ""name"": ""bar"" }{ ""name"": ""baz"" }"));
+            reader.SupportMultipleContent = true;
+
+            while (await reader.ReadAsync())
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                MultipleItemsClass foo = await serializer.DeserializeAsync<MultipleItemsClass>(reader);
+
+                values.Add(foo);
+            }
+
+            Assert.AreEqual(2, values.Count);
+            Assert.AreEqual("bar", values[0].Name);
+            Assert.AreEqual("baz", values[1].Name);
+        }
+
+        [Test]
+        public async Task TokenFromBsonAsync()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+            await writer.WriteStartArrayAsync();
+            await writer.WriteValueAsync("2000-01-02T03:04:05+06:00");
+            await writer.WriteEndArrayAsync();
+
+            byte[] data = ms.ToArray();
+            BsonReader reader = new BsonReader(new MemoryStream(data))
+            {
+                ReadRootValueAsArray = true
+            };
+
+            JArray a = (JArray)await JToken.ReadFromAsync(reader);
+            JValue v = (JValue)a[0];
+
+            Assert.AreEqual(typeof(string), v.Value.GetType());
+            StringAssert.AreEqual(@"[
+  ""2000-01-02T03:04:05+06:00""
+]", a.ToString());
+        }
+
+        [Test]
+        public async Task DeserializeEmptyJsonStringAsync()
+        {
+            string s = (string)await new JsonSerializer().DeserializeAsync(new JsonTextReader(new StringReader("''")));
+            Assert.AreEqual("", s);
+        }
+
+        [Test]
+        public async Task CheckAdditionalContentAsync()
+        {
+            string json = "{one:1}{}";
+
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            JsonSerializer s = JsonSerializer.Create(settings);
+            IDictionary<string, int> o = await s.DeserializeAsync<Dictionary<string, int>>(new JsonTextReader(new StringReader(json)));
+
+            Assert.IsNotNull(o);
+            Assert.AreEqual(1, o["one"]);
+
+            settings.CheckAdditionalContent = true;
+            s = JsonSerializer.Create(settings);
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await s.DeserializeAsync<Dictionary<string, int>>(new JsonTextReader(new StringReader(json))); }, "Additional text encountered after finished reading JSON content: {. Path '', line 1, position 7.");
+        }
+
+        [Test]
+        public async Task AdditionalContentAfterFinishAsync()
+        {
+            await ExceptionAssert.ThrowsAsync<JsonException>(async () =>
+            {
+                string json = "[{},1]";
+
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.CheckAdditionalContent = true;
+
+                var reader = new JsonTextReader(new StringReader(json));
+                await reader.ReadAsync();
+                await reader.ReadAsync();
+
+                await serializer.DeserializeAsync(reader, typeof(MyType));
+            }, "Additional text found in JSON string after finishing deserializing object.");
+        }
+
+        public class MyType
+        {
+        }
+
+        [Test]
+        public async Task JsonSerializerDateFormatStringAsync()
+        {
+            CultureInfo culture = new CultureInfo("en-NZ");
+            culture.DateTimeFormat.AMDesignator = "a.m.";
+            culture.DateTimeFormat.PMDesignator = "p.m.";
+
+            IList<object> dates = new List<object>
+            {
+                new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc),
+                new DateTimeOffset(2000, 12, 12, 12, 12, 12, TimeSpan.FromHours(1))
+            };
+
+            StringWriter sw = new StringWriter();
+            JsonTextWriter jsonWriter = new JsonTextWriter(sw);
+
+            JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                DateFormatString = "yyyy tt",
+                Culture = culture,
+                Formatting = Formatting.Indented
+            });
+            await serializer.SerializeAsync(jsonWriter, dates);
+
+            Assert.IsNull(jsonWriter.DateFormatString);
+            Assert.AreEqual(CultureInfo.InvariantCulture, jsonWriter.Culture);
+            Assert.AreEqual(Formatting.None, jsonWriter.Formatting);
+
+            string json = sw.ToString();
+
+            StringAssert.AreEqual(@"[
+  ""2000 p.m."",
+  ""2000 p.m.""
+]", json);
+        }
+
+        [Test]
+        public async Task JsonSerializerStringEscapeHandlingAsync()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter jsonWriter = new JsonTextWriter(sw);
+
+            JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                StringEscapeHandling = StringEscapeHandling.EscapeHtml,
+                Formatting = Formatting.Indented
+            });
+            await serializer.SerializeAsync(jsonWriter, new { html = "<html></html>" });
+
+            Assert.AreEqual(StringEscapeHandling.Default, jsonWriter.StringEscapeHandling);
+
+            string json = sw.ToString();
+
+            StringAssert.AreEqual(@"{
+  ""html"": ""\u003chtml\u003e\u003c/html\u003e""
+}", json);
+        }
+
+        [Test]
+        public async Task DeserializeDecimalAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader("1234567890.123456"));
+            var settings = new JsonSerializerSettings();
+            var serialiser = JsonSerializer.Create(settings);
+            decimal? d = await serialiser.DeserializeAsync<decimal?>(reader);
+
+            Assert.AreEqual(1234567890.123456m, d);
+        }
+
+        [Test]
+        public async Task DateFormatStringWithDateTimeAsync()
+        {
+            DateTime dt = new DateTime(2000, 12, 22);
+            string dateFormatString = "yyyy'-pie-'MMM'-'dddd'-'dd";
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                DateFormatString = dateFormatString
+            };
+
+            string json = JsonConvert.SerializeObject(dt, settings);
+
+            Assert.AreEqual(@"""2000-pie-Dec-Friday-22""", json);
+
+            DateTime dt1 = JsonConvert.DeserializeObject<DateTime>(json, settings);
+
+            Assert.AreEqual(dt, dt1);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json))
+            {
+                DateFormatString = dateFormatString
+            };
+            JValue v = (JValue)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual(JTokenType.Date, v.Type);
+            Assert.AreEqual(typeof(DateTime), v.Value.GetType());
+            Assert.AreEqual(dt, (DateTime)v.Value);
+
+            reader = new JsonTextReader(new StringReader(@"""abc"""))
+            {
+                DateFormatString = dateFormatString
+            };
+            v = (JValue)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual(JTokenType.String, v.Type);
+            Assert.AreEqual(typeof(string), v.Value.GetType());
+            Assert.AreEqual("abc", v.Value);
+        }
+
+        [Test]
+        public async Task DateFormatStringWithDateTimeAndCultureAsync()
+        {
+            CultureInfo culture = new CultureInfo("tr-TR");
+
+            DateTime dt = new DateTime(2000, 12, 22);
+            string dateFormatString = "yyyy'-pie-'MMM'-'dddd'-'dd";
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                DateFormatString = dateFormatString,
+                Culture = culture
+            };
+
+            string json = JsonConvert.SerializeObject(dt, settings);
+
+            Assert.AreEqual(@"""2000-pie-Ara-Cuma-22""", json);
+
+            DateTime dt1 = JsonConvert.DeserializeObject<DateTime>(json, settings);
+
+            Assert.AreEqual(dt, dt1);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json))
+            {
+                DateFormatString = dateFormatString,
+                Culture = culture
+            };
+            JValue v = (JValue)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual(JTokenType.Date, v.Type);
+            Assert.AreEqual(typeof(DateTime), v.Value.GetType());
+            Assert.AreEqual(dt, (DateTime)v.Value);
+
+            reader = new JsonTextReader(new StringReader(@"""2000-pie-Dec-Friday-22"""))
+            {
+                DateFormatString = dateFormatString,
+                Culture = culture
+            };
+            v = (JValue)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual(JTokenType.String, v.Type);
+            Assert.AreEqual(typeof(string), v.Value.GetType());
+            Assert.AreEqual("2000-pie-Dec-Friday-22", v.Value);
+        }
+
+        [Test]
+        public async Task DateFormatStringWithDateTimeOffsetAsync()
+        {
+            DateTimeOffset dt = new DateTimeOffset(new DateTime(2000, 12, 22));
+            string dateFormatString = "yyyy'-pie-'MMM'-'dddd'-'dd";
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                DateFormatString = dateFormatString
+            };
+
+            string json = JsonConvert.SerializeObject(dt, settings);
+
+            Assert.AreEqual(@"""2000-pie-Dec-Friday-22""", json);
+
+            DateTimeOffset dt1 = JsonConvert.DeserializeObject<DateTimeOffset>(json, settings);
+
+            Assert.AreEqual(dt, dt1);
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json))
+            {
+                DateFormatString = dateFormatString,
+                DateParseHandling = DateParseHandling.DateTimeOffset
+            };
+            JValue v = (JValue)await JToken.ReadFromAsync(reader);
+
+            Assert.AreEqual(JTokenType.Date, v.Type);
+            Assert.AreEqual(typeof(DateTimeOffset), v.Value.GetType());
+            Assert.AreEqual(dt, (DateTimeOffset)v.Value);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerCollectionsAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerCollectionsAsyncTests.cs
@@ -1,0 +1,73 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class JsonSerializerCollectionsAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task CustomCollectionSerializationAsync()
+        {
+            ProductCollection collection = new ProductCollection
+            {
+                new Product { Name = "Test1" },
+                new Product { Name = "Test2" },
+                new Product { Name = "Test3" }
+            };
+
+            JsonSerializer jsonSerializer = new JsonSerializer
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            };
+
+            StringWriter sw = new StringWriter();
+
+            await jsonSerializer.SerializeAsync(sw, collection);
+
+            Assert.AreEqual(@"[{""Name"":""Test1"",""ExpiryDate"":""2000-01-01T00:00:00Z"",""Price"":0.0,""Sizes"":null},{""Name"":""Test2"",""ExpiryDate"":""2000-01-01T00:00:00Z"",""Price"":0.0,""Sizes"":null},{""Name"":""Test3"",""ExpiryDate"":""2000-01-01T00:00:00Z"",""Price"":0.0,""Sizes"":null}]",
+                sw.GetStringBuilder().ToString());
+
+            ProductCollection collectionNew = (ProductCollection)await jsonSerializer.DeserializeAsync(new JsonTextReader(new StringReader(sw.GetStringBuilder().ToString())), typeof(ProductCollection));
+
+            CollectionAssert.AreEqual(collection, collectionNew);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingAsyncTests.cs
@@ -1,0 +1,109 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Tests.TestObjects;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class MissingMemberHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task MissingMemberDeserializeOkayAsync()
+        {
+            Product product = new Product
+            {
+                Name = "Apple",
+                ExpiryDate = new DateTime(2008, 12, 28), Price = 3.99M,
+                Sizes = new[] {"Small", "Medium", "Large"}
+            };
+
+            string output = JsonConvert.SerializeObject(product);
+
+            //{
+            //  "Name": "Apple",
+            //  "ExpiryDate": new Date(1230422400000),
+            //  "Price": 3.99,
+            //  "Sizes": [
+            //    "Small",
+            //    "Medium",
+            //    "Large"
+            //  ]
+            //}
+
+            JsonSerializer jsonSerializer = new JsonSerializer
+            {
+                MissingMemberHandling = MissingMemberHandling.Ignore
+            };
+
+            object deserializedValue;
+
+            using (JsonReader jsonReader = new JsonTextReader(new StringReader(output)))
+            {
+                deserializedValue = await jsonSerializer.DeserializeAsync(jsonReader, typeof(ProductShort));
+            }
+
+            ProductShort deserializedProductShort = (ProductShort)deserializedValue;
+
+            Assert.AreEqual("Apple", deserializedProductShort.Name);
+            Assert.AreEqual(new DateTime(2008, 12, 28), deserializedProductShort.ExpiryDate);
+            Assert.AreEqual("Small", deserializedProductShort.Sizes[0]);
+            Assert.AreEqual("Medium", deserializedProductShort.Sizes[1]);
+            Assert.AreEqual("Large", deserializedProductShort.Sizes[2]);
+        }
+
+        [Test]
+        public async Task MissingMemberIgnoreComplexValueAsync()
+        {
+            JsonSerializer serializer = new JsonSerializer
+            {
+                MissingMemberHandling = MissingMemberHandling.Ignore
+            };
+            serializer.Converters.Add(new JavaScriptDateTimeConverter());
+
+            string response = @"{""PreProperty"":1,""DateProperty"":new Date(1225962698973),""PostProperty"":2}";
+
+            MyClass myClass = (MyClass)await serializer.DeserializeAsync(new StringReader(response), typeof(MyClass));
+
+            Assert.AreEqual(1, myClass.PreProperty);
+            Assert.AreEqual(2, myClass.PostProperty);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/NullValueHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/NullValueHandlingAsyncTests.cs
@@ -1,0 +1,74 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class NullValueHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task NullValueHandlingSerializationAsync()
+        {
+            Store s1 = new Store();
+
+            JsonSerializer jsonSerializer = new JsonSerializer
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            };
+
+            StringWriter sw = new StringWriter();
+            await jsonSerializer.SerializeAsync(sw, s1);
+
+            //JsonConvert.ConvertDateTimeToJavaScriptTicks(s1.Establised.DateTime)
+
+            Assert.AreEqual(@"{""Color"":4,""Establised"":""2010-01-22T01:01:01Z"",""Width"":1.1,""Employees"":999,""RoomsPerFloor"":[1,2,3,4,5,6,7,8,9],""Open"":false,""Symbol"":""@"",""Mottos"":[""Hello World"",""öäüÖÄÜ\\'{new Date(12345);}[222]_µ@²³~"",null,"" ""],""Cost"":100980.1,""Escape"":""\r\n\t\f\b?{\\r\\n\""'"",""product"":[{""Name"":""Rocket"",""ExpiryDate"":""2000-02-02T23:01:30Z"",""Price"":0.0},{""Name"":""Alien"",""ExpiryDate"":""2000-01-01T00:00:00Z"",""Price"":0.0}]}", sw.GetStringBuilder().ToString());
+
+            Store s2 = (Store)await jsonSerializer.DeserializeAsync(new JsonTextReader(new StringReader("{}")), typeof(Store));
+            Assert.AreEqual("\r\n\t\f\b?{\\r\\n\"\'", s2.Escape);
+
+            Store s3 = (Store)await jsonSerializer.DeserializeAsync(new JsonTextReader(new StringReader(@"{""Escape"":null}")), typeof(Store));
+            Assert.AreEqual("\r\n\t\f\b?{\\r\\n\"\'", s3.Escape);
+
+            Store s4 = (Store)await jsonSerializer.DeserializeAsync(new JsonTextReader(new StringReader(@"{""Color"":2,""Establised"":""\/Date(1264071600000+1300)\/"",""Width"":1.1,""Employees"":999,""RoomsPerFloor"":[1,2,3,4,5,6,7,8,9],""Open"":false,""Symbol"":""@"",""Mottos"":[""Hello World"",""öäüÖÄÜ\\'{new Date(12345);}[222]_µ@²³~"",null,"" ""],""Cost"":100980.1,""Escape"":""\r\n\t\f\b?{\\r\\n\""'"",""product"":[{""Name"":""Rocket"",""ExpiryDate"":""\/Date(949485690000+1300)\/"",""Price"":0},{""Name"":""Alien"",""ExpiryDate"":""\/Date(946638000000)\/"",""Price"":0.0}]}")), typeof(Store));
+            Assert.AreEqual(s1.Establised, s3.Establised);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/PopulateAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/PopulateAsyncTests.cs
@@ -1,0 +1,73 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Tests.TestObjects.Organization;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class PopulateAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task PopulateListOfPeopleAsync()
+        {
+            List<Person> p = new List<Person>();
+
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.PopulateAsync(new StringReader(@"[{""Name"":""James""},{""Name"":""Jim""}]"), p);
+
+            Assert.AreEqual(2, p.Count);
+            Assert.AreEqual("James", p[0].Name);
+            Assert.AreEqual("Jim", p[1].Name);
+        }
+
+        [Test]
+        public async Task PopulateDictionaryAsync()
+        {
+            Dictionary<string, string> p = new Dictionary<string, string>();
+
+            JsonSerializer serializer = new JsonSerializer();
+            await serializer.PopulateAsync(new StringReader(@"{""Name"":""James""}"), p);
+
+            Assert.AreEqual(1, p.Count);
+            Assert.AreEqual("James", p["Name"]);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/PreserveReferencesHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/PreserveReferencesHandlingAsyncTests.cs
@@ -1,0 +1,104 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Text;
+using Newtonsoft.Json.Tests.TestObjects;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class PreserveReferencesHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task PreserveReferencesHandlingWithReusedJsonSerializerAsync()
+        {
+            MyClass c = new MyClass();
+
+            IList<MyClass> myClasses1 = new List<MyClass>
+            {
+                c,
+                c
+            };
+
+            var ser = new JsonSerializer()
+            {
+                PreserveReferencesHandling = PreserveReferencesHandling.All
+            };
+
+            MemoryStream ms = new MemoryStream();
+
+            using (var sw = new StreamWriter(ms))
+            using (var writer = new JsonTextWriter(sw) { Formatting = Formatting.Indented })
+            {
+                await ser.SerializeAsync(writer, myClasses1);
+            }
+
+            byte[] data = ms.ToArray();
+            string json = Encoding.UTF8.GetString(data, 0, data.Length);
+
+            StringAssert.AreEqual(@"{
+  ""$id"": ""1"",
+  ""$values"": [
+    {
+      ""$id"": ""2"",
+      ""PreProperty"": 0,
+      ""PostProperty"": 0
+    },
+    {
+      ""$ref"": ""2""
+    }
+  ]
+}", json);
+
+            ms = new MemoryStream(data);
+            IList<MyClass> myClasses2;
+
+            using (var sr = new StreamReader(ms))
+            using (var reader = new JsonTextReader(sr))
+            {
+                myClasses2 = await ser.DeserializeAsync<IList<MyClass>>(reader);
+            }
+
+            Assert.AreEqual(2, myClasses2.Count);
+            Assert.AreEqual(myClasses2[0], myClasses2[1]);
+
+            Assert.AreNotEqual(myClasses1[0], myClasses2[0]);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingAsyncTests.cs
@@ -1,0 +1,544 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Converters;
+using System.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using System.IO;
+using System.Threading;
+using Newtonsoft.Json.Linq;
+using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class SerializationErrorHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task DeserializingErrorHandlingUsingEventAsync()
+        {
+            List<string> errors = new List<string>();
+
+            JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Error = delegate(object sender, ErrorEventArgs args)
+                {
+                    errors.Add(args.ErrorContext.Path + " - " + args.ErrorContext.Member + " - " + args.ErrorContext.Error.Message);
+                    args.ErrorContext.Handled = true;
+                },
+                Converters = { new IsoDateTimeConverter() }
+            });
+            var c = await serializer.DeserializeAsync<List<DateTime>>(new JsonTextReader(new StringReader(@"[
+        ""2009-09-09T00:00:00Z"",
+        ""I am not a date and will error!"",
+        [
+          1
+        ],
+        ""1977-02-20T00:00:00Z"",
+        null,
+        ""2000-12-01T00:00:00Z""
+      ]")));
+
+            // 2009-09-09T00:00:00Z
+            // 1977-02-20T00:00:00Z
+            // 2000-12-01T00:00:00Z
+
+            // The string was not recognized as a valid DateTime. There is a unknown word starting at index 0.
+            // Unexpected token parsing date. Expected String, got StartArray.
+            // Cannot convert null value to System.DateTime.
+
+            Assert.AreEqual(3, c.Count);
+            Assert.AreEqual(new DateTime(2009, 9, 9, 0, 0, 0, DateTimeKind.Utc), c[0]);
+            Assert.AreEqual(new DateTime(1977, 2, 20, 0, 0, 0, DateTimeKind.Utc), c[1]);
+            Assert.AreEqual(new DateTime(2000, 12, 1, 0, 0, 0, DateTimeKind.Utc), c[2]);
+
+            Assert.AreEqual(3, errors.Count);
+            var possibleErrs = new[]
+            {
+                "[1] - 1 - The string was not recognized as a valid DateTime. There is an unknown word starting at index 0.",
+                "[1] - 1 - String was not recognized as a valid DateTime."
+            };
+
+            Assert.IsTrue(possibleErrs.Any(m => m == errors[0]),
+                "Expected One of: " + string.Join(Environment.NewLine, possibleErrs) + Environment.NewLine + "But was: " + errors[0]);
+
+            Assert.AreEqual("[2] - 2 - Unexpected token parsing date. Expected String, got StartArray. Path '[2]', line 4, position 9.", errors[1]);
+            Assert.AreEqual("[4] - 4 - Cannot convert null value to System.DateTime. Path '[4]', line 8, position 12.", errors[2]);
+        }
+
+        [Test]
+        public async Task DeserializeNestedUnhandledAsync()
+        {
+            List<string> errors = new List<string>();
+
+            string json = @"[[""kjhkjhkjhkjh""]]";
+
+            Exception e = null;
+            try
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Error += delegate(object sender, ErrorEventArgs args)
+                {
+                    // only log an error once
+                    if (args.CurrentObject == args.ErrorContext.OriginalObject)
+                    {
+                        errors.Add(args.ErrorContext.Path + " - " + args.ErrorContext.Member + " - " + args.ErrorContext.Error.Message);
+                    }
+                };
+
+                await serializer.DeserializeAsync(new StringReader(json), typeof(List<List<DateTime>>));
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+            }
+
+            Assert.AreEqual(@"Could not convert string to DateTime: kjhkjhkjhkjh. Path '[0][0]', line 1, position 16.", e.Message);
+
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual(@"[0][0] - 0 - Could not convert string to DateTime: kjhkjhkjhkjh. Path '[0][0]', line 1, position 16.", errors[0]);
+        }
+
+        [Test]
+        public async Task MultipleRequiredPropertyErrorsAsync()
+        {
+            string json = "{}";
+            List<string> errors = new List<string>();
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.MetadataPropertyHandling = MetadataPropertyHandling.Default;
+            serializer.Error += delegate(object sender, ErrorEventArgs args)
+            {
+                errors.Add(args.ErrorContext.Path + " - " + args.ErrorContext.Member + " - " + args.ErrorContext.Error.Message);
+                args.ErrorContext.Handled = true;
+            };
+            await serializer.DeserializeAsync(new JsonTextReader(new StringReader(json)), typeof(MyTypeWithRequiredMembers));
+
+            Assert.AreEqual(2, errors.Count);
+            Assert.IsTrue(errors[0].StartsWith(" - Required1 - Required property 'Required1' not found in JSON. Path '', line 1, position 2."));
+            Assert.IsTrue(errors[1].StartsWith(" - Required2 - Required property 'Required2' not found in JSON. Path '', line 1, position 2."));
+        }
+
+        [Test]
+        public async Task HandlingArrayErrorsAsync()
+        {
+            string json = "[\"a\",\"b\",\"45\",34]";
+
+            List<string> errors = new List<string>();
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Error += delegate(object sender, ErrorEventArgs args)
+            {
+                errors.Add(args.ErrorContext.Path + " - " + args.ErrorContext.Member + " - " + args.ErrorContext.Error.Message);
+                args.ErrorContext.Handled = true;
+            };
+
+            await serializer.DeserializeAsync(new JsonTextReader(new StringReader(json)), typeof(int[]));
+
+            Assert.AreEqual(2, errors.Count);
+            Assert.AreEqual("[0] - 0 - Could not convert string to integer: a. Path '[0]', line 1, position 4.", errors[0]);
+            Assert.AreEqual("[1] - 1 - Could not convert string to integer: b. Path '[1]', line 1, position 8.", errors[1]);
+        }
+
+        [Test]
+        public async Task HandlingMultidimensionalArrayErrorsAsync()
+        {
+            string json = "[[\"a\",\"45\"],[\"b\",34]]";
+
+            List<string> errors = new List<string>();
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Error += delegate(object sender, ErrorEventArgs args)
+            {
+                errors.Add(args.ErrorContext.Path + " - " + args.ErrorContext.Member + " - " + args.ErrorContext.Error.Message);
+                args.ErrorContext.Handled = true;
+            };
+
+            await serializer.DeserializeAsync(new JsonTextReader(new StringReader(json)), typeof(int[,]));
+
+            Assert.AreEqual(2, errors.Count);
+            Assert.AreEqual("[0][0] - 0 - Could not convert string to integer: a. Path '[0][0]', line 1, position 5.", errors[0]);
+            Assert.AreEqual("[1][0] - 0 - Could not convert string to integer: b. Path '[1][0]', line 1, position 16.", errors[1]);
+        }
+
+        [Test]
+        public async Task ErrorHandlingAndAvoidingRecursiveDepthErrorAsync()
+        {
+            string json = "{'A':{'A':{'A':{'A':{'A':{}}}}}}";
+            JsonSerializer serializer = new JsonSerializer();
+            IList<string> errors = new List<string>();
+            serializer.Error += (sender, e) =>
+            {
+                e.ErrorContext.Handled = true;
+                errors.Add(e.ErrorContext.Path);
+            };
+
+            await serializer.DeserializeAsync<Nest>(new JsonTextReader(new StringReader(json)) { MaxDepth = 3 });
+
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual("A.A.A", errors[0]);
+        }
+
+        public class Nest
+        {
+            public Nest A { get; set; }
+        }
+
+        [Test]
+        public async Task InfiniteErrorHandlingLoopFromInputErrorAsync()
+        {
+            IList<string> errors = new List<string>();
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.Error += (sender, e) =>
+            {
+                errors.Add(e.ErrorContext.Error.Message);
+                e.ErrorContext.Handled = true;
+            };
+
+            ErrorPerson[] result = await serializer.DeserializeAsync<ErrorPerson[]>(new JsonTextReader(new ThrowingReader()));
+
+            Assert.IsNull(result);
+            Assert.AreEqual(3, errors.Count);
+            Assert.AreEqual("too far", errors[0]);
+            Assert.AreEqual("too far", errors[1]);
+            Assert.AreEqual("Infinite loop detected from error handling. Path '[1023]', line 1, position 65536.", errors[2]);
+        }
+
+        [Test]
+        public async Task ArrayHandling_JTokenReaderAsync()
+        {
+            IList<string> errors = new List<string>();
+
+            JTokenReader reader = new JTokenReader(new JArray(0, true));
+
+            JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Error = (sender, arg) =>
+                {
+                    errors.Add(arg.ErrorContext.Error.Message);
+                    arg.ErrorContext.Handled = true;
+                }
+            });
+            object o = await serializer.DeserializeAsync(reader, typeof(int[]));
+
+            Assert.IsNotNull(o);
+
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual("Error reading integer. Unexpected token: Boolean. Path '[1]'.", errors[0]);
+
+            Assert.AreEqual(1, ((int[])o).Length);
+            Assert.AreEqual(0, ((int[])o)[0]);
+        }
+
+        [Test]
+        public async Task ErrorHandlingEndOfContentAsync()
+        {
+            IList<string> errors = new List<string>();
+
+            const string input = "{\"events\":[{\"code\":64411},{\"code\":64411,\"prio";
+
+            const int maxDepth = 256;
+            using (var jsonTextReader = new JsonTextReader(new StringReader(input)) { MaxDepth = maxDepth })
+            {
+                JsonSerializer jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
+                {
+                    MaxDepth = maxDepth,
+                    MetadataPropertyHandling = MetadataPropertyHandling.Default
+                });
+                jsonSerializer.Error += (sender, e) =>
+                {
+                    errors.Add(e.ErrorContext.Error.Message);
+                    e.ErrorContext.Handled = true;
+                };
+
+                LogMessage logMessage = await jsonSerializer.DeserializeAsync<LogMessage>(jsonTextReader);
+
+                Assert.IsNotNull(logMessage.Events);
+                Assert.AreEqual(1, logMessage.Events.Count);
+                Assert.AreEqual("64411", logMessage.Events[0].Code);
+            }
+
+            Assert.AreEqual(3, errors.Count);
+            Assert.AreEqual(@"Unterminated string. Expected delimiter: "". Path 'events[1].code', line 1, position 45.", errors[0]);
+            Assert.AreEqual(@"Unexpected end when deserializing array. Path 'events[1].code', line 1, position 45.", errors[1]);
+            Assert.AreEqual(@"Unexpected end when deserializing object. Path 'events[1].code', line 1, position 45.", errors[2]);
+        }
+
+        [Test]
+        public async Task ErrorHandlingEndOfContentDictionaryAsync()
+        {
+            IList<string> errors = new List<string>();
+
+            const string input = "{\"events\":{\"code\":64411},\"events2\":{\"code\":64412,";
+
+            const int maxDepth = 256;
+            using (var jsonTextReader = new JsonTextReader(new StringReader(input)) { MaxDepth = maxDepth })
+            {
+                JsonSerializer jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings { MaxDepth = maxDepth, MetadataPropertyHandling = MetadataPropertyHandling.Default });
+                jsonSerializer.Error += (sender, e) =>
+                {
+                    errors.Add(e.ErrorContext.Error.Message);
+                    e.ErrorContext.Handled = true;
+                };
+
+                IDictionary<string, LogEvent> logEvents = await jsonSerializer.DeserializeAsync<IDictionary<string, LogEvent>>(jsonTextReader);
+
+                Assert.IsNotNull(logEvents);
+                Assert.AreEqual(2, logEvents.Count);
+                Assert.AreEqual("64411", logEvents["events"].Code);
+                Assert.AreEqual("64412", logEvents["events2"].Code);
+            }
+
+            Assert.AreEqual(2, errors.Count);
+            Assert.AreEqual(@"Unexpected end when deserializing object. Path 'events2.code', line 1, position 49.", errors[0]);
+            Assert.AreEqual(@"Unexpected end when deserializing object. Path 'events2.code', line 1, position 49.", errors[1]);
+        }
+
+        [Test]
+        public async Task NoObjectWithEventAsync()
+        {
+            string json = "{\"}";
+            byte[] byteArray = Encoding.UTF8.GetBytes(json);
+            MemoryStream stream = new MemoryStream(byteArray);
+            JsonTextReader jReader = new JsonTextReader(new StreamReader(stream));
+            JsonSerializer s = new JsonSerializer();
+            s.Error += (sender, args) => { args.ErrorContext.Handled = true; };
+            ErrorPerson2 obj = await s.DeserializeAsync<ErrorPerson2>(jReader);
+
+            Assert.IsNull(obj);
+        }
+
+        [Test]
+        public async Task NoObjectWithAttributeAsync()
+        {
+            string json = "{\"}";
+            byte[] byteArray = Encoding.UTF8.GetBytes(json);
+            MemoryStream stream = new MemoryStream(byteArray);
+            JsonTextReader jReader = new JsonTextReader(new StreamReader(stream));
+            JsonSerializer s = new JsonSerializer();
+
+            await ExceptionAssert.ThrowsAsync<JsonReaderException>(async () => { await s.DeserializeAsync<ErrorTestObject>(jReader); }, @"Unterminated string. Expected delimiter: "". Path '', line 1, position 3.");
+        }
+
+        public class RootThing
+        {
+            public Something Something { get; set; }
+        }
+
+        public class RootSomethingElse
+        {
+            public SomethingElse SomethingElse { get; set; }
+        }
+
+        /// <summary>
+        /// This could be an object we are passing up in an interface.
+        /// </summary>
+        [JsonConverter(typeof(SomethingConverter))]
+        public class Something
+        {
+            public class SomethingConverter : JsonConverter
+            {
+                public override bool CanConvert(Type objectType)
+                {
+                    return true;
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    Assert.Fail("Only async form should be called.");
+                    return null;
+                }
+
+                public override async Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+                {
+                    try
+                    {
+                        // Do own stuff.
+                        // Then call deserialise for inner object.
+                        await serializer.DeserializeAsync(reader, typeof(SomethingElse));
+
+                        return null;
+                    }
+                    catch (Exception ex)
+                    {
+                        // If we get an error wrap it in something less scary.
+                        throw new Exception("An error occurred.", ex);
+                    }
+                }
+
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    Assert.Fail("Only async form should be called.");
+                }
+
+                public override async Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+                {
+                    try
+                    {
+                        Something s = (Something)value;
+
+                        // Do own stuff.
+                        // Then call serialise for inner object.
+                        await serializer.SerializeAsync(writer, s.RootSomethingElse);
+                    }
+                    catch (Exception ex)
+                    {
+                        // If we get an error wrap it in something less scary.
+                        throw new Exception("An error occurred.", ex);
+                    }
+                }
+            }
+
+            public RootSomethingElse RootSomethingElse { get; set; }
+
+            public Something()
+            {
+                RootSomethingElse = new RootSomethingElse();
+            }
+        }
+
+        /// <summary>
+        /// This is an object that is contained in the interface object.
+        /// </summary>
+        [JsonConverter(typeof(SomethingElseConverter))]
+        public class SomethingElse
+        {
+            public class SomethingElseConverter : JsonConverter
+            {
+                public override bool CanConvert(Type objectType)
+                {
+                    return true;
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        [Test]
+        public async Task DeserializeWrappingErrorsAndErrorHandlingAsync()
+        {
+            var serialiser = JsonSerializer.Create(new JsonSerializerSettings());
+
+            string foo = "{ something: { rootSomethingElse { somethingElse: 0 } } }";
+            var reader = new StringReader(foo);
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => { await serialiser.DeserializeAsync(reader, typeof(Something)); }, "An error occurred.");
+        }
+
+        [Test]
+        public async Task SerializeWrappingErrorsAndErrorHandlingAsync()
+        {
+            var serialiser = JsonSerializer.Create(new JsonSerializerSettings());
+
+            Something s = new Something
+            {
+                RootSomethingElse = new RootSomethingElse
+                {
+                    SomethingElse = new SomethingElse()
+                }
+            };
+            RootThing r = new RootThing
+            {
+                Something = s
+            };
+
+            var writer = new StringWriter();
+
+            await ExceptionAssert.ThrowsAsync<Exception>(async () => { await serialiser.SerializeAsync(writer, r); }, "An error occurred.");
+        }
+
+        [Test]
+        public async Task IntegerToLarge_ReadNextValueAsync()
+        {
+            IList<string> errorMessages = new List<string>();
+
+            JsonReader reader = new JsonTextReader(new StringReader(@"{
+  ""string1"": ""blah"",
+  ""int1"": 2147483648,
+  ""string2"": ""also blah"",
+  ""int2"": 2147483648,
+  ""string3"": ""more blah"",
+  ""dateTime1"": ""200NOTDATE"",
+  ""string4"": ""even more blah""
+}"));
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.Error = (sender, args) =>
+            {
+                errorMessages.Add(args.ErrorContext.Error.Message);
+                args.ErrorContext.Handled = true;
+            };
+            JsonSerializer serializer = JsonSerializer.Create(settings);
+
+            DataModel data = new DataModel();
+            await serializer.PopulateAsync(reader, data);
+
+            Assert.AreEqual("blah", data.String1);
+            Assert.AreEqual(0, data.Int1);
+            Assert.AreEqual("also blah", data.String2);
+            Assert.AreEqual(0, data.Int2);
+            Assert.AreEqual("more blah", data.String3);
+            Assert.AreEqual(default(DateTime), data.DateTime1);
+            Assert.AreEqual("even more blah", data.String4);
+
+            //Assert.AreEqual(2, errorMessages.Count);
+            Assert.AreEqual("JSON integer 2147483648 is too large or small for an Int32. Path 'int1', line 3, position 20.", errorMessages[0]);
+            Assert.AreEqual("JSON integer 2147483648 is too large or small for an Int32. Path 'int2', line 5, position 20.", errorMessages[1]);
+            Assert.AreEqual("Could not convert string to DateTime: 200NOTDATE. Path 'dateTime1', line 7, position 27.", errorMessages[2]);
+        }
+
+        private class DataModel
+        {
+            public string String1 { get; set; }
+            public int Int1 { get; set; }
+            public string String2 { get; set; }
+            public int Int2 { get; set; }
+            public string String3 { get; set; }
+            public DateTime DateTime1 { get; set; }
+            public string String4 { get; set; }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/TraceWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TraceWriterAsyncTests.cs
@@ -1,0 +1,302 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.IO;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Text;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Serialization;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class TraceWriterAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task WriteNullableByteAsync()
+        {
+            StringWriter sw = new StringWriter();
+            TraceJsonWriter traceJsonWriter = new TraceJsonWriter(new JsonTextWriter(sw));
+            await traceJsonWriter.WriteStartArrayAsync();
+            await traceJsonWriter.WriteValueAsync((byte?)null);
+            await traceJsonWriter.WriteEndArrayAsync();
+
+            StringAssert.AreEqual(@"Serialized JSON: 
+[
+  null
+]", traceJsonWriter.GetSerializedJsonMessage());
+        }
+
+#if !PORTABLE || NETSTANDARD1_1
+        [Test]
+        public async Task TraceJsonWriterTestAsync()
+        {
+            StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+            JsonTextWriter w = new JsonTextWriter(sw);
+            TraceJsonWriter traceWriter = new TraceJsonWriter(w);
+
+            await traceWriter.WriteStartObjectAsync();
+            await traceWriter.WritePropertyNameAsync("Array");
+            await traceWriter.WriteStartArrayAsync();
+            await traceWriter.WriteValueAsync("String!");
+            await traceWriter.WriteValueAsync(new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc));
+            await traceWriter.WriteValueAsync(new DateTimeOffset(2000, 12, 12, 12, 12, 12, TimeSpan.FromHours(2)));
+            await traceWriter.WriteValueAsync(1.1f);
+            await traceWriter.WriteValueAsync(1.1d);
+            await traceWriter.WriteValueAsync(1.1m);
+            await traceWriter.WriteValueAsync(1);
+            await traceWriter.WriteValueAsync('!');
+            await traceWriter.WriteValueAsync((short)1);
+            await traceWriter.WriteValueAsync((ushort)1);
+            await traceWriter.WriteValueAsync(1);
+            await traceWriter.WriteValueAsync(1U);
+            await traceWriter.WriteValueAsync((sbyte)1);
+            await traceWriter.WriteValueAsync((byte)1);
+            await traceWriter.WriteValueAsync(1L);
+            await traceWriter.WriteValueAsync(1UL);
+            await traceWriter.WriteValueAsync(true);
+
+            await traceWriter.WriteValueAsync((DateTime?)new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc));
+            await traceWriter.WriteValueAsync((DateTimeOffset?)new DateTimeOffset(2000, 12, 12, 12, 12, 12, TimeSpan.FromHours(2)));
+            await traceWriter.WriteValueAsync((float?)1.1f);
+            await traceWriter.WriteValueAsync((double?)1.1d);
+            await traceWriter.WriteValueAsync((decimal?)1.1m);
+            await traceWriter.WriteValueAsync((int?)1);
+            await traceWriter.WriteValueAsync((char?)'!');
+            await traceWriter.WriteValueAsync((short?)1);
+            await traceWriter.WriteValueAsync((ushort?)1);
+            await traceWriter.WriteValueAsync((int?)1);
+            await traceWriter.WriteValueAsync((uint?)1);
+            await traceWriter.WriteValueAsync((sbyte?)1);
+            await traceWriter.WriteValueAsync((byte?)1);
+            await traceWriter.WriteValueAsync((long?)1);
+            await traceWriter.WriteValueAsync((ulong?)1);
+            await traceWriter.WriteValueAsync((bool?)true);
+            await traceWriter.WriteValueAsync(BigInteger.Parse("9999999990000000000000000000000000000000000"));
+
+            await traceWriter.WriteValueAsync((object)true);
+            await traceWriter.WriteValueAsync(TimeSpan.FromMinutes(1));
+            await traceWriter.WriteValueAsync(Guid.Empty);
+            await traceWriter.WriteValueAsync(new Uri("http://www.google.com/"));
+            await traceWriter.WriteValueAsync(Encoding.UTF8.GetBytes("String!"));
+            await traceWriter.WriteRawValueAsync("[1],");
+            await traceWriter.WriteRawAsync("[2]");
+            await traceWriter.WriteNullAsync();
+            await traceWriter.WriteUndefinedAsync();
+            await traceWriter.WriteStartConstructorAsync("ctor");
+            await traceWriter.WriteValueAsync(1);
+            await traceWriter.WriteEndConstructorAsync();
+            await traceWriter.WriteCommentAsync("A comment");
+            await traceWriter.WriteWhitespaceAsync("       ");
+            await traceWriter.WriteEndAsync();
+            await traceWriter.WriteEndObjectAsync();
+            await traceWriter.FlushAsync();
+            await traceWriter.CloseAsync();
+
+            string json = @"{
+  ""Array"": [
+    ""String!"",
+    ""2000-12-12T12:12:12Z"",
+    ""2000-12-12T12:12:12+02:00"",
+    1.1,
+    1.1,
+    1.1,
+    1,
+    ""!"",
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    true,
+    ""2000-12-12T12:12:12Z"",
+    ""2000-12-12T12:12:12+02:00"",
+    1.1,
+    1.1,
+    1.1,
+    1,
+    ""!"",
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    true,
+    9999999990000000000000000000000000000000000,
+    true,
+    true,
+    ""00:01:00"",
+    ""00000000-0000-0000-0000-000000000000"",
+    ""http://www.google.com/"",
+    ""U3RyaW5nIQ=="",
+    [1],[2],
+    null,
+    undefined,
+    new ctor(
+      1
+    )
+    /*A comment*/       
+  ]
+}";
+
+            StringAssert.AreEqual("Serialized JSON: " + Environment.NewLine + json, traceWriter.GetSerializedJsonMessage());
+        }
+
+        [Test]
+        public async Task TraceJsonReaderTestAsync()
+        {
+            string json = @"{
+  ""Array"": [
+    ""String!"",
+    ""2000-12-12T12:12:12Z"",
+    ""2000-12-12T12:12:12Z"",
+    ""2000-12-12T12:12:12+00:00"",
+    ""U3RyaW5nIQ=="",
+    1,
+    1.1,
+    1.2,
+    9999999990000000000000000000000000000000000,
+    null,
+    undefined,
+    new ctor(
+      1
+    )
+    /*A comment*/
+  ]
+}";
+
+            StringReader sw = new StringReader(json);
+            JsonTextReader w = new JsonTextReader(sw);
+            TraceJsonReader traceReader = new TraceJsonReader(w);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartObject, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.PropertyName, traceReader.TokenType);
+            Assert.AreEqual("Array", traceReader.Value);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartArray, traceReader.TokenType);
+            Assert.AreEqual(null, traceReader.Value);
+
+            await traceReader.ReadAsStringAsync();
+            Assert.AreEqual(JsonToken.String, traceReader.TokenType);
+            Assert.AreEqual('"', traceReader.QuoteChar);
+            Assert.AreEqual("String!", traceReader.Value);
+
+            // for great code coverage justice!
+            traceReader.QuoteChar = '\'';
+            Assert.AreEqual('\'', traceReader.QuoteChar);
+
+            await traceReader.ReadAsStringAsync();
+            Assert.AreEqual(JsonToken.String, traceReader.TokenType);
+            Assert.AreEqual("2000-12-12T12:12:12Z", traceReader.Value);
+
+            await traceReader.ReadAsDateTimeAsync();
+            Assert.AreEqual(JsonToken.Date, traceReader.TokenType);
+            Assert.AreEqual(new DateTime(2000, 12, 12, 12, 12, 12, DateTimeKind.Utc), traceReader.Value);
+
+            await traceReader.ReadAsDateTimeOffsetAsync();
+            Assert.AreEqual(JsonToken.Date, traceReader.TokenType);
+            Assert.AreEqual(new DateTimeOffset(2000, 12, 12, 12, 12, 12, TimeSpan.Zero), traceReader.Value);
+
+            await traceReader.ReadAsBytesAsync();
+            Assert.AreEqual(JsonToken.Bytes, traceReader.TokenType);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("String!"), (byte[])traceReader.Value);
+
+            await traceReader.ReadAsInt32Async();
+            Assert.AreEqual(JsonToken.Integer, traceReader.TokenType);
+            Assert.AreEqual(1, traceReader.Value);
+
+            await traceReader.ReadAsDecimalAsync();
+            Assert.AreEqual(JsonToken.Float, traceReader.TokenType);
+            Assert.AreEqual(1.1m, traceReader.Value);
+
+            await traceReader.ReadAsDoubleAsync();
+            Assert.AreEqual(JsonToken.Float, traceReader.TokenType);
+            Assert.AreEqual(1.2d, traceReader.Value);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, traceReader.TokenType);
+            Assert.AreEqual(typeof(BigInteger), traceReader.ValueType);
+            Assert.AreEqual(BigInteger.Parse("9999999990000000000000000000000000000000000"), traceReader.Value);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.Null, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.Undefined, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.StartConstructor, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.Integer, traceReader.TokenType);
+            Assert.AreEqual(1L, traceReader.Value);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.EndConstructor, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.Comment, traceReader.TokenType);
+            Assert.AreEqual("A comment", traceReader.Value);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.EndArray, traceReader.TokenType);
+
+            await traceReader.ReadAsync();
+            Assert.AreEqual(JsonToken.EndObject, traceReader.TokenType);
+
+            Assert.IsFalse(await traceReader.ReadAsync());
+
+            traceReader.Close();
+
+            StringAssert.AreEqual("Deserialized JSON: " + Environment.NewLine + json, traceReader.GetDeserializedJsonMessage());
+        }
+#endif
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingAsyncTests.cs
@@ -1,0 +1,333 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40 || PORTABLE)
+
+using System.Text;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Tests.TestObjects;
+using Newtonsoft.Json.Tests.TestObjects.Organization;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Utilities;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Tests.Serialization
+{
+    [TestFixture]
+    public class TypeNameHandlingAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task NestedValueObjectsAsync()
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 3; i++)
+            {
+                sb.Append(@"{""$value"":");
+            }
+
+            await ExceptionAssert.ThrowsAsync<JsonSerializationException>(async () =>
+            {
+                var reader = new JsonTextReader(new StringReader(sb.ToString()));
+                var ser = new JsonSerializer();
+                ser.MetadataPropertyHandling = MetadataPropertyHandling.Default;
+                await ser.DeserializeAsync<sbyte>(reader);
+            }, "Unexpected token when deserializing primitive value: StartObject. Path '$value', line 1, position 11.");
+        }
+
+        [Test]
+        public async Task SerializeRootTypeNameIfDerivedWithAutoAsync()
+        {
+            var serializer = new JsonSerializer()
+            {
+                TypeNameHandling = TypeNameHandling.Auto
+            };
+            var sw = new StringWriter();
+            await serializer.SerializeAsync(new JsonTextWriter(sw) { Formatting = Formatting.Indented }, new WagePerson(), typeof(Person));
+            var result = sw.ToString();
+
+            StringAssert.AreEqual(@"{
+  ""$type"": ""Newtonsoft.Json.Tests.TestObjects.Organization.WagePerson, Newtonsoft.Json.Tests"",
+  ""HourlyWage"": 0.0,
+  ""Name"": null,
+  ""BirthDate"": ""0001-01-01T00:00:00"",
+  ""LastModified"": ""0001-01-01T00:00:00""
+}", result);
+
+            Assert.IsTrue(result.Contains("WagePerson"));
+            using (var rd = new JsonTextReader(new StringReader(result)))
+            {
+                var person = await serializer.DeserializeAsync<Person>(rd);
+
+                CustomAssert.IsInstanceOfType(typeof(WagePerson), person);
+            }
+        }
+
+        public class Wrapper
+        {
+            public IList<EmployeeReference> Array { get; set; }
+            public IDictionary<string, EmployeeReference> Dictionary { get; set; }
+        }
+
+        public interface ICorrelatedMessage
+        {
+            string CorrelationId { get; set; }
+        }
+
+        public class SendHttpRequest : ICorrelatedMessage
+        {
+            public SendHttpRequest()
+            {
+                RequestEncoding = "UTF-8";
+                Method = "GET";
+            }
+
+            public string Method { get; set; }
+            public Dictionary<string, string> Headers { get; set; }
+            public string Url { get; set; }
+            public Dictionary<string, string> RequestData;
+            public string RequestBodyText { get; set; }
+            public string User { get; set; }
+            public string Passwd { get; set; }
+            public string RequestEncoding { get; set; }
+            public string CorrelationId { get; set; }
+        }
+
+        public class TypeNameProperty
+        {
+            public string Name { get; set; }
+
+            [JsonProperty(TypeNameHandling = TypeNameHandling.All)]
+            public object Value { get; set; }
+        }
+
+        public class NewTypeNameSerializationBinder : ISerializationBinder
+        {
+            public string TypeFormat { get; private set; }
+
+            public NewTypeNameSerializationBinder(string typeFormat)
+            {
+                TypeFormat = typeFormat;
+            }
+
+            public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+            {
+                assemblyName = null;
+                typeName = serializedType.Name;
+            }
+
+            public Type BindToType(string assemblyName, string typeName)
+            {
+                string resolvedTypeName = string.Format(TypeFormat, typeName);
+
+                return Type.GetType(resolvedTypeName, true);
+            }
+        }
+
+        [Test]
+        public async Task CollectionWithAbstractItemsAsync()
+        {
+            HolderClass testObject = new HolderClass();
+            testObject.TestMember = new ContentSubClass("First One");
+            testObject.AnotherTestMember = new Dictionary<int, IList<ContentBaseClass>>();
+            testObject.AnotherTestMember.Add(1, new List<ContentBaseClass>());
+            testObject.AnotherTestMember[1].Add(new ContentSubClass("Second One"));
+            testObject.AThirdTestMember = new ContentSubClass("Third One");
+
+            JsonSerializer serializingTester = new JsonSerializer();
+            serializingTester.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+
+            StringWriter sw = new StringWriter();
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                serializingTester.TypeNameHandling = TypeNameHandling.Auto;
+                await serializingTester.SerializeAsync(jsonWriter, testObject);
+            }
+
+            string json = sw.ToString();
+
+            string contentSubClassRef = ReflectionUtils.GetTypeName(typeof(ContentSubClass), TypeNameAssemblyFormatHandling.Simple, null);
+            string dictionaryRef = ReflectionUtils.GetTypeName(typeof(Dictionary<int, IList<ContentBaseClass>>), TypeNameAssemblyFormatHandling.Simple, null);
+            string listRef = ReflectionUtils.GetTypeName(typeof(List<ContentBaseClass>), TypeNameAssemblyFormatHandling.Simple, null);
+
+            string expected = @"{
+  ""TestMember"": {
+    ""$type"": """ + contentSubClassRef + @""",
+    ""SomeString"": ""First One""
+  },
+  ""AnotherTestMember"": {
+    ""$type"": """ + dictionaryRef + @""",
+    ""1"": [
+      {
+        ""$type"": """ + contentSubClassRef + @""",
+        ""SomeString"": ""Second One""
+      }
+    ]
+  },
+  ""AThirdTestMember"": {
+    ""$type"": """ + contentSubClassRef + @""",
+    ""SomeString"": ""Third One""
+  }
+}";
+
+            StringAssert.AreEqual(expected, json);
+
+            StringReader sr = new StringReader(json);
+
+            JsonSerializer deserializingTester = new JsonSerializer();
+
+            HolderClass anotherTestObject;
+
+            using (JsonTextReader jsonReader = new JsonTextReader(sr))
+            {
+                deserializingTester.TypeNameHandling = TypeNameHandling.Auto;
+
+                anotherTestObject = await deserializingTester.DeserializeAsync<HolderClass>(jsonReader);
+            }
+
+            Assert.IsNotNull(anotherTestObject);
+            CustomAssert.IsInstanceOfType(typeof(ContentSubClass), anotherTestObject.TestMember);
+            CustomAssert.IsInstanceOfType(typeof(Dictionary<int, IList<ContentBaseClass>>), anotherTestObject.AnotherTestMember);
+            Assert.AreEqual(1, anotherTestObject.AnotherTestMember.Count);
+
+            IList<ContentBaseClass> list = anotherTestObject.AnotherTestMember[1];
+
+            CustomAssert.IsInstanceOfType(typeof(List<ContentBaseClass>), list);
+            Assert.AreEqual(1, list.Count);
+            CustomAssert.IsInstanceOfType(typeof(ContentSubClass), list[0]);
+        }
+
+        public class UrlStatus
+        {
+            public int Status { get; set; }
+            public string Url { get; set; }
+        }
+
+        public class CustomEnumerable<T> : IEnumerable<T>
+        {
+            //NOTE: a simple linked list
+            private readonly T value;
+            private readonly CustomEnumerable<T> next;
+            private readonly int count;
+
+            private CustomEnumerable(T value, CustomEnumerable<T> next)
+            {
+                this.value = value;
+                this.next = next;
+                count = this.next.count + 1;
+            }
+
+            public CustomEnumerable()
+            {
+                count = 0;
+            }
+
+            public CustomEnumerable<T> AddFirst(T newVal)
+            {
+                return new CustomEnumerable<T>(newVal, this);
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                if (count == 0) // last node
+                {
+                    yield break;
+                }
+                yield return value;
+
+                var nextInLine = next;
+                while (nextInLine != null)
+                {
+                    if (nextInLine.count != 0)
+                    {
+                        yield return nextInLine.value;
+                    }
+                    nextInLine = nextInLine.next;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        public class Car
+        {
+            // included in JSON
+            public string Model { get; set; }
+            public DateTime Year { get; set; }
+            public List<string> Features { get; set; }
+            public object[] Objects { get; set; }
+
+            // ignored
+            [JsonIgnore]
+            public DateTime LastModified { get; set; }
+        }
+
+#if !DNXCORE50
+        [Test]
+        public async Task ISerializableTypeNameHandlingTestAsync()
+        {
+            IExample e = new Example("Rob");
+
+            SerializableWrapper w = new SerializableWrapper
+            {
+                Content = e
+            };
+
+            await TestJsonSerializationRoundTripAsync(w, TypeNameHandling.All);
+            await TestJsonSerializationRoundTripAsync(w, TypeNameHandling.Auto);
+            await TestJsonSerializationRoundTripAsync(w, TypeNameHandling.Objects);
+        }
+
+        private async Task TestJsonSerializationRoundTripAsync(SerializableWrapper e, TypeNameHandling flag)
+        {
+            StringWriter writer = new StringWriter();
+
+            JsonSerializer serializer = new JsonSerializer();
+            serializer.TypeNameHandling = flag;
+
+            await serializer.SerializeAsync(new JsonTextWriter(writer), e);
+
+            SerializableWrapper f = await serializer.DeserializeAsync<SerializableWrapper>(new JsonTextReader(new StringReader(writer.ToString())));
+
+            Assert.AreEqual(e, f, "Objects should be equal after round trip json serialization");
+        }
+#endif
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json.Tests/Utilities/DateTimeUtilsAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/DateTimeUtilsAsyncTests.cs
@@ -1,0 +1,119 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Tests.Utilities
+{
+    [TestFixture]
+    public class DateTimeUtilsAsyncTests : TestFixtureBase
+    {
+        [Test]
+        public async Task RoundTripDateTimeMinAndMax()
+        {
+            await Task.WhenAll(RoundtripDateIsoAsync(DateTime.MinValue), RoundtripDateIsoAsync(DateTime.MaxValue));
+        }
+
+        [Test]
+        public async Task RoundTripDateTimeOffset()
+        {
+            await Task.WhenAll(
+                RoundtripDateIsoAsync(DateTimeOffset.MinValue),
+                RoundtripDateIsoAsync(DateTimeOffset.MaxValue),
+                RoundtripDateIsoAsync(new DateTimeOffset(2000, 2, 29, 12, 39, 40, 123, TimeSpan.Zero)),
+                RoundtripDateIsoAsync(new DateTimeOffset(2000, 2, 29, 12, 39, 40, 123, new TimeSpan(1, 30, 0))),
+                RoundtripDateIsoAsync(new DateTimeOffset(2000, 2, 29, 12, 39, 40, 123, -new TimeSpan(8, 30, 0))));
+        }
+
+        [Test]
+        public void WriteDateTimeAsyncAlreadyCancelled()
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            var token = source.Token;
+            source.Cancel();
+            var task = DateTimeUtils.WriteDateTimeStringAsync(TextWriter.Null, DateTime.MaxValue, DateFormatHandling.IsoDateFormat, null, CultureInfo.InvariantCulture, token);
+            Assert.IsTrue(task.IsCanceled);
+            task = DateTimeUtils.WriteDateTimeStringAsync(TextWriter.Null, DateTime.MaxValue, DateFormatHandling.IsoDateFormat, "yyyy-MM-dd", CultureInfo.InvariantCulture, token);
+            Assert.IsTrue(task.IsCanceled);
+        }
+
+        private static StringReference CreateStringReference(string s)
+        {
+            return new StringReference(s.ToCharArray(), 0, s.Length);
+        }
+
+        private static async Task RoundtripDateIsoAsync(DateTime value)
+        {
+            StringWriter sw = new StringWriter();
+            await DateTimeUtils.WriteDateTimeStringAsync(sw, value, DateFormatHandling.IsoDateFormat, null, CultureInfo.InvariantCulture, CancellationToken.None);
+            string minDateText = sw.ToString();
+
+            DateTime parsedDt;
+            DateTimeUtils.TryParseDateTimeIso(CreateStringReference(minDateText), DateTimeZoneHandling.RoundtripKind, out parsedDt);
+
+            Assert.AreEqual(value, parsedDt);
+        }
+
+        private static async Task RoundtripDateIsoAsync(DateTimeOffset value)
+        {
+            StringWriter sw = new StringWriter();
+            await DateTimeUtils.WriteDateTimeOffsetStringAsync(sw, value, DateFormatHandling.IsoDateFormat, null, CultureInfo.InvariantCulture, CancellationToken.None);
+            string minDateText = sw.ToString();
+
+            DateTimeOffset parsedDt;
+            DateTimeUtils.TryParseDateTimeOffsetIso(CreateStringReference(minDateText), out parsedDt);
+
+            Assert.AreEqual(value, parsedDt);
+        }
+
+        [Test]
+        public void WriteDateTimeOffsetAsyncAlreadyCancelled()
+        {
+            CancellationTokenSource source = new CancellationTokenSource();
+            var token = source.Token;
+            source.Cancel();
+            var task = DateTimeUtils.WriteDateTimeOffsetStringAsync(TextWriter.Null, DateTime.MaxValue, DateFormatHandling.IsoDateFormat, null, CultureInfo.InvariantCulture, token);
+            Assert.IsTrue(task.IsCanceled);
+            task = DateTimeUtils.WriteDateTimeOffsetStringAsync(TextWriter.Null, DateTime.MaxValue, DateFormatHandling.IsoDateFormat, "yyyy-MM-dd", CultureInfo.InvariantCulture, token);
+            Assert.IsTrue(task.IsCanceled);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/BinaryConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/BinaryConverter.Async.cs
@@ -1,0 +1,185 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || DOTNET || PORTABLE40 || PORTABLE)
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class BinaryConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, cancellationToken);
+        }
+    }
+
+    public partial class BinaryConverter
+    {
+        private bool SafeAsync => GetType() == typeof(BinaryConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                return writer.WriteNullAsync(cancellationToken);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return cancellationToken.CancelledAsync();
+            }
+
+            byte[] data = GetByteArray(value);
+
+            return writer.WriteValueAsync(data, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (!ReflectionUtils.IsNullable(objectType))
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot convert null value to {0}.".FormatWith(CultureInfo.InvariantCulture, objectType));
+                }
+
+                return cancellationToken.CancelledOrNullAsync();
+            }
+
+            return ReadJsonNotNullAsync(reader, objectType, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            byte[] data;
+
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                data = await ReadByteArrayAsync(reader, cancellationToken).ConfigureAwait(false);
+            }
+            else if (reader.TokenType == JsonToken.String)
+            {
+                // current token is already at base64 string
+                // unable to call ReadAsBytes so do it the old fashion way
+                string encodedData = reader.Value.ToString();
+                data = Convert.FromBase64String(encodedData);
+            }
+            else
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected token parsing binary. Expected String or StartArray, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            Type t = (ReflectionUtils.IsNullableType(objectType)) ? Nullable.GetUnderlyingType(objectType) : objectType;
+
+            if (t.AssignableToTypeName(BinaryTypeName))
+            {
+                EnsureReflectionObject(t);
+
+                return _reflectionObject.Creator(data);
+            }
+
+            if (t == typeof(SqlBinary))
+            {
+                return new SqlBinary(data);
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected object type when writing binary: {0}".FormatWith(CultureInfo.InvariantCulture, objectType));
+        }
+
+        private static async Task<byte[]> ReadByteArrayAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            List<byte> byteList = new List<byte>();
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.Integer:
+                        byteList.Add(Convert.ToByte(reader.Value, CultureInfo.InvariantCulture));
+                        break;
+                    case JsonToken.EndArray:
+                        return byteList.ToArray();
+                    case JsonToken.Comment:
+                        // skip
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when reading bytes: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading bytes.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/BinaryConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/BinaryConverter.cs
@@ -35,7 +35,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a binary value to and from a base 64 string value.
     /// </summary>
-    public class BinaryConverter : JsonConverter
+    public partial class BinaryConverter : JsonConverter
     {
 #if !NET20
         private const string BinaryTypeName = "System.Data.Linq.Binary";
@@ -195,6 +195,15 @@ namespace Newtonsoft.Json.Converters
 
             return false;
         }
+    }
+
+    internal sealed partial class BinaryConverterImpl : BinaryConverter
+    {
+        private BinaryConverterImpl()
+        {
+        }
+
+        public static readonly BinaryConverterImpl Instance = new BinaryConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/BsonObjectIdConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/BsonObjectIdConverter.Async.cs
@@ -1,0 +1,79 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Bson;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class BsonObjectIdConverterImpl
+    {
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, cancellationToken);
+        }
+    }
+
+    public partial class BsonObjectIdConverter
+    {
+        private bool SafeAsync => GetType() == typeof(BsonObjectIdConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            BsonObjectId objectId = (BsonObjectId)value;
+
+            BsonWriter bsonWriter = writer as BsonWriter;
+            if (bsonWriter != null)
+            {
+                bsonWriter.WriteObjectId(objectId.Value);
+            }
+            else
+            {
+                await writer.WriteValueAsync(objectId.Value, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}
+#endif

--- a/Src/Newtonsoft.Json/Converters/BsonObjectIdConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/BsonObjectIdConverter.cs
@@ -33,7 +33,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="BsonObjectId"/> to and from JSON and BSON.
     /// </summary>
-    public class BsonObjectIdConverter : JsonConverter
+    public partial class BsonObjectIdConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.
@@ -87,5 +87,15 @@ namespace Newtonsoft.Json.Converters
         {
             return (objectType == typeof(BsonObjectId));
         }
+    }
+
+    // By-passes any checks to avoid problems with inheritance in async calls.
+    internal sealed partial class BsonObjectIdConverterImpl : BsonObjectIdConverter
+    {
+        private BsonObjectIdConverterImpl()
+        {
+        }
+
+        public static readonly BsonObjectIdConverter Instance = new BsonObjectIdConverterImpl();
     }
 }

--- a/Src/Newtonsoft.Json/Converters/CustomCreationConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/CustomCreationConverter.Async.cs
@@ -1,0 +1,100 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    public abstract partial class CustomCreationConverter<T>
+    {
+        private bool? _safeCreate;
+
+        private bool SafeAsync
+        {
+            get
+            {
+                if (_safeCreate.HasValue)
+                {
+                    // In most cases we assume that we can't do any asynchronous operations safely in any
+                    // derived class. In this case though the whole point is for users to override Create,
+                    // and it's safe as long as they haven't also overridden Read, which would be relatively
+                    // rare. Therefore check that Read hasn't been overridden.
+                    MethodInfo baseMethod = typeof(CustomCreationConverter<T>).GetMethod("ReadJsonAsync");
+                    _safeCreate = GetType()
+                        .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                        .All(m => m.GetBaseDefinition() != baseMethod);
+                }
+
+                return _safeCreate.GetValueOrDefault();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>If a derived class overrides <see cref="ReadJson"/> this will execute synchronously, returning an
+        /// already-completed task, unless that class also overrides this method.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, serializer, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        private Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            return reader.TokenType == JsonToken.Null
+                ? cancellationToken.CancelledOrNullAsync()
+                : ReadJsonNotNullAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        { 
+            T value = Create(objectType);
+            if (value == null)
+            {
+                throw new JsonSerializationException("No object created.");
+            }
+
+            await serializer.PopulateAsync(reader, value, cancellationToken).ConfigureAwait(false);
+            return value;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/CustomCreationConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/CustomCreationConverter.cs
@@ -33,7 +33,7 @@ namespace Newtonsoft.Json.Converters
     /// Creates a custom object.
     /// </summary>
     /// <typeparam name="T">The object type to convert.</typeparam>
-    public abstract class CustomCreationConverter<T> : JsonConverter
+    public abstract partial class CustomCreationConverter<T> : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/Src/Newtonsoft.Json/Converters/DataSetConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/DataSetConverter.Async.cs
@@ -1,0 +1,147 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || PORTABLE40 || DOTNET || PORTABLE)
+
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class DataSetConverterImpl
+    {
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, serializer, cancellationToken);
+        }
+    }
+
+    public partial class DataSetConverter
+    {
+        private bool SafeAsync => GetType() == typeof(DataSetConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DataSet dataSet = (DataSet)value;
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            DataTableConverter converter = DataTableConverterImpl.Instance;
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (DataTable table in dataSet.Tables)
+            {
+                await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(table.TableName) : table.TableName, cancellationToken).ConfigureAwait(false);
+
+                await converter.WriteJsonAsync(writer, table, serializer, cancellationToken).ConfigureAwait(false);
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadJsonAsync(reader, objectType, serializer, cancellationToken) : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            return reader.TokenType == JsonToken.Null
+                ? cancellationToken.CancelledOrNullAsync() 
+                : ReadJsonNotNullAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // handle typed datasets
+            DataSet ds = objectType == typeof(DataSet)
+                ? new DataSet()
+                : (DataSet)Activator.CreateInstance(objectType);
+
+            DataTableConverter converter = DataTableConverterImpl.Instance;
+
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            while (reader.TokenType == JsonToken.PropertyName)
+            {
+                DataTable dt = ds.Tables[(string)reader.Value];
+                bool exists = dt != null;
+
+                dt = (DataTable)await converter.ReadJsonAsync(reader, typeof(DataTable), dt, serializer, cancellationToken).ConfigureAwait(false);
+
+                if (!exists)
+                {
+                    ds.Tables.Add(dt);
+                }
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return ds;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/DataSetConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataSetConverter.cs
@@ -33,7 +33,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="DataSet"/> to and from JSON.
     /// </summary>
-    public class DataSetConverter : JsonConverter
+    public partial class DataSetConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.
@@ -46,7 +46,7 @@ namespace Newtonsoft.Json.Converters
             DataSet dataSet = (DataSet)value;
             DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
 
-            DataTableConverter converter = new DataTableConverter();
+            DataTableConverter converter = DataTableConverterImpl.Instance;
 
             writer.WriteStartObject();
 
@@ -76,11 +76,9 @@ namespace Newtonsoft.Json.Converters
             }
 
             // handle typed datasets
-            DataSet ds = (objectType == typeof(DataSet))
-                ? new DataSet()
-                : (DataSet)Activator.CreateInstance(objectType);
+            DataSet ds = (objectType == typeof(DataSet)) ? new DataSet() : (DataSet)Activator.CreateInstance(objectType);
 
-            DataTableConverter converter = new DataTableConverter();
+            DataTableConverter converter = DataTableConverterImpl.Instance;
 
             reader.ReadAndAssert();
 
@@ -113,6 +111,15 @@ namespace Newtonsoft.Json.Converters
         {
             return typeof(DataSet).IsAssignableFrom(valueType);
         }
+    }
+
+    internal sealed partial class DataSetConverterImpl : DataSetConverter
+    {
+        private DataSetConverterImpl()
+        {
+        }
+
+        public static readonly DataSetConverter Instance = new DataSetConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/DataTableConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/DataTableConverter.Async.cs
@@ -1,0 +1,237 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || PORTABLE40 || DOTNET || PORTABLE)
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class DataTableConverterImpl
+    {
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+    }
+    public partial class DataTableConverter
+    {
+        private bool SafeAsync => GetType() == typeof(DataTableConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DataTable table = (DataTable)value;
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (DataRow row in table.Rows)
+            {
+                await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+                foreach (DataColumn column in row.Table.Columns)
+                {
+                    object columnValue = row[column];
+
+                    if (serializer.NullValueHandling == NullValueHandling.Ignore && (columnValue == null || columnValue == DBNull.Value))
+                    {
+                        continue;
+                    }
+
+                    await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(column.ColumnName) : column.ColumnName, cancellationToken).ConfigureAwait(false);
+                    await serializer.SerializeAsync(writer, columnValue, cancellationToken).ConfigureAwait(false);
+                }
+                await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            return reader.TokenType == JsonToken.Null
+                ? cancellationToken.CancelledOrNullAsync()
+                : ReadJsonNotNullAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DataTable dt = existingValue as DataTable ??
+                (objectType == typeof(DataTable) ? new DataTable() : (DataTable)Activator.CreateInstance(objectType));
+
+            // DataTable is inside a DataSet
+            // populate the name from the property name
+            if (reader.TokenType == JsonToken.PropertyName)
+            {
+                dt.TableName = (string)reader.Value;
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+                if (reader.TokenType == JsonToken.Null)
+                {
+                    return dt;
+                }
+            }
+
+            if (reader.TokenType != JsonToken.StartArray)
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected JSON token when reading DataTable. Expected StartArray, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            while (reader.TokenType != JsonToken.EndArray)
+            {
+                await CreateRowAsync(reader, dt, serializer, cancellationToken).ConfigureAwait(false);
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return dt;
+        }
+        private static async Task CreateRowAsync(JsonReader reader, DataTable dt, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            DataRow dr = dt.NewRow();
+
+            while (reader.TokenType == JsonToken.PropertyName)
+            {
+                string columnName = (string)reader.Value;
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+                DataColumn column = dt.Columns[columnName];
+                if (column == null)
+                {
+                    Type columnType = GetColumnDataType(reader);
+                    column = new DataColumn(columnName, columnType);
+                    dt.Columns.Add(column);
+                }
+
+                if (column.DataType == typeof(DataTable))
+                {
+                    if (reader.TokenType == JsonToken.StartArray)
+                    {
+                        await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    DataTable nestedDt = new DataTable();
+
+                    while (reader.TokenType != JsonToken.EndArray)
+                    {
+                        await CreateRowAsync(reader, nestedDt, serializer, cancellationToken).ConfigureAwait(false);
+
+                        await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    dr[columnName] = nestedDt;
+                }
+                else if (column.DataType.IsArray && column.DataType != typeof(byte[]))
+                {
+                    if (reader.TokenType == JsonToken.StartArray)
+                    {
+                        await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    List<object> o = new List<object>();
+
+                    while (reader.TokenType != JsonToken.EndArray)
+                    {
+                        o.Add(reader.Value);
+                        await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    Array destinationArray = Array.CreateInstance(column.DataType.GetElementType(), o.Count);
+                    Array.Copy(o.ToArray(), destinationArray, o.Count);
+
+                    dr[columnName] = destinationArray;
+                }
+                else
+                {
+                    object columnValue = reader.Value != null
+                        ? serializer.Deserialize(reader, column.DataType) ?? DBNull.Value
+                        : DBNull.Value;
+
+                    dr[columnName] = columnValue;
+                }
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            dr.EndEdit();
+            dt.Rows.Add(dr);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
@@ -36,7 +36,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="DataTable"/> to and from JSON.
     /// </summary>
-    public class DataTableConverter : JsonConverter
+    public partial class DataTableConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.
@@ -242,6 +242,15 @@ namespace Newtonsoft.Json.Converters
         {
             return typeof(DataTable).IsAssignableFrom(valueType);
         }
+    }
+
+    internal sealed partial class DataTableConverterImpl : DataTableConverter
+    {
+        private DataTableConverterImpl()
+        {
+        }
+
+        public static readonly DataTableConverter Instance = new DataTableConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.Async.cs
@@ -1,0 +1,209 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class DiscriminatedUnionConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+    }
+
+    public partial class DiscriminatedUnionConverter
+    {
+        private bool SafeAsync => GetType() == typeof(DiscriminatedUnionConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            Type unionType = UnionTypeLookupCache.Get(value.GetType());
+            Union union = UnionCache.Get(unionType);
+
+            int tag = (int)union.TagReader.Invoke(value);
+            UnionCase caseInfo = union.Cases.Single(c => c.Tag == tag);
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(CasePropertyName) : CasePropertyName, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(caseInfo.Name, cancellationToken).ConfigureAwait(false);
+            if (caseInfo.Fields != null && caseInfo.Fields.Length > 0)
+            {
+                object[] fields = (object[])caseInfo.FieldReader.Invoke(value);
+
+                await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(FieldsPropertyName) : FieldsPropertyName, cancellationToken).ConfigureAwait(false);
+                await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+                foreach (object field in fields)
+                {
+                    await serializer.SerializeAsync(writer, field, cancellationToken).ConfigureAwait(false);
+                }
+                await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+            }
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, serializer, cancellationToken)
+                : ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            return reader.TokenType == JsonToken.Null
+                ? cancellationToken.CancelledOrNullAsync()
+                : ReadJsonNotNullAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            UnionCase caseInfo = null;
+            string caseName = null;
+            JArray fields = null;
+
+            // start object
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            while (reader.TokenType == JsonToken.PropertyName)
+            {
+                string propertyName = reader.Value.ToString();
+                if (string.Equals(propertyName, CasePropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+                    Union union = UnionCache.Get(objectType);
+
+                    caseName = reader.Value.ToString();
+
+                    caseInfo = union.Cases.SingleOrDefault(c => c.Name == caseName);
+
+                    if (caseInfo == null)
+                    {
+                        throw JsonSerializationException.Create(reader, "No union type found with the name '{0}'.".FormatWith(CultureInfo.InvariantCulture, caseName));
+                    }
+                }
+                else if (string.Equals(propertyName, FieldsPropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    if (reader.TokenType != JsonToken.StartArray)
+                    {
+                        throw JsonSerializationException.Create(reader, "Union fields must been an array.");
+                    }
+
+                    fields = (JArray)JToken.ReadFrom(reader);
+                }
+                else
+                {
+                    throw JsonSerializationException.Create(reader, "Unexpected property '{0}' found when reading union.".FormatWith(CultureInfo.InvariantCulture, propertyName));
+                }
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (caseInfo == null)
+            {
+                throw JsonSerializationException.Create(reader, "No '{0}' property with union name found.".FormatWith(CultureInfo.InvariantCulture, CasePropertyName));
+            }
+
+            object[] typedFieldValues = new object[caseInfo.Fields.Length];
+
+            if (caseInfo.Fields.Length > 0 && fields == null)
+            {
+                throw JsonSerializationException.Create(reader, "No '{0}' property with union fields found.".FormatWith(CultureInfo.InvariantCulture, FieldsPropertyName));
+            }
+
+            if (fields != null)
+            {
+                if (caseInfo.Fields.Length != fields.Count)
+                {
+                    throw JsonSerializationException.Create(reader, "The number of field values does not match the number of properties defined by union '{0}'.".FormatWith(CultureInfo.InvariantCulture, caseName));
+                }
+
+                for (int i = 0; i < fields.Count; i++)
+                {
+                    JToken t = fields[i];
+                    PropertyInfo fieldProperty = caseInfo.Fields[i];
+
+                    typedFieldValues[i] = t.ToObject(fieldProperty.PropertyType, serializer);
+                }
+            }
+
+            object[] args = { typedFieldValues };
+
+            return caseInfo.Constructor.Invoke(args);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DiscriminatedUnionConverter.cs
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a F# discriminated union type to and from JSON.
     /// </summary>
-    public class DiscriminatedUnionConverter : JsonConverter
+    public partial class DiscriminatedUnionConverter : JsonConverter
     {
         #region UnionDefinition
         internal class Union
@@ -274,6 +274,15 @@ namespace Newtonsoft.Json.Converters
 
             return (bool)FSharpUtils.IsUnion(null, objectType, null);
         }
+    }
+
+    internal sealed partial class DiscriminatedUnionConverterImpl : DiscriminatedUnionConverter
+    {
+        private DiscriminatedUnionConverterImpl()
+        {
+        }
+
+        public static readonly DiscriminatedUnionConverter Instance = new DiscriminatedUnionConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.Async.cs
@@ -1,0 +1,168 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || DOTNET || PORTABLE40 || PORTABLE)
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class EntityKeyMemberConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+    }
+
+    public partial class EntityKeyMemberConverter
+    {
+        private bool SafeAsync => GetType() == typeof(EntityKeyMemberConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            EnsureReflectionObject(value.GetType());
+
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            string keyName = (string)_reflectionObject.GetValue(value, KeyPropertyName);
+            object keyValue = _reflectionObject.GetValue(value, ValuePropertyName);
+
+            Type keyValueType = keyValue?.GetType();
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(KeyPropertyName) : KeyPropertyName, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(keyName, cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(TypePropertyName) : TypePropertyName, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(keyValueType?.FullName, cancellationToken).ConfigureAwait(false);
+
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(ValuePropertyName) : ValuePropertyName, cancellationToken).ConfigureAwait(false);
+
+            if (keyValueType != null)
+            {
+                string valueJson;
+                if (JsonSerializerInternalWriter.TryConvertToString(keyValue, keyValueType, out valueJson))
+                {
+                    await writer.WriteValueAsync(valueJson, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteValueAsync(keyValue, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await writer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, serializer, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal async Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureReflectionObject(objectType);
+
+            object entityKeyMember = _reflectionObject.Creator();
+
+            await ReadAndAssertPropertyAsync(reader, KeyPropertyName, cancellationToken).ConfigureAwait(false);
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            _reflectionObject.SetValue(entityKeyMember, KeyPropertyName, reader.Value.ToString());
+
+            await ReadAndAssertPropertyAsync(reader, TypePropertyName, cancellationToken).ConfigureAwait(false);
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            string type = reader.Value.ToString();
+
+            Type t = Type.GetType(type);
+
+            await ReadAndAssertPropertyAsync(reader, ValuePropertyName, cancellationToken).ConfigureAwait(false);
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            _reflectionObject.SetValue(entityKeyMember, ValuePropertyName, await serializer.DeserializeAsync(reader, t, cancellationToken).ConfigureAwait(false));
+
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            return entityKeyMember;
+        }
+
+        private static async Task ReadAndAssertPropertyAsync(JsonReader reader, string propertyName, CancellationToken cancellationToken)
+        {
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.PropertyName || !string.Equals(reader.Value.ToString(), propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new JsonSerializationException("Expected JSON property '{0}'.".FormatWith(CultureInfo.InvariantCulture, propertyName));
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts an Entity Framework <see cref="T:System.Data.EntityKeyMember"/> to and from JSON.
     /// </summary>
-    public class EntityKeyMemberConverter : JsonConverter
+    public partial class EntityKeyMemberConverter : JsonConverter
     {
         private const string EntityKeyMemberFullTypeName = "System.Data.EntityKeyMember";
 
@@ -151,6 +151,15 @@ namespace Newtonsoft.Json.Converters
         {
             return objectType.AssignableToTypeName(EntityKeyMemberFullTypeName);
         }
+    }
+
+    internal sealed partial class EntityKeyMemberConverterImpl : EntityKeyMemberConverter
+    {
+        private EntityKeyMemberConverterImpl()
+        {
+        }
+
+        public static readonly EntityKeyMemberConverter Instance = new EntityKeyMemberConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.Async.cs
@@ -1,0 +1,142 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class ExpandoObjectConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReadValueAsync(reader, cancellationToken);
+        }
+    }
+
+    public partial class ExpandoObjectConverter
+    {
+        private bool SafeAsync => GetType() == typeof(ExpandoObjectConverter);
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? ReadValueAsync(reader, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal async Task<object> ReadValueAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            if (!await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+            }
+
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    return await ReadObjectAsync(reader, cancellationToken).ConfigureAwait(false);
+                case JsonToken.StartArray:
+                    return await ReadListAsync(reader, cancellationToken).ConfigureAwait(false);
+                default:
+                    if (JsonTokenUtils.IsPrimitiveToken(reader.TokenType))
+                    {
+                        return reader.Value;
+                    }
+
+                    throw JsonSerializationException.Create(reader, "Unexpected token when converting ExpandoObject: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+        }
+
+        private async Task<object> ReadListAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            IList<object> list = new List<object>();
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.Comment:
+                        break;
+                    default:
+                        list.Add(ReadValueAsync(reader, cancellationToken));
+                        break;
+                    case JsonToken.EndArray:
+                        return list;
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+        }
+
+        private async Task<object> ReadObjectAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            IDictionary<string, object> expandoObject = new ExpandoObject();
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string propertyName = reader.Value.ToString();
+
+                        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+                        }
+
+                        expandoObject[propertyName] = await ReadValueAsync(reader, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        return expandoObject;
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading ExpandoObject.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/ExpandoObjectConverter.cs
@@ -38,7 +38,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts an <see cref="ExpandoObject"/> to and from JSON.
     /// </summary>
-    public class ExpandoObjectConverter : JsonConverter
+    public partial class ExpandoObjectConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.
@@ -162,6 +162,15 @@ namespace Newtonsoft.Json.Converters
         {
             get { return false; }
         }
+    }
+
+    internal sealed partial class ExpandoObjectConverterImpl : ExpandoObjectConverter
+    {
+        private ExpandoObjectConverterImpl()
+        {
+        }
+
+        public static readonly ExpandoObjectConverter Instance = new ExpandoObjectConverterImpl();
     }
 }
 

--- a/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.Async.cs
@@ -1,0 +1,94 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    public partial class IsoDateTimeConverter
+    {
+        private bool SafeAsync => GetType() == typeof(IsoDateTimeConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        private Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            string text;
+
+            if (value is DateTime)
+            {
+                DateTime dateTime = (DateTime)value;
+
+                if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
+                    || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
+                {
+                    dateTime = dateTime.ToUniversalTime();
+                }
+
+                text = dateTime.ToString(_dateTimeFormat ?? DefaultDateTimeFormat, Culture);
+            }
+            else if (value is DateTimeOffset)
+            {
+                DateTimeOffset dateTimeOffset = (DateTimeOffset)value;
+                if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
+                    || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
+                {
+                    dateTimeOffset = dateTimeOffset.ToUniversalTime();
+                }
+
+                text = dateTimeOffset.ToString(_dateTimeFormat ?? DefaultDateTimeFormat, Culture);
+            }
+            else
+            {
+                throw new JsonSerializationException("Unexpected value when converting date. Expected DateTime or DateTimeOffset, got {0}.".FormatWith(CultureInfo.InvariantCulture, ReflectionUtils.GetObjectType(value)));
+            }
+
+            return writer.WriteValueAsync(text, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
@@ -32,7 +32,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="DateTime"/> to and from the ISO 8601 date format (e.g. <c>"2008-04-12T12:53Z"</c>).
     /// </summary>
-    public class IsoDateTimeConverter : DateTimeConverterBase
+    public partial class IsoDateTimeConverter : DateTimeConverterBase
     {
         private const string DefaultDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
 

--- a/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.Async.cs
@@ -1,0 +1,154 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    public partial class JavaScriptDateTimeConverter
+    {
+        private bool SafeAsync => GetType() == typeof(JavaScriptDateTimeConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync 
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        private async Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            long ticks;
+
+            if (value is DateTime)
+            {
+                DateTime dateTime = (DateTime)value;
+                DateTime utcDateTime = dateTime.ToUniversalTime();
+                ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(utcDateTime);
+            }
+            else if (value is DateTimeOffset)
+            {
+                DateTimeOffset dateTimeOffset = (DateTimeOffset)value;
+                DateTimeOffset utcDateTimeOffset = dateTimeOffset.ToUniversalTime();
+                ticks = DateTimeUtils.ConvertDateTimeToJavaScriptTicks(utcDateTimeOffset.UtcDateTime);
+            }
+            else
+            {
+                throw new JsonSerializationException("Expected date object value.");
+            }
+
+            await writer.WriteStartConstructorAsync("Date", cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(ticks, cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndConstructorAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        private Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (!ReflectionUtils.IsNullable(objectType))
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot convert null value to {0}.".FormatWith(CultureInfo.InvariantCulture, objectType));
+                }
+
+                return cancellationToken.CancelledOrNullAsync();
+            }
+
+            return ReadJsonNotNullAsync(reader, objectType, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        { 
+            if (reader.TokenType != JsonToken.StartConstructor || !string.Equals(reader.Value.ToString(), "Date", StringComparison.Ordinal))
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected token or value when parsing date. Token: {0}, Value: {1}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType, reader.Value));
+            }
+
+            await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.Integer)
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected token parsing date. Expected Integer, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            long ticks = (long)reader.Value;
+
+            DateTime d = DateTimeUtils.ConvertJavaScriptTicksToDateTime(ticks);
+
+            await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.EndConstructor)
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected token parsing date. Expected EndConstructor, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            Type t = (ReflectionUtils.IsNullableType(objectType))
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
+            if (t == typeof(DateTimeOffset))
+            {
+                return new DateTimeOffset(d);
+            }
+
+            return d;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/JavaScriptDateTimeConverter.cs
@@ -32,7 +32,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="DateTime"/> to and from a JavaScript <c>Date</c> constructor (e.g. <c>new Date(52231943)</c>).
     /// </summary>
-    public class JavaScriptDateTimeConverter : DateTimeConverterBase
+    public partial class JavaScriptDateTimeConverter : DateTimeConverterBase
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.Async.cs
@@ -1,0 +1,155 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class KeyValuePairConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+    }
+
+    public partial class KeyValuePairConverter
+    {
+        private bool SafeAsync => GetType() == typeof(KeyValuePairConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken)) => SafeAsync
+            ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+            : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReflectionObject reflectionObject = ReflectionObjectPerType.Get(value.GetType());
+
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(KeyName) : KeyName, cancellationToken).ConfigureAwait(false);
+            await serializer.SerializeAsync(writer, reflectionObject.GetValue(value, KeyName), reflectionObject.GetType(KeyName), cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(ValueName) : ValueName, cancellationToken).ConfigureAwait(false);
+            await serializer.SerializeAsync(writer, reflectionObject.GetValue(value, ValueName), reflectionObject.GetType(ValueName), cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, objectType, serializer, cancellationToken)
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (!ReflectionUtils.IsNullableType(objectType))
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot convert null value to KeyValuePair.");
+                }
+
+                return cancellationToken.CancelledOrNullAsync();
+            }
+
+            return ReadJsonNotNullAsync(reader, objectType, serializer, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            object key = null;
+            object value = null;
+
+            await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+
+            Type t = ReflectionUtils.IsNullableType(objectType)
+                ? Nullable.GetUnderlyingType(objectType)
+                : objectType;
+
+            ReflectionObject reflectionObject = ReflectionObjectPerType.Get(t);
+
+            while (reader.TokenType == JsonToken.PropertyName)
+            {
+                string propertyName = reader.Value.ToString();
+                if (string.Equals(propertyName, KeyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    key = serializer.Deserialize(reader, reflectionObject.GetType(KeyName));
+                }
+                else if (string.Equals(propertyName, ValueName, StringComparison.OrdinalIgnoreCase))
+                {
+                    await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    value = serializer.Deserialize(reader, reflectionObject.GetType(ValueName));
+                }
+                else
+                {
+                    await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                await reader.ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return reflectionObject.Creator(key, value);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/KeyValuePairConverter.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="KeyValuePair{TKey,TValue}"/> to and from JSON.
     /// </summary>
-    public class KeyValuePairConverter : JsonConverter
+    public partial class KeyValuePairConverter : JsonConverter
     {
         private const string KeyName = "Key";
         private const string ValueName = "Value";
@@ -145,5 +145,14 @@ namespace Newtonsoft.Json.Converters
 
             return false;
         }
+    }
+
+    internal sealed partial class KeyValuePairConverterImpl : KeyValuePairConverter
+    {
+        public KeyValuePairConverterImpl()
+        {
+        }
+
+        public static readonly KeyValuePairConverter Instance = new KeyValuePairConverterImpl();
     }
 }

--- a/Src/Newtonsoft.Json/Converters/RegexConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/RegexConverter.Async.cs
@@ -1,0 +1,186 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Bson;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class RegexConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, serializer, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+    }
+
+    public partial class RegexConverter
+    {
+        private bool SafeAsync => GetType() == typeof(RegexConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, serializer, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal Task DoWriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            Regex regex = (Regex)value;
+
+            BsonWriter bsonWriter = writer as BsonWriter;
+            if (bsonWriter != null)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return cancellationToken.CancelledAsync();
+                }
+
+                WriteBson(bsonWriter, regex);
+                return AsyncUtils.CompletedTask;
+            }
+
+            return WriteJsonAsync(writer, regex, serializer, cancellationToken);
+        }
+
+        private static async Task WriteJsonAsync(JsonWriter writer, Regex regex, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            DefaultContractResolver resolver = serializer.ContractResolver as DefaultContractResolver;
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(PatternName) : PatternName, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(regex.ToString(), cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(resolver != null ? resolver.GetResolvedPropertyName(OptionsName) : OptionsName, cancellationToken).ConfigureAwait(false);
+            await serializer.SerializeAsync(writer, regex.Options, cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoReadJsonAsync(reader, serializer, cancellationToken) 
+                : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync<object>();
+
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    return ReadRegexObjectAsync(reader, serializer, cancellationToken);
+                case JsonToken.String:
+                    return Task.FromResult(ReadRegexString(reader));
+                case JsonToken.Null:
+                    return Task.FromResult<object>(null);
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected token when reading Regex.");
+        }
+
+        private static async Task<object> ReadRegexObjectAsync(JsonReader reader, JsonSerializer serializer, CancellationToken cancellationToken)
+        {
+            string pattern = null;
+            RegexOptions? options = null;
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string propertyName = reader.Value.ToString();
+
+                        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            throw JsonSerializationException.Create(reader, "Unexpected end when reading Regex.");
+                        }
+
+                        if (string.Equals(propertyName, PatternName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            pattern = (string)reader.Value;
+                        }
+                        else if (string.Equals(propertyName, OptionsName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            options = await serializer.DeserializeAsync<RegexOptions>(reader, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        if (pattern == null)
+                        {
+                            throw JsonSerializationException.Create(reader, "Error deserializing Regex. No pattern found.");
+                        }
+
+                        return new Regex(pattern, options ?? RegexOptions.None);
+                }
+            }
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when reading Regex.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/RegexConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/RegexConverter.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="Regex"/> to and from JSON and BSON.
     /// </summary>
-    public class RegexConverter : JsonConverter
+    public partial class RegexConverter : JsonConverter
     {
         private const string PatternName = "Pattern";
         private const string OptionsName = "Options";
@@ -223,5 +223,14 @@ namespace Newtonsoft.Json.Converters
         {
             return (objectType == typeof(Regex));
         }
+    }
+
+    internal sealed partial class RegexConverterImpl : RegexConverter
+    {
+        private RegexConverterImpl()
+        {
+        }
+
+        public static readonly RegexConverter Instance = new RegexConverterImpl();
     }
 }

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.Async.cs
@@ -1,0 +1,82 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    public partial class StringEnumConverter
+    {
+        private bool SafeAsync => GetType() == typeof(StringEnumConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        private Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                return writer.WriteNullAsync(cancellationToken);
+            }
+
+            Enum e = (Enum)value;
+
+            string enumName = e.ToString("G");
+
+            if (char.IsNumber(enumName[0]) || enumName[0] == '-')
+            {
+                // enum value has no name so write number
+                return writer.WriteValueAsync(value, cancellationToken);
+            }
+
+            Type enumType = e.GetType();
+
+            string finalName = EnumUtils.ToEnumName(enumType, enumName, CamelCaseText);
+
+            return writer.WriteValueAsync(finalName, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts an <see cref="Enum"/> to and from its name string value.
     /// </summary>
-    public class StringEnumConverter : JsonConverter
+    public partial class StringEnumConverter : JsonConverter
     {
         /// <summary>
         /// Gets or sets a value indicating whether the written enum text should be camel case.

--- a/Src/Newtonsoft.Json/Converters/VersionConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/VersionConverter.Async.cs
@@ -1,0 +1,72 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Converters
+{
+    public partial class VersionConverter
+    {
+        private bool SafeAsync => GetType() == typeof(VersionConverter);
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync
+                ? DoWriteJsonAsync(writer, value, cancellationToken)
+                : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        private Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            if (value == null)
+            {
+                return writer.WriteNullAsync(cancellationToken);
+            }
+
+            if (value is Version)
+            {
+                return writer.WriteValueAsync(value.ToString(), cancellationToken);
+            }
+
+            throw new JsonSerializationException("Expected Version object value");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/VersionConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/VersionConverter.cs
@@ -32,7 +32,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts a <see cref="Version"/> to and from a string (e.g. <c>"1.2.3.4"</c>).
     /// </summary>
-    public class VersionConverter : JsonConverter
+    public partial class VersionConverter : JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.Async.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.Async.cs
@@ -1,0 +1,707 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    internal sealed partial class XmlNodeConverterImpl
+    {
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadJsonAsync(reader, objectType, cancellationToken);
+        }
+
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteJsonAsync(writer, value, cancellationToken);
+        }
+    }
+
+    public partial class XmlNodeConverter
+    {
+        private bool SafeAsync
+        {
+            get { return GetType() == typeof(XmlNodeConverter); }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteJsonAsync(writer, value, cancellationToken) : base.WriteJsonAsync(writer, value, serializer, cancellationToken);
+        }
+
+        internal async Task DoWriteJsonAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IXmlNode node = WrapXml(value);
+
+            XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
+            PushParentNamespaces(node, manager);
+
+            if (!OmitRootObject)
+            {
+                await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await SerializeNodeAsync(writer, node, manager, !OmitRootObject, cancellationToken).ConfigureAwait(false);
+
+            if (!OmitRootObject)
+            {
+                await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task SerializeNodeAsync(JsonWriter writer, IXmlNode node, XmlNamespaceManager manager, bool writePropertyName, CancellationToken cancellationToken)
+        {
+            switch (node.NodeType)
+            {
+                case XmlNodeType.Document:
+                case XmlNodeType.DocumentFragment:
+                    await SerializeGroupedNodesAsync(writer, node, manager, writePropertyName, cancellationToken).ConfigureAwait(false);
+                    break;
+                case XmlNodeType.Element:
+                    if (IsArray(node) && AllSameName(node) && node.ChildNodes.Count > 0)
+                    {
+                        await SerializeGroupedNodesAsync(writer, node, manager, false, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        manager.PushScope();
+
+                        foreach (IXmlNode attribute in node.Attributes)
+                        {
+                            if (attribute.NamespaceUri == "http://www.w3.org/2000/xmlns/")
+                            {
+                                string namespacePrefix = attribute.LocalName != "xmlns" ? XmlConvert.DecodeName(attribute.LocalName) : string.Empty;
+                                string namespaceUri = attribute.Value;
+
+                                manager.AddNamespace(namespacePrefix, namespaceUri);
+                            }
+                        }
+
+                        if (writePropertyName)
+                        {
+                            await writer.WritePropertyNameAsync(GetPropertyName(node, manager), cancellationToken).ConfigureAwait(false);
+                        }
+
+                        if (!ValueAttributes(node.Attributes) && node.ChildNodes.Count == 1 && node.ChildNodes[0].NodeType == XmlNodeType.Text)
+                        {
+                            // write elements with a single text child as a name value pair
+                            await writer.WriteValueAsync(node.ChildNodes[0].Value, cancellationToken).ConfigureAwait(false);
+                        }
+                        else if (node.ChildNodes.Count == 0 && CollectionUtils.IsNullOrEmpty(node.Attributes))
+                        {
+                            IXmlElement element = (IXmlElement)node;
+
+                            // empty element
+                            if (element.IsEmpty)
+                            {
+                                await writer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                await writer.WriteValueAsync(string.Empty, cancellationToken).ConfigureAwait(false);
+                            }
+                        }
+                        else
+                        {
+                            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+                            for (int i = 0; i < node.Attributes.Count; i++)
+                            {
+                                await SerializeNodeAsync(writer, node.Attributes[i], manager, true, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            await SerializeGroupedNodesAsync(writer, node, manager, true, cancellationToken).ConfigureAwait(false);
+
+                            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+                        }
+
+                        manager.PopScope();
+                    }
+
+                    break;
+                case XmlNodeType.Comment:
+                    if (writePropertyName)
+                    {
+                        await writer.WriteCommentAsync(node.Value, cancellationToken).ConfigureAwait(false);
+                    }
+                    break;
+                case XmlNodeType.Attribute:
+                case XmlNodeType.Text:
+                case XmlNodeType.CDATA:
+                case XmlNodeType.ProcessingInstruction:
+                case XmlNodeType.Whitespace:
+                case XmlNodeType.SignificantWhitespace:
+                    if (node.NamespaceUri == "http://www.w3.org/2000/xmlns/" && node.Value == JsonNamespaceUri)
+                    {
+                        return;
+                    }
+
+                    if (node.NamespaceUri == JsonNamespaceUri)
+                    {
+                        if (node.LocalName == "Array")
+                        {
+                            return;
+                        }
+                    }
+
+                    if (writePropertyName)
+                    {
+                        await writer.WritePropertyNameAsync(GetPropertyName(node, manager), cancellationToken).ConfigureAwait(false);
+                    }
+                    await writer.WriteValueAsync(node.Value, cancellationToken).ConfigureAwait(false);
+                    break;
+                case XmlNodeType.XmlDeclaration:
+                    IXmlDeclaration declaration = (IXmlDeclaration)node;
+                    await writer.WritePropertyNameAsync(GetPropertyName(node, manager), cancellationToken).ConfigureAwait(false);
+                    await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (!string.IsNullOrEmpty(declaration.Version))
+                    {
+                        await writer.WritePropertyNameAsync("@version", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(declaration.Version, cancellationToken).ConfigureAwait(false);
+                    }
+                    if (!string.IsNullOrEmpty(declaration.Encoding))
+                    {
+                        await writer.WritePropertyNameAsync("@encoding", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(declaration.Encoding, cancellationToken).ConfigureAwait(false);
+                    }
+                    if (!string.IsNullOrEmpty(declaration.Standalone))
+                    {
+                        await writer.WritePropertyNameAsync("@standalone", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(declaration.Standalone, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case XmlNodeType.DocumentType:
+                    IXmlDocumentType documentType = (IXmlDocumentType)node;
+                    await writer.WritePropertyNameAsync(GetPropertyName(node, manager), cancellationToken).ConfigureAwait(false);
+                    await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (!string.IsNullOrEmpty(documentType.Name))
+                    {
+                        await writer.WritePropertyNameAsync("@name", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(documentType.Name, cancellationToken).ConfigureAwait(false);
+                    }
+                    if (!string.IsNullOrEmpty(documentType.Public))
+                    {
+                        await writer.WritePropertyNameAsync("@public", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(documentType.Public, cancellationToken).ConfigureAwait(false);
+                    }
+                    if (!string.IsNullOrEmpty(documentType.System))
+                    {
+                        await writer.WritePropertyNameAsync("@system", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(documentType.System, cancellationToken).ConfigureAwait(false);
+                    }
+                    if (!string.IsNullOrEmpty(documentType.InternalSubset))
+                    {
+                        await writer.WritePropertyNameAsync("@internalSubset", cancellationToken).ConfigureAwait(false);
+                        await writer.WriteValueAsync(documentType.InternalSubset, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                default:
+                    throw new JsonSerializationException("Unexpected XmlNodeType when serializing nodes: " + node.NodeType);
+            }
+        }
+
+        private async Task SerializeGroupedNodesAsync(JsonWriter writer, IXmlNode node, XmlNamespaceManager manager, bool writePropertyName, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // group nodes together by name
+            Dictionary<string, List<IXmlNode>> nodesGroupedByName = new Dictionary<string, List<IXmlNode>>();
+
+            for (int i = 0; i < node.ChildNodes.Count; i++)
+            {
+                IXmlNode childNode = node.ChildNodes[i];
+                string nodeName = GetPropertyName(childNode, manager);
+
+                List<IXmlNode> nodes;
+                if (!nodesGroupedByName.TryGetValue(nodeName, out nodes))
+                {
+                    nodes = new List<IXmlNode>();
+                    nodesGroupedByName.Add(nodeName, nodes);
+                }
+
+                nodes.Add(childNode);
+            }
+
+            // loop through grouped nodes. write single name instances as normal,
+            // write multiple names together in an array
+            foreach (KeyValuePair<string, List<IXmlNode>> nodeNameGroup in nodesGroupedByName)
+            {
+                List<IXmlNode> groupedNodes = nodeNameGroup.Value;
+
+
+                if (groupedNodes.Count == 1 && !IsArray(groupedNodes[0]))
+                {
+                    await SerializeNodeAsync(writer, groupedNodes[0], manager, writePropertyName, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    if (writePropertyName)
+                    {
+                        await writer.WritePropertyNameAsync(nodeNameGroup.Key, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+                    for (int i = 0; i < groupedNodes.Count; i++)
+                    {
+                        await SerializeNodeAsync(writer, groupedNodes[i], manager, false, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadJsonAsync(reader, objectType, cancellationToken) : base.ReadJsonAsync(reader, objectType, existingValue, serializer, cancellationToken);
+        }
+
+        internal Task<object> DoReadJsonAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            return reader.TokenType == JsonToken.Null ? cancellationToken.CancelledOrNullAsync() : ReadJsonNotNullAsync(reader, objectType, cancellationToken);
+        }
+
+        private async Task<object> ReadJsonNotNullAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
+            IXmlDocument document = null;
+            IXmlNode rootNode = null;
+
+#if !NET20
+            if (typeof(XObject).IsAssignableFrom(objectType))
+            {
+                if (objectType != typeof(XDocument) && objectType != typeof(XElement))
+                {
+                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XDocument or XElement.");
+                }
+
+                XDocument d = new XDocument();
+                document = new XDocumentWrapper(d);
+                rootNode = document;
+            }
+#endif
+#if !(DOTNET || PORTABLE)
+            if (typeof(XmlNode).IsAssignableFrom(objectType))
+            {
+                if (objectType != typeof(XmlDocument))
+                {
+                    throw new JsonSerializationException("XmlNodeConverter only supports deserializing XmlDocuments");
+                }
+
+                XmlDocument d = new XmlDocument();
+
+                // prevent http request when resolving any DTD references
+                d.XmlResolver = null;
+
+                document = new XmlDocumentWrapper(d);
+                rootNode = document;
+            }
+#endif
+
+            if (document == null || rootNode == null)
+            {
+                throw new JsonSerializationException("Unexpected type when converting XML: " + objectType);
+            }
+
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                throw new JsonSerializationException("XmlNodeConverter can only convert JSON that begins with an object.");
+            }
+
+            if (!string.IsNullOrEmpty(DeserializeRootElementName))
+            {
+                //rootNode = document.CreateElement(DeserializeRootElementName);
+                //document.AppendChild(rootNode);
+                await ReadElementAsync(reader, document, rootNode, DeserializeRootElementName, manager, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                await DeserializeNodeAsync(reader, document, manager, rootNode, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (objectType == typeof(XElement))
+            {
+                XElement element = (XElement)document.DocumentElement.WrappedNode;
+                element.Remove();
+
+                return element;
+            }
+
+            return document.WrappedNode;
+        }
+
+        private async Task ReadElementAsync(JsonReader reader, IXmlDocument document, IXmlNode currentNode, string propertyName, XmlNamespaceManager manager, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                throw JsonSerializationException.Create(reader, "XmlNodeConverter cannot convert JSON with an empty property name to XML.");
+            }
+
+            Dictionary<string, string> attributeNameValues = ReadAttributeElements(reader, manager);
+
+            string elementPrefix = MiscellaneousUtils.GetPrefix(propertyName);
+
+            if (propertyName.StartsWith('@'))
+            {
+                string attributeName = propertyName.Substring(1);
+                string attributePrefix = MiscellaneousUtils.GetPrefix(attributeName);
+
+                AddAttribute(reader, document, currentNode, propertyName, attributeName, manager, attributePrefix);
+                return;
+            }
+
+            if (propertyName.StartsWith('$'))
+            {
+                switch (propertyName)
+                {
+                    case JsonTypeReflector.ArrayValuesPropertyName:
+                        propertyName = propertyName.Substring(1);
+                        elementPrefix = manager.LookupPrefix(JsonNamespaceUri);
+                        await CreateElementAsync(reader, document, currentNode, propertyName, manager, elementPrefix, attributeNameValues, cancellationToken).ConfigureAwait(false);
+                        return;
+                    case JsonTypeReflector.IdPropertyName:
+                    case JsonTypeReflector.RefPropertyName:
+                    case JsonTypeReflector.TypePropertyName:
+                    case JsonTypeReflector.ValuePropertyName:
+                        string attributeName = propertyName.Substring(1);
+                        string attributePrefix = manager.LookupPrefix(JsonNamespaceUri);
+                        AddAttribute(reader, document, currentNode, propertyName, attributeName, manager, attributePrefix);
+                        return;
+                }
+            }
+
+            await CreateElementAsync(reader, document, currentNode, propertyName, manager, elementPrefix, attributeNameValues, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task CreateElementAsync(JsonReader reader, IXmlDocument document, IXmlNode currentNode, string elementName, XmlNamespaceManager manager, string elementPrefix, Dictionary<string, string> attributeNameValues, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IXmlElement element = CreateElement(elementName, document, elementPrefix, manager);
+
+            currentNode.AppendChild(element);
+
+            // add attributes to newly created element
+            foreach (KeyValuePair<string, string> nameValue in attributeNameValues)
+            {
+                string encodedName = XmlConvert.EncodeName(nameValue.Key);
+                string attributePrefix = MiscellaneousUtils.GetPrefix(nameValue.Key);
+
+                IXmlNode attribute = !string.IsNullOrEmpty(attributePrefix) ? document.CreateAttribute(encodedName, manager.LookupNamespace(attributePrefix) ?? string.Empty, nameValue.Value) : document.CreateAttribute(encodedName, nameValue.Value);
+
+                element.SetAttributeNode(attribute);
+            }
+
+            if (reader.TokenType == JsonToken.String || reader.TokenType == JsonToken.Integer || reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Boolean || reader.TokenType == JsonToken.Date)
+            {
+                string text = ConvertTokenToXmlValue(reader);
+                if (text != null)
+                {
+                    element.AppendChild(document.CreateTextNode(text));
+                }
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                // empty element. do nothing
+            }
+            else
+            {
+                // finished element will have no children to deserialize
+                if (reader.TokenType != JsonToken.EndObject)
+                {
+                    manager.PushScope();
+                    await DeserializeNodeAsync(reader, document, manager, element, cancellationToken).ConfigureAwait(false);
+                    manager.PopScope();
+                }
+
+                manager.RemoveNamespace(string.Empty, manager.DefaultNamespace);
+            }
+        }
+
+        private async Task DeserializeNodeAsync(JsonReader reader, IXmlDocument document, XmlNamespaceManager manager, IXmlNode currentNode, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        if (currentNode.NodeType == XmlNodeType.Document && document.DocumentElement != null)
+                        {
+                            throw JsonSerializationException.Create(reader, "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName.");
+                        }
+
+                        string propertyName = reader.Value.ToString();
+                        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+                        if (reader.TokenType == JsonToken.StartArray)
+                        {
+                            int count = 0;
+                            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.EndArray)
+                            {
+                                await DeserializeValueAsync(reader, document, manager, propertyName, currentNode, cancellationToken).ConfigureAwait(false);
+                                count++;
+                            }
+
+                            if (count == 1 && WriteArrayAttribute)
+                            {
+                                foreach (IXmlNode childNode in currentNode.ChildNodes)
+                                {
+                                    IXmlElement element = childNode as IXmlElement;
+                                    if (element != null && element.LocalName == propertyName)
+                                    {
+                                        AddJsonArrayAttribute(element, document);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            await DeserializeValueAsync(reader, document, manager, propertyName, currentNode, cancellationToken).ConfigureAwait(false);
+                        }
+
+                        break;
+                    case JsonToken.StartConstructor:
+                        string constructorName = reader.Value.ToString();
+
+                        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.EndConstructor)
+                        {
+                            await DeserializeValueAsync(reader, document, manager, constructorName, currentNode, cancellationToken).ConfigureAwait(false);
+                        }
+
+                        break;
+                    case JsonToken.Comment:
+                        currentNode.AppendChild(document.CreateComment((string)reader.Value));
+                        break;
+                    case JsonToken.EndObject:
+                    case JsonToken.EndArray:
+                        return;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected JsonToken when deserializing node: " + reader.TokenType);
+                }
+            } while (reader.TokenType == JsonToken.PropertyName || await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            // don't read if current token is a property. token was already read when parsing element attributes
+        }
+
+        private async Task DeserializeValueAsync(JsonReader reader, IXmlDocument document, XmlNamespaceManager manager, string propertyName, IXmlNode currentNode, CancellationToken cancellationToken)
+        {
+            switch (propertyName)
+            {
+                case TextName:
+                    currentNode.AppendChild(document.CreateTextNode(reader.Value.ToString()));
+                    break;
+                case CDataName:
+                    currentNode.AppendChild(document.CreateCDataSection(reader.Value.ToString()));
+                    break;
+                case WhitespaceName:
+                    currentNode.AppendChild(document.CreateWhitespace(reader.Value.ToString()));
+                    break;
+                case SignificantWhitespaceName:
+                    currentNode.AppendChild(document.CreateSignificantWhitespace(reader.Value.ToString()));
+                    break;
+                default:
+
+                    // processing instructions and the xml declaration start with ?
+                    if (!string.IsNullOrEmpty(propertyName) && propertyName[0] == '?')
+                    {
+                        await CreateInstructionAsync(reader, document, currentNode, propertyName, cancellationToken).ConfigureAwait(false);
+                    }
+                    else if (string.Equals(propertyName, "!DOCTYPE", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await CreateDocumentTypeAsync(reader, document, currentNode, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (reader.TokenType == JsonToken.StartArray)
+                        {
+                            // handle nested arrays
+                            await ReadArrayElementsAsync(reader, document, propertyName, currentNode, manager, cancellationToken).ConfigureAwait(false);
+                            return;
+                        }
+
+                        // have to wait until attributes have been parsed before creating element
+                        // attributes may contain namespace info used by the element
+                        await ReadElementAsync(reader, document, currentNode, propertyName, manager, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+            }
+        }
+
+        private static async Task CreateInstructionAsync(JsonReader reader, IXmlDocument document, IXmlNode currentNode, string propertyName, CancellationToken cancellationToken)
+        {
+            if (propertyName == DeclarationName)
+            {
+                string version = null;
+                string encoding = null;
+                string standalone = null;
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.EndObject)
+                {
+                    switch (reader.Value.ToString())
+                    {
+                        case "@version":
+                            await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                            version = reader.Value.ToString();
+                            break;
+                        case "@encoding":
+                            await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                            encoding = reader.Value.ToString();
+                            break;
+                        case "@standalone":
+                            await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                            standalone = reader.Value.ToString();
+                            break;
+                        default:
+                            throw JsonSerializationException.Create(reader, "Unexpected property name encountered while deserializing XmlDeclaration: " + reader.Value);
+                    }
+                }
+
+                IXmlNode declaration = document.CreateXmlDeclaration(version, encoding, standalone);
+                currentNode.AppendChild(declaration);
+            }
+            else
+            {
+                IXmlNode instruction = document.CreateProcessingInstruction(propertyName.Substring(1), reader.Value.ToString());
+                currentNode.AppendChild(instruction);
+            }
+        }
+
+        private static async Task CreateDocumentTypeAsync(JsonReader reader, IXmlDocument document, IXmlNode currentNode, CancellationToken cancellationToken)
+        {
+            string name = null;
+            string publicId = null;
+            string systemId = null;
+            string internalSubset = null;
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.EndObject)
+            {
+                switch (reader.Value.ToString())
+                {
+                    case "@name":
+                        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                        name = reader.Value.ToString();
+                        break;
+                    case "@public":
+                        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                        publicId = reader.Value.ToString();
+                        break;
+                    case "@system":
+                        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                        systemId = reader.Value.ToString();
+                        break;
+                    case "@internalSubset":
+                        await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                        internalSubset = reader.Value.ToString();
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected property name encountered while deserializing XmlDeclaration: " + reader.Value);
+                }
+            }
+
+            IXmlNode documentType = document.CreateXmlDocumentType(name, publicId, systemId, internalSubset);
+            currentNode.AppendChild(documentType);
+        }
+
+        private async Task ReadArrayElementsAsync(JsonReader reader, IXmlDocument document, string propertyName, IXmlNode currentNode, XmlNamespaceManager manager, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string elementPrefix = MiscellaneousUtils.GetPrefix(propertyName);
+
+            IXmlElement nestedArrayElement = CreateElement(propertyName, document, elementPrefix, manager);
+
+            currentNode.AppendChild(nestedArrayElement);
+
+            int count = 0;
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.EndArray)
+            {
+                await DeserializeValueAsync(reader, document, manager, propertyName, nestedArrayElement, cancellationToken).ConfigureAwait(false);
+                count++;
+            }
+
+            if (WriteArrayAttribute)
+            {
+                AddJsonArrayAttribute(nestedArrayElement, document);
+            }
+
+            if (count == 1 && WriteArrayAttribute)
+            {
+                foreach (IXmlNode childNode in nestedArrayElement.ChildNodes)
+                {
+                    IXmlElement element = childNode as IXmlElement;
+                    if (element != null && element.LocalName == propertyName)
+                    {
+                        AddJsonArrayAttribute(element, document);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -975,7 +975,7 @@ namespace Newtonsoft.Json.Converters
     /// <summary>
     /// Converts XML to and from JSON.
     /// </summary>
-    public class XmlNodeConverter : JsonConverter
+    public partial class XmlNodeConverter : JsonConverter
     {
         private const string TextName = "#text";
         private const string CommentName = "#comment";
@@ -2065,6 +2065,13 @@ namespace Newtonsoft.Json.Converters
 #endif
 
             return false;
+        }
+    }
+
+    internal sealed partial class XmlNodeConverterImpl : XmlNodeConverter
+    {
+        public XmlNodeConverterImpl()
+        {
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonConverter.Async.cs
+++ b/Src/Newtonsoft.Json/JsonConverter.Async.cs
@@ -1,0 +1,76 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public abstract partial class JsonConverter
+    {
+        /// <summary>
+        /// Asynchronously writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous write operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteJsonAsync(JsonWriter writer, object value, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return cancellationToken.CancelledAsync();
+            }
+
+            WriteJson(writer, value, serializer);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the Result property is the object read.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<object> ReadJsonAsync(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<object>() ?? Task.FromResult(ReadJson(reader, objectType, existingValue, serializer));
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonConverter.cs
+++ b/Src/Newtonsoft.Json/JsonConverter.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Converts an object to and from JSON.
     /// </summary>
-    public abstract class JsonConverter
+    public abstract partial class JsonConverter
     {
         /// <summary>
         /// Writes the JSON representation of the object.

--- a/Src/Newtonsoft.Json/JsonReader.Async.cs
+++ b/Src/Newtonsoft.Json/JsonReader.Async.cs
@@ -1,0 +1,214 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public abstract partial class JsonReader
+    {
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns <c>true</c> if the next token was read successfully; <c>false</c> if there are no more tokens to read.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<bool> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<bool>() ?? Read().ToAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously skips the children of the current token.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public async Task SkipAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (TokenType == JsonToken.PropertyName)
+            {
+                await ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (JsonTokenUtils.IsStartToken(TokenType))
+            {
+                int depth = Depth;
+
+                while (await ReadAsync(cancellationToken).ConfigureAwait(false) && (depth < Depth))
+                {
+                }
+            }
+        }
+
+        internal async Task ReaderReadAndAssertAsync(CancellationToken cancellationToken)
+        {
+            if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw CreateUnexpectedEndException();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="bool"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="bool"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<bool?> ReadAsBooleanAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<bool?>() ?? Task.FromResult(ReadAsBoolean());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="byte"/>[].
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="byte"/>[]. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<byte[]> ReadAsBytesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<byte[]>() ?? Task.FromResult(ReadAsBytes());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="DateTime"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="DateTime"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<DateTime?> ReadAsDateTimeAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<DateTime?>() ?? Task.FromResult(ReadAsDateTime());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<DateTimeOffset?> ReadAsDateTimeOffsetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<DateTimeOffset?>() ?? Task.FromResult(ReadAsDateTimeOffset());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="decimal"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="decimal"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<decimal?> ReadAsDecimalAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<decimal?>() ?? Task.FromResult(ReadAsDecimal());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="double"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="double"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<double?> ReadAsDoubleAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+
+            return Task.FromResult(ReadAsDouble());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="int"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="int"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<int?> ReadAsInt32Async(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<int?>() ?? Task.FromResult(ReadAsInt32());
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="string"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task<string> ReadAsStringAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return cancellationToken.CancelIfRequesedAsync<string>() ?? Task.FromResult(ReadAsString());
+        }
+
+        internal async Task<bool> ReadAndMoveToContentAsync(CancellationToken cancellationToken)
+        {
+            return await ReadAsync(cancellationToken).ConfigureAwait(false) && await MoveToContentAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task<bool> MoveToContentAsync(CancellationToken cancellationToken)
+        {
+            for (;;)
+            {
+                switch (TokenType)
+                {
+                    case JsonToken.None:
+                    case JsonToken.Comment:
+                        if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    default:
+                        return true;
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to serialized JSON data.
     /// </summary>
-    public abstract class JsonReader : IDisposable
+    public abstract partial class JsonReader : IDisposable
     {
         /// <summary>
         /// Specifies the state of the reader.

--- a/Src/Newtonsoft.Json/JsonSerializer.Async.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.Async.cs
@@ -1,0 +1,338 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public partial class JsonSerializer
+    {
+        /// <summary>
+        /// Asynchronously serializes the specified <see cref="Object"/> and writes the JSON structure
+        /// using the specified <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="textWriter">The <see cref="TextWriter"/> used to write the JSON structure.</param>
+        /// <param name="value">The <see cref="Object"/> to serialize.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task SerializeAsync(TextWriter textWriter, object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SerializeAsync(textWriter, value, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously serializes the specified <see cref="Object"/> and writes the JSON structure
+        /// using the specified <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="textWriter">The <see cref="TextWriter"/> used to write the JSON structure.</param>
+        /// <param name="value">The <see cref="Object"/> to serialize.</param>
+        /// <param name="objectType">
+        /// The type of the value being serialized.
+        /// This parameter is used when <see cref="TypeNameHandling"/> is Auto to write out the type name if the type of the value does not match.
+        /// Specifing the type is optional.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task SerializeAsync(TextWriter textWriter, object value, Type objectType, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SerializeAsync(new JsonTextWriterImpl(textWriter), value, objectType, cancellationToken);
+        }
+
+
+        /// <summary>
+        /// Asynchronously serializes the specified <see cref="Object"/> and writes the JSON structure
+        /// using the specified <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> used to write the JSON structure.</param>
+        /// <param name="value">The <see cref="Object"/> to serialize.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task SerializeAsync(JsonWriter jsonWriter, object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SerializeInternalAsync(jsonWriter, value, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously serializes the specified <see cref="Object"/> and writes the JSON structure
+        /// using the specified <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> used to write the JSON structure.</param>
+        /// <param name="value">The <see cref="Object"/> to serialize.</param>
+        /// <param name="objectType">
+        /// The type of the value being serialized.
+        /// This parameter is used when <see cref="TypeNameHandling"/> is Auto to write out the type name if the type of the value does not match.
+        /// Specifing the type is optional.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task SerializeAsync(JsonWriter jsonWriter, object value, Type objectType, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SerializeInternalAsync(jsonWriter, value, objectType, cancellationToken);
+        }
+
+        internal virtual async Task SerializeInternalAsync(JsonWriter jsonWriter, object value, Type objectType, CancellationToken cancellationToken)
+        {
+            ValidationUtils.ArgumentNotNull(jsonWriter, nameof(jsonWriter));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // set serialization options onto writer
+            Formatting? previousFormatting = null;
+            if (_formatting != null && jsonWriter.Formatting != _formatting)
+            {
+                previousFormatting = jsonWriter.Formatting;
+                jsonWriter.Formatting = _formatting.GetValueOrDefault();
+            }
+
+            DateFormatHandling? previousDateFormatHandling = null;
+            if (_dateFormatHandling != null && jsonWriter.DateFormatHandling != _dateFormatHandling)
+            {
+                previousDateFormatHandling = jsonWriter.DateFormatHandling;
+                jsonWriter.DateFormatHandling = _dateFormatHandling.GetValueOrDefault();
+            }
+
+            DateTimeZoneHandling? previousDateTimeZoneHandling = null;
+            if (_dateTimeZoneHandling != null && jsonWriter.DateTimeZoneHandling != _dateTimeZoneHandling)
+            {
+                previousDateTimeZoneHandling = jsonWriter.DateTimeZoneHandling;
+                jsonWriter.DateTimeZoneHandling = _dateTimeZoneHandling.GetValueOrDefault();
+            }
+
+            FloatFormatHandling? previousFloatFormatHandling = null;
+            if (_floatFormatHandling != null && jsonWriter.FloatFormatHandling != _floatFormatHandling)
+            {
+                previousFloatFormatHandling = jsonWriter.FloatFormatHandling;
+                jsonWriter.FloatFormatHandling = _floatFormatHandling.GetValueOrDefault();
+            }
+
+            StringEscapeHandling? previousStringEscapeHandling = null;
+            if (_stringEscapeHandling != null && jsonWriter.StringEscapeHandling != _stringEscapeHandling)
+            {
+                previousStringEscapeHandling = jsonWriter.StringEscapeHandling;
+                jsonWriter.StringEscapeHandling = _stringEscapeHandling.GetValueOrDefault();
+            }
+
+            CultureInfo previousCulture = null;
+            if (_culture != null && !_culture.Equals(jsonWriter.Culture))
+            {
+                previousCulture = jsonWriter.Culture;
+                jsonWriter.Culture = _culture;
+            }
+
+            string previousDateFormatString = null;
+            if (_dateFormatStringSet && jsonWriter.DateFormatString != _dateFormatString)
+            {
+                previousDateFormatString = jsonWriter.DateFormatString;
+                jsonWriter.DateFormatString = _dateFormatString;
+            }
+
+            TraceJsonWriter traceJsonWriter = TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose ? new TraceJsonWriter(jsonWriter) : null;
+
+            JsonSerializerInternalWriter serializerWriter = new JsonSerializerInternalWriter(this);
+            await serializerWriter.SerializeAsync(traceJsonWriter ?? jsonWriter, value, objectType, cancellationToken).ConfigureAwait(false);
+
+            if (traceJsonWriter != null)
+            {
+                TraceWriter.Trace(TraceLevel.Verbose, traceJsonWriter.GetSerializedJsonMessage(), null);
+            }
+
+            // reset writer back to previous options
+            if (previousFormatting != null)
+            {
+                jsonWriter.Formatting = previousFormatting.GetValueOrDefault();
+            }
+            if (previousDateFormatHandling != null)
+            {
+                jsonWriter.DateFormatHandling = previousDateFormatHandling.GetValueOrDefault();
+            }
+            if (previousDateTimeZoneHandling != null)
+            {
+                jsonWriter.DateTimeZoneHandling = previousDateTimeZoneHandling.GetValueOrDefault();
+            }
+            if (previousFloatFormatHandling != null)
+            {
+                jsonWriter.FloatFormatHandling = previousFloatFormatHandling.GetValueOrDefault();
+            }
+            if (previousStringEscapeHandling != null)
+            {
+                jsonWriter.StringEscapeHandling = previousStringEscapeHandling.GetValueOrDefault();
+            }
+            if (_dateFormatStringSet)
+            {
+                jsonWriter.DateFormatString = previousDateFormatString;
+            }
+            if (previousCulture != null)
+            {
+                jsonWriter.Culture = previousCulture;
+            }
+        }
+
+        /// <summary>
+        /// Deserializes the JSON structure contained by the specified <see cref="JsonReader"/>
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> containing the object.</param>
+        /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation. The <see cref="Task{TResult}.Result"/>
+        /// property returns the instance of <typeparamref name="T"/> being deserialized.</returns>
+        public async Task<T> DeserializeAsync<T>(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return (T)await DeserializeAsync(reader, typeof(T), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deserializes the JSON structure contained by the specified <see cref="JsonReader"/>
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> containing the object.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="object"/>  being deserialized.</returns>
+        public Task<object> DeserializeAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DeserializeInternalAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Deserializes the JSON structure contained by the specified <see cref="JsonReader"/>
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> containing the object.</param>
+        /// <param name="objectType">The <see cref="Type"/> of object being deserialized.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation. The <see cref="Task{TResult}.Result"/>
+        /// property returns the instance of <paramref name="objectType"/> being deserialized.</returns>
+        public Task<object> DeserializeAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DeserializeInternalAsync(reader, objectType, cancellationToken);
+        }
+
+        /// <summary>
+        /// Deserializes the JSON structure contained by the specified <see cref="JsonReader"/>
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <param name="reader">The <see cref="TextReader"/> containing the object.</param>
+        /// <param name="objectType">The <see cref="Type"/> of object being deserialized.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation. The <see cref="Task{TResult}.Result"/>
+        /// property returns the instance of <paramref name="objectType"/> being deserialized.</returns>
+        public Task<object> DeserializeAsync(TextReader reader, Type objectType, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DeserializeAsync(new JsonTextReaderImpl(reader), objectType, cancellationToken);
+        }
+
+        internal virtual async Task<object> DeserializeInternalAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // set serialization options onto reader
+            CultureInfo previousCulture;
+            DateTimeZoneHandling? previousDateTimeZoneHandling;
+            DateParseHandling? previousDateParseHandling;
+            FloatParseHandling? previousFloatParseHandling;
+            int? previousMaxDepth;
+            string previousDateFormatString;
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+
+            TraceJsonReader traceJsonReader = TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose ? new TraceJsonReader(reader) : null;
+
+            JsonSerializerInternalReader serializerReader = new JsonSerializerInternalReader(this);
+            object value = await serializerReader.DeserializeAsync(traceJsonReader ?? reader, objectType, CheckAdditionalContent, cancellationToken).ConfigureAwait(false);
+
+            if (traceJsonReader != null)
+            {
+                TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
+            }
+
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+
+            return value;
+        }
+
+        /// <summary>
+        /// Asynchronously populates the JSON values onto the target object.
+        /// </summary>
+        /// <param name="reader">The <see cref="TextReader"/> that contains the JSON structure to reader values from.</param>
+        /// <param name="target">The target object to populate values onto.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task PopulateAsync(TextReader reader, object target, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PopulateAsync(new JsonTextReaderImpl(reader), target, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously populates the JSON values onto the target object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> that contains the JSON structure to reader values from.</param>
+        /// <param name="target">The target object to populate values onto.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public Task PopulateAsync(JsonReader reader, object target, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PopulateInternalAsync(reader, target, cancellationToken);
+        }
+
+        internal virtual async Task PopulateInternalAsync(JsonReader reader, object target, CancellationToken cancellationToken)
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+            ValidationUtils.ArgumentNotNull(target, nameof(target));
+
+            // set serialization options onto reader
+            CultureInfo previousCulture;
+            DateTimeZoneHandling? previousDateTimeZoneHandling;
+            DateParseHandling? previousDateParseHandling;
+            FloatParseHandling? previousFloatParseHandling;
+            int? previousMaxDepth;
+            string previousDateFormatString;
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+
+            TraceJsonReader traceJsonReader = TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose ? new TraceJsonReader(reader) : null;
+
+            await new JsonSerializerInternalReader(this).PopulateAsync(traceJsonReader ?? reader, target, cancellationToken).ConfigureAwait(false);
+
+            if (traceJsonReader != null)
+            {
+                TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
+            }
+
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -42,7 +42,7 @@ namespace Newtonsoft.Json
     /// Serializes and deserializes objects into and from the JSON format.
     /// The <see cref="JsonSerializer"/> enables you to control how objects are encoded into JSON.
     /// </summary>
-    public class JsonSerializer
+    public partial class JsonSerializer
     {
         internal TypeNameHandling _typeNameHandling;
         internal TypeNameAssemblyFormatHandling _typeNameAssemblyFormatHandling;

--- a/Src/Newtonsoft.Json/JsonTextReader.Async.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.Async.cs
@@ -1,0 +1,2375 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+#if !(NET20 || NET35 || PORTABLE40 || PORTABLE) || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public partial class JsonTextReader
+    {
+        private bool SafeAsync => GetType() == typeof(JsonTextReader);
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns <c>true</c> if the next token was read successfully; <c>false</c> if there are no more tokens to read.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsync(cancellationToken) : base.ReadAsync(cancellationToken);
+        }
+
+        internal async Task<bool> DoReadAsync(CancellationToken cancellationToken)
+        {
+            EnsureBuffer();
+
+            for (;;)
+            {
+                switch (_currentState)
+                {
+                    case State.Start:
+                    case State.Property:
+                    case State.Array:
+                    case State.ArrayStart:
+                    case State.Constructor:
+                    case State.ConstructorStart:
+                        return await ParseValueAsync(cancellationToken).ConfigureAwait(false);
+                    case State.Object:
+                    case State.ObjectStart:
+                        return await ParseObjectAsync(cancellationToken).ConfigureAwait(false);
+                    case State.PostValue:
+
+                        // returns true if it hits
+                        // end of object or array
+                        if (await ParsePostValueAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case State.Finished:
+                        if (await EnsureCharsAsync(0, false, cancellationToken).ConfigureAwait(false))
+                        {
+                            await EatWhitespaceAsync(false, cancellationToken).ConfigureAwait(false);
+                            if (_isEndOfFile)
+                            {
+                                SetToken(JsonToken.None);
+                                return false;
+                            }
+
+                            if (_chars[_charPos] == '/')
+                            {
+                                await ParseCommentAsync(true, cancellationToken).ConfigureAwait(false);
+                                return true;
+                            }
+
+                            throw JsonReaderException.Create(this, "Additional text encountered after finished reading JSON content: {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+                        }
+
+                        SetToken(JsonToken.None);
+                        return false;
+                    default:
+                        throw JsonReaderException.Create(this, "Unexpected state: {0}.".FormatWith(CultureInfo.InvariantCulture, CurrentState));
+                }
+            }
+        }
+
+        private Task<int> ReadDataAsync(bool append, CancellationToken cancellationToken)
+        {
+            return ReadDataAsync(append, 0, cancellationToken);
+        }
+
+        private async Task<int> ReadDataAsync(bool append, int charsRequired, CancellationToken cancellationToken)
+        {
+            if (_isEndOfFile)
+            {
+                return 0;
+            }
+
+            // char buffer is full
+            if (_charsUsed + charsRequired >= _chars.Length - 1)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (append)
+                {
+                    // copy to new array either double the size of the current or big enough to fit required content
+                    int newArrayLength = Math.Max(_chars.Length * 2, _charsUsed + charsRequired + 1);
+
+                    // increase the size of the buffer
+                    char[] dst = BufferUtils.RentBuffer(_arrayPool, newArrayLength);
+
+                    BlockCopyChars(_chars, 0, dst, 0, _chars.Length);
+
+                    BufferUtils.ReturnBuffer(_arrayPool, _chars);
+
+                    _chars = dst;
+                }
+                else
+                {
+                    int remainingCharCount = _charsUsed - _charPos;
+
+                    if (remainingCharCount + charsRequired + 1 >= _chars.Length)
+                    {
+                        // the remaining count plus the required is bigger than the current buffer size
+                        char[] dst = BufferUtils.RentBuffer(_arrayPool, remainingCharCount + charsRequired + 1);
+
+                        if (remainingCharCount > 0)
+                        {
+                            BlockCopyChars(_chars, _charPos, dst, 0, remainingCharCount);
+                        }
+
+                        BufferUtils.ReturnBuffer(_arrayPool, _chars);
+
+                        _chars = dst;
+                    }
+                    else
+                    {
+                        // copy any remaining data to the beginning of the buffer if needed and reset positions
+                        if (remainingCharCount > 0)
+                        {
+                            BlockCopyChars(_chars, _charPos, _chars, 0, remainingCharCount);
+                        }
+                    }
+
+                    _lineStartPos -= _charPos;
+                    _charPos = 0;
+                    _charsUsed = remainingCharCount;
+                }
+            }
+
+            int attemptCharReadCount = _chars.Length - _charsUsed - 1;
+
+            int charsRead = await _reader.ReadAsync(_chars, _charsUsed, attemptCharReadCount, cancellationToken).ConfigureAwait(false);
+
+            _charsUsed += charsRead;
+
+            if (charsRead == 0)
+            {
+                _isEndOfFile = true;
+            }
+
+            _chars[_charsUsed] = '\0';
+            return charsRead;
+        }
+
+        private async Task<bool> ParseValueAsync(CancellationToken cancellationToken)
+        {
+            for (;;)
+            {
+                char currentChar = _chars[_charPos];
+
+                switch (currentChar)
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(false, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                        }
+
+                        break;
+                    case '"':
+                    case '\'':
+                        await ParseStringAsync(currentChar, ReadType.Read, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case 't':
+                        await ParseTrueAsync(cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case 'f':
+                        await ParseFalseAsync(cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case 'n':
+                        if (await EnsureCharsAsync(1, true, cancellationToken).ConfigureAwait(false))
+                        {
+                            char next = _chars[_charPos + 1];
+
+                            if (next == 'u')
+                            {
+                                await ParseNullAsync(cancellationToken).ConfigureAwait(false);
+                            }
+                            else if (next == 'e')
+                            {
+                                await ParseConstructorAsync(cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                throw CreateUnexpectedCharacterException(_chars[_charPos]);
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                            throw CreateUnexpectedEndException();
+                        }
+
+                        return true;
+                    case 'N':
+                        await ParseNumberNaNAsync(ReadType.Read, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case 'I':
+                        await ParseNumberPositiveInfinityAsync(ReadType.Read, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case '-':
+                        if (await EnsureCharsAsync(1, true, cancellationToken).ConfigureAwait(false) && _chars[_charPos + 1] == 'I')
+                        {
+                            await ParseNumberNegativeInfinityAsync(ReadType.Read, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await ParseNumberAsync(ReadType.Read, cancellationToken).ConfigureAwait(false);
+                        }
+                        return true;
+                    case '/':
+                        await ParseCommentAsync(true, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case 'u':
+                        await ParseUndefinedAsync(cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case '{':
+                        _charPos++;
+                        SetToken(JsonToken.StartObject);
+                        return true;
+                    case '[':
+                        _charPos++;
+                        SetToken(JsonToken.StartArray);
+                        return true;
+                    case ']':
+                        _charPos++;
+                        SetToken(JsonToken.EndArray);
+                        return true;
+                    case ',':
+
+                        // don't increment position, the next call to read will handle comma
+                        // this is done to handle multiple empty comma values
+                        SetToken(JsonToken.Undefined);
+                        return true;
+                    case ')':
+                        _charPos++;
+                        SetToken(JsonToken.EndConstructor);
+                        return true;
+                    case StringUtils.CarriageReturn:
+                        await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case StringUtils.LineFeed:
+                        ProcessLineFeed();
+                        break;
+                    case ' ':
+                    case StringUtils.Tab:
+
+                        // eat
+                        _charPos++;
+                        break;
+                    default:
+                        if (char.IsWhiteSpace(currentChar))
+                        {
+                            // eat
+                            _charPos++;
+                            break;
+                        }
+
+                        if (char.IsNumber(currentChar) || currentChar == '-' || currentChar == '.')
+                        {
+                            ParseNumber(ReadType.Read);
+                            return true;
+                        }
+
+                        throw CreateUnexpectedCharacterException(currentChar);
+                }
+            }
+        }
+
+        private async Task ReadStringIntoBufferAsync(char quote, CancellationToken cancellationToken)
+        {
+            int charPos = _charPos;
+            int initialPosition = _charPos;
+            int lastWritePosition = _charPos;
+            _stringBuffer.Position = 0;
+
+            for (;;)
+            {
+                switch (_chars[charPos++])
+                {
+                    case '\0':
+                        if (_charsUsed == charPos - 1)
+                        {
+                            charPos--;
+
+                            if (await ReadDataAsync(true, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                _charPos = charPos;
+                                throw JsonReaderException.Create(this, "Unterminated string. Expected delimiter: {0}.".FormatWith(CultureInfo.InvariantCulture, quote));
+                            }
+                        }
+
+                        break;
+                    case '\\':
+                        _charPos = charPos;
+                        if (!await EnsureCharsAsync(0, true, cancellationToken).ConfigureAwait(false))
+                        {
+                            throw JsonReaderException.Create(this, "Unterminated string. Expected delimiter: {0}.".FormatWith(CultureInfo.InvariantCulture, quote));
+                        }
+
+                        // start of escape sequence
+                        int escapeStartPos = charPos - 1;
+
+                        char currentChar = _chars[charPos];
+                        charPos++;
+
+                        char writeChar;
+
+                        switch (currentChar)
+                        {
+                            case 'b':
+                                writeChar = '\b';
+                                break;
+                            case 't':
+                                writeChar = '\t';
+                                break;
+                            case 'n':
+                                writeChar = '\n';
+                                break;
+                            case 'f':
+                                writeChar = '\f';
+                                break;
+                            case 'r':
+                                writeChar = '\r';
+                                break;
+                            case '\\':
+                                writeChar = '\\';
+                                break;
+                            case '"':
+                            case '\'':
+                            case '/':
+                                writeChar = currentChar;
+                                break;
+                            case 'u':
+                                _charPos = charPos;
+                                writeChar = await ParseUnicodeAsync(cancellationToken).ConfigureAwait(false);
+
+                                if (StringUtils.IsLowSurrogate(writeChar))
+                                {
+                                    // low surrogate with no preceding high surrogate; this char is replaced
+                                    writeChar = UnicodeReplacementChar;
+                                }
+                                else if (StringUtils.IsHighSurrogate(writeChar))
+                                {
+                                    bool anotherHighSurrogate;
+
+                                    // loop for handling situations where there are multiple consecutive high surrogates
+                                    do
+                                    {
+                                        anotherHighSurrogate = false;
+
+                                        // potential start of a surrogate pair
+                                        if (EnsureChars(2, true) && _chars[_charPos] == '\\' && _chars[_charPos + 1] == 'u')
+                                        {
+                                            char highSurrogate = writeChar;
+
+                                            _charPos += 2;
+                                            writeChar = await ParseUnicodeAsync(cancellationToken).ConfigureAwait(false);
+
+                                            if (StringUtils.IsLowSurrogate(writeChar))
+                                            {
+                                                // a valid surrogate pair!
+                                            }
+                                            else if (StringUtils.IsHighSurrogate(writeChar))
+                                            {
+                                                // another high surrogate; replace current and start check over
+                                                highSurrogate = UnicodeReplacementChar;
+                                                anotherHighSurrogate = true;
+                                            }
+                                            else
+                                            {
+                                                // high surrogate not followed by low surrogate; original char is replaced
+                                                highSurrogate = UnicodeReplacementChar;
+                                            }
+
+                                            EnsureBufferNotEmpty();
+
+                                            WriteCharToBuffer(highSurrogate, lastWritePosition, escapeStartPos);
+                                            lastWritePosition = _charPos;
+                                        }
+                                        else
+                                        {
+                                            // there are not enough remaining chars for the low surrogate or is not follow by unicode sequence
+                                            // replace high surrogate and continue on as usual
+                                            writeChar = UnicodeReplacementChar;
+                                        }
+                                    } while (anotherHighSurrogate);
+                                }
+
+                                charPos = _charPos;
+                                break;
+                            default:
+                                _charPos = charPos;
+                                throw JsonReaderException.Create(this, "Bad JSON escape sequence: {0}.".FormatWith(CultureInfo.InvariantCulture, @"\" + currentChar));
+                        }
+
+                        EnsureBufferNotEmpty();
+                        WriteCharToBuffer(writeChar, lastWritePosition, escapeStartPos);
+
+                        lastWritePosition = charPos;
+                        break;
+                    case StringUtils.CarriageReturn:
+                        _charPos = charPos - 1;
+                        await ProcessCarriageReturnAsync(true, cancellationToken).ConfigureAwait(false);
+                        charPos = _charPos;
+                        break;
+                    case StringUtils.LineFeed:
+                        _charPos = charPos - 1;
+                        ProcessLineFeed();
+                        charPos = _charPos;
+                        break;
+                    case '"':
+                    case '\'':
+                        if (_chars[charPos - 1] == quote)
+                        {
+                            charPos--;
+
+                            if (initialPosition == lastWritePosition)
+                            {
+                                _stringReference = new StringReference(_chars, initialPosition, charPos - initialPosition);
+                            }
+                            else
+                            {
+                                EnsureBufferNotEmpty();
+
+                                if (charPos > lastWritePosition)
+                                {
+                                    _stringBuffer.Append(_arrayPool, _chars, lastWritePosition, charPos - lastWritePosition);
+                                }
+
+                                _stringReference = new StringReference(_stringBuffer.InternalBuffer, 0, _stringBuffer.Position);
+                            }
+
+                            charPos++;
+                            _charPos = charPos;
+                            return;
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        private async Task ProcessCarriageReturnAsync(bool append, CancellationToken cancellationToken)
+        {
+            _charPos++;
+
+            if (await EnsureCharsAsync(1, append, cancellationToken).ConfigureAwait(false) && _chars[_charPos] == StringUtils.LineFeed)
+            {
+                _charPos++;
+            }
+
+            OnNewLine(_charPos);
+        }
+
+        private async Task<char> ParseUnicodeAsync(CancellationToken cancellationToken)
+        {
+            char writeChar;
+            if (await EnsureCharsAsync(4, true, cancellationToken).ConfigureAwait(false))
+            {
+                char hexChar = Convert.ToChar(ConvertUtils.HexTextToInt(_chars, _charPos, _charPos + 4));
+                writeChar = hexChar;
+
+                _charPos += 4;
+            }
+            else
+            {
+                throw JsonReaderException.Create(this, "Unexpected end while parsing unicode character.");
+            }
+
+            return writeChar;
+        }
+
+        private Task<bool> EnsureCharsAsync(int relativePosition, bool append, CancellationToken cancellationToken)
+        {
+            if (_charPos + relativePosition < _charsUsed)
+            {
+                return AsyncUtils.True;
+            }
+
+            if (_isEndOfFile)
+            {
+                return AsyncUtils.False;
+            }
+
+            return ReadCharsAsync(relativePosition, append, cancellationToken);
+        }
+
+        private async Task<bool> ReadCharsAsync(int relativePosition, bool append, CancellationToken cancellationToken)
+        {
+            int charsRequired = _charPos + relativePosition - _charsUsed + 1;
+
+            int totalCharsRead = 0;
+
+            // it is possible that the TextReader doesn't return all data at once
+            // repeat read until the required text is returned or the reader is out of content
+            do
+            {
+                int charsRead = await ReadDataAsync(append, charsRequired - totalCharsRead, cancellationToken).ConfigureAwait(false);
+
+                // no more content
+                if (charsRead == 0)
+                {
+                    return false;
+                }
+
+                totalCharsRead += charsRead;
+            } while (totalCharsRead < charsRequired);
+
+            return true;
+        }
+
+        private async Task<bool> ParseObjectAsync(CancellationToken cancellationToken)
+        {
+            for (;;)
+            {
+                char currentChar = _chars[_charPos];
+
+                switch (currentChar)
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(false, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                        }
+
+                        break;
+                    case '}':
+                        SetToken(JsonToken.EndObject);
+                        _charPos++;
+                        return true;
+                    case '/':
+                        await ParseCommentAsync(true, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case StringUtils.CarriageReturn:
+                        await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case StringUtils.LineFeed:
+                        ProcessLineFeed();
+                        break;
+                    case ' ':
+                    case StringUtils.Tab:
+
+                        // eat
+                        _charPos++;
+                        break;
+                    default:
+                        if (char.IsWhiteSpace(currentChar))
+                        {
+                            // eat
+                            _charPos++;
+                        }
+                        else
+                        {
+                            return await ParsePropertyAsync(cancellationToken).ConfigureAwait(false);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        private async Task ParseCommentAsync(bool setToken, CancellationToken cancellationToken)
+        {
+            // should have already parsed / character before reaching this method
+            _charPos++;
+
+            if (!await EnsureCharsAsync(1, false, cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonReaderException.Create(this, "Unexpected end while parsing comment.");
+            }
+
+            bool singlelineComment;
+
+            if (_chars[_charPos] == '*')
+            {
+                singlelineComment = false;
+            }
+            else if (_chars[_charPos] == '/')
+            {
+                singlelineComment = true;
+            }
+            else
+            {
+                throw JsonReaderException.Create(this, "Error parsing comment. Expected: *, got {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+            }
+
+            _charPos++;
+
+            int initialPosition = _charPos;
+
+            for (;;)
+            {
+                switch (_chars[_charPos])
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(true, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                if (!singlelineComment)
+                                {
+                                    throw JsonReaderException.Create(this, "Unexpected end while parsing comment.");
+                                }
+
+                                EndComment(setToken, initialPosition, _charPos);
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                        }
+
+                        break;
+                    case '*':
+                        _charPos++;
+
+                        if (!singlelineComment)
+                        {
+                            if (await EnsureCharsAsync(0, true, cancellationToken).ConfigureAwait(false))
+                            {
+                                if (_chars[_charPos] == '/')
+                                {
+                                    EndComment(setToken, initialPosition, _charPos - 1);
+
+                                    _charPos++;
+                                    return;
+                                }
+                            }
+                        }
+
+                        break;
+                    case StringUtils.CarriageReturn:
+                        if (singlelineComment)
+                        {
+                            EndComment(setToken, initialPosition, _charPos);
+                            return;
+                        }
+
+                        await ProcessCarriageReturnAsync(true, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case StringUtils.LineFeed:
+                        if (singlelineComment)
+                        {
+                            EndComment(setToken, initialPosition, _charPos);
+                            return;
+                        }
+
+                        ProcessLineFeed();
+                        break;
+                    default:
+                        _charPos++;
+                        break;
+                }
+            }
+        }
+
+        private async Task<bool> ParsePostValueAsync(CancellationToken cancellationToken)
+        {
+            for (;;)
+            {
+                char currentChar = _chars[_charPos];
+
+                switch (currentChar)
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(false, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                _currentState = State.Finished;
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                        }
+
+                        break;
+                    case '}':
+                        _charPos++;
+                        SetToken(JsonToken.EndObject);
+                        return true;
+                    case ']':
+                        _charPos++;
+                        SetToken(JsonToken.EndArray);
+                        return true;
+                    case ')':
+                        _charPos++;
+                        SetToken(JsonToken.EndConstructor);
+                        return true;
+                    case '/':
+                        await ParseCommentAsync(true, cancellationToken).ConfigureAwait(false);
+                        return true;
+                    case ',':
+                        _charPos++;
+
+                        // finished parsing
+                        SetStateBasedOnCurrent();
+                        return false;
+                    case ' ':
+                    case StringUtils.Tab:
+
+                        // eat
+                        _charPos++;
+                        break;
+                    case StringUtils.CarriageReturn:
+                        await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case StringUtils.LineFeed:
+                        ProcessLineFeed();
+                        break;
+                    default:
+                        if (char.IsWhiteSpace(currentChar))
+                        {
+                            // eat
+                            _charPos++;
+                        }
+                        else
+                        {
+                            throw JsonReaderException.Create(this, "After parsing a value an unexpected character was encountered: {0}.".FormatWith(CultureInfo.InvariantCulture, currentChar));
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        private async Task<bool> EatWhitespaceAsync(bool oneOrMore, CancellationToken cancellationToken)
+        {
+            bool finished = false;
+            bool ateWhitespace = false;
+            while (!finished)
+            {
+                char currentChar = _chars[_charPos];
+
+                switch (currentChar)
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(false, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                finished = true;
+                            }
+                        }
+                        else
+                        {
+                            _charPos++;
+                        }
+                        break;
+                    case StringUtils.CarriageReturn:
+                        await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case StringUtils.LineFeed:
+                        ProcessLineFeed();
+                        break;
+                    default:
+                        if (currentChar == ' ' || char.IsWhiteSpace(currentChar))
+                        {
+                            ateWhitespace = true;
+                            _charPos++;
+                        }
+                        else
+                        {
+                            finished = true;
+                        }
+                        break;
+                }
+            }
+
+            return !oneOrMore || ateWhitespace;
+        }
+
+        private async Task ParseStringAsync(char quote, ReadType readType, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _charPos++;
+
+            ShiftBufferIfNeeded();
+            await ReadStringIntoBufferAsync(quote, cancellationToken).ConfigureAwait(false);
+            SetPostValueState(true);
+
+            switch (readType)
+            {
+                case ReadType.ReadAsBytes:
+                    Guid g;
+                    byte[] data;
+                    if (_stringReference.Length == 0)
+                    {
+                        data = new byte[0];
+                    }
+                    else if (_stringReference.Length == 36 && ConvertUtils.TryConvertGuid(_stringReference.ToString(), out g))
+                    {
+                        data = g.ToByteArray();
+                    }
+                    else
+                    {
+                        data = Convert.FromBase64CharArray(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length);
+                    }
+
+                    SetToken(JsonToken.Bytes, data, false);
+                    break;
+                case ReadType.ReadAsString:
+                    string text = _stringReference.ToString();
+
+                    SetToken(JsonToken.String, text, false);
+                    _quoteChar = quote;
+                    break;
+                case ReadType.ReadAsInt32:
+                case ReadType.ReadAsDecimal:
+                case ReadType.ReadAsBoolean:
+
+                    // caller will convert result
+                    break;
+                default:
+                    if (_dateParseHandling != DateParseHandling.None)
+                    {
+                        DateParseHandling dateParseHandling;
+                        if (readType == ReadType.ReadAsDateTime)
+                        {
+                            dateParseHandling = DateParseHandling.DateTime;
+                        }
+#if !NET20
+                        else if (readType == ReadType.ReadAsDateTimeOffset)
+                        {
+                            dateParseHandling = DateParseHandling.DateTimeOffset;
+                        }
+#endif
+                        else
+                        {
+                            dateParseHandling = _dateParseHandling;
+                        }
+
+                        if (dateParseHandling == DateParseHandling.DateTime)
+                        {
+                            DateTime dt;
+                            if (DateTimeUtils.TryParseDateTime(_stringReference, DateTimeZoneHandling, DateFormatString, Culture, out dt))
+                            {
+                                SetToken(JsonToken.Date, dt, false);
+                                return;
+                            }
+                        }
+#if !NET20
+                        else
+                        {
+                            DateTimeOffset dt;
+                            if (DateTimeUtils.TryParseDateTimeOffset(_stringReference, DateFormatString, Culture, out dt))
+                            {
+                                SetToken(JsonToken.Date, dt, false);
+                                return;
+                            }
+                        }
+#endif
+                    }
+
+                    SetToken(JsonToken.String, _stringReference.ToString(), false);
+                    _quoteChar = quote;
+                    break;
+            }
+        }
+
+        private async Task<bool> MatchValueAsync(string value, CancellationToken cancellationToken)
+        {
+            if (!await EnsureCharsAsync(value.Length - 1, true, cancellationToken).ConfigureAwait(false))
+            {
+                _charPos = _charsUsed;
+                throw CreateUnexpectedEndException();
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (_chars[_charPos + i] != value[i])
+                {
+                    _charPos += i;
+                    return false;
+                }
+            }
+
+            _charPos += value.Length;
+
+            return true;
+        }
+
+        private async Task<bool> MatchValueWithTrailingSeparatorAsync(string value, CancellationToken cancellationToken)
+        {
+            // will match value and then move to the next character, checking that it is a separator character
+            if (!await MatchValueAsync(value, cancellationToken).ConfigureAwait(false))
+            {
+                return false;
+            }
+
+            if (!await EnsureCharsAsync(0, false, cancellationToken).ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            return IsSeparator(_chars[_charPos]) || _chars[_charPos] == '\0';
+        }
+
+        private async Task MatchAndSetAsync(string value, JsonToken newToken, object tokenValue, CancellationToken cancellationToken)
+        {
+            if (await MatchValueWithTrailingSeparatorAsync(value, cancellationToken).ConfigureAwait(false))
+            {
+                SetToken(newToken, tokenValue);
+            }
+            else
+            {
+                throw JsonReaderException.Create(this, "Error parsing " + newToken.ToString().ToLowerInvariant() + " value.");
+            }
+        }
+
+        private Task ParseTrueAsync(CancellationToken cancellationToken)
+        {
+            return MatchAndSetAsync(JsonConvert.True, JsonToken.Boolean, true, cancellationToken);
+        }
+
+        private Task ParseFalseAsync(CancellationToken cancellationToken)
+        {
+            return MatchAndSetAsync(JsonConvert.False, JsonToken.Boolean, false, cancellationToken);
+        }
+
+        private Task ParseNullAsync(CancellationToken cancellationToken)
+        {
+            return MatchAndSetAsync(JsonConvert.Null, JsonToken.Null, null, cancellationToken);
+        }
+
+        private async Task ParseConstructorAsync(CancellationToken cancellationToken)
+        {
+            if (await MatchValueWithTrailingSeparatorAsync("new", cancellationToken).ConfigureAwait(false))
+            {
+                await EatWhitespaceAsync(false, cancellationToken).ConfigureAwait(false);
+
+                int initialPosition = _charPos;
+                int endPosition;
+
+                for (;;)
+                {
+                    char currentChar = _chars[_charPos];
+                    if (currentChar == '\0')
+                    {
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(true, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                throw JsonReaderException.Create(this, "Unexpected end while parsing constructor.");
+                            }
+                        }
+                        else
+                        {
+                            endPosition = _charPos;
+                            _charPos++;
+                            break;
+                        }
+                    }
+                    else if (char.IsLetterOrDigit(currentChar))
+                    {
+                        _charPos++;
+                    }
+                    else if (currentChar == StringUtils.CarriageReturn)
+                    {
+                        endPosition = _charPos;
+                        await ProcessCarriageReturnAsync(true, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+                    else if (currentChar == StringUtils.LineFeed)
+                    {
+                        endPosition = _charPos;
+                        ProcessLineFeed();
+                        break;
+                    }
+                    else if (char.IsWhiteSpace(currentChar))
+                    {
+                        endPosition = _charPos;
+                        _charPos++;
+                        break;
+                    }
+                    else if (currentChar == '(')
+                    {
+                        endPosition = _charPos;
+                        break;
+                    }
+                    else
+                    {
+                        throw JsonReaderException.Create(this, "Unexpected character while parsing constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, currentChar));
+                    }
+                }
+
+                _stringReference = new StringReference(_chars, initialPosition, endPosition - initialPosition);
+                string constructorName = _stringReference.ToString();
+
+                EatWhitespace(false);
+
+                if (_chars[_charPos] != '(')
+                {
+                    throw JsonReaderException.Create(this, "Unexpected character while parsing constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+                }
+
+                _charPos++;
+
+                ClearRecentString();
+
+                SetToken(JsonToken.StartConstructor, constructorName);
+            }
+            else
+            {
+                throw JsonReaderException.Create(this, "Unexpected content while parsing JSON.");
+            }
+        }
+
+        private async Task<object> ParseNumberNaNAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            if (await MatchValueWithTrailingSeparatorAsync(JsonConvert.NaN, cancellationToken).ConfigureAwait(false))
+            {
+                switch (readType)
+                {
+                    case ReadType.Read:
+                    case ReadType.ReadAsDouble:
+                        if (_floatParseHandling == FloatParseHandling.Double)
+                        {
+                            SetToken(JsonToken.Float, double.NaN);
+                            return double.NaN;
+                        }
+
+                        break;
+                    case ReadType.ReadAsString:
+                        SetToken(JsonToken.String, JsonConvert.NaN);
+                        return JsonConvert.NaN;
+                }
+
+                throw JsonReaderException.Create(this, "Cannot read NaN value.");
+            }
+
+            throw JsonReaderException.Create(this, "Error parsing NaN value.");
+        }
+
+        private async Task<object> ParseNumberPositiveInfinityAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            if (await MatchValueWithTrailingSeparatorAsync(JsonConvert.PositiveInfinity, cancellationToken).ConfigureAwait(false))
+            {
+                switch (readType)
+                {
+                    case ReadType.Read:
+                    case ReadType.ReadAsDouble:
+                        if (_floatParseHandling == FloatParseHandling.Double)
+                        {
+                            SetToken(JsonToken.Float, double.PositiveInfinity);
+                            return double.PositiveInfinity;
+                        }
+
+                        break;
+                    case ReadType.ReadAsString:
+                        SetToken(JsonToken.String, JsonConvert.PositiveInfinity);
+                        return JsonConvert.PositiveInfinity;
+                }
+
+                throw JsonReaderException.Create(this, "Cannot read Infinity value.");
+            }
+
+            throw JsonReaderException.Create(this, "Error parsing Infinity value.");
+        }
+
+        private async Task<object> ParseNumberNegativeInfinityAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            if (await MatchValueWithTrailingSeparatorAsync(JsonConvert.NegativeInfinity, cancellationToken).ConfigureAwait(false))
+            {
+                switch (readType)
+                {
+                    case ReadType.Read:
+                    case ReadType.ReadAsDouble:
+                        if (_floatParseHandling == FloatParseHandling.Double)
+                        {
+                            SetToken(JsonToken.Float, double.NegativeInfinity);
+                            return double.NegativeInfinity;
+                        }
+
+                        break;
+                    case ReadType.ReadAsString:
+                        SetToken(JsonToken.String, JsonConvert.NegativeInfinity);
+                        return JsonConvert.NegativeInfinity;
+                }
+
+                throw JsonReaderException.Create(this, "Cannot read -Infinity value.");
+            }
+
+            throw JsonReaderException.Create(this, "Error parsing -Infinity value.");
+        }
+
+        private async Task ParseNumberAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            ShiftBufferIfNeeded();
+
+            char firstChar = _chars[_charPos];
+            int initialPosition = _charPos;
+
+            await ReadNumberIntoBufferAsync(cancellationToken).ConfigureAwait(false);
+
+            // set state to PostValue now so that if there is an error parsing the number then the reader can continue
+            SetPostValueState(true);
+
+            _stringReference = new StringReference(_chars, initialPosition, _charPos - initialPosition);
+
+            object numberValue;
+            JsonToken numberType;
+
+            bool singleDigit = char.IsDigit(firstChar) && _stringReference.Length == 1;
+            bool nonBase10 = firstChar == '0' && _stringReference.Length > 1 && _stringReference.Chars[_stringReference.StartIndex + 1] != '.' && _stringReference.Chars[_stringReference.StartIndex + 1] != 'e' && _stringReference.Chars[_stringReference.StartIndex + 1] != 'E';
+
+            if (readType == ReadType.ReadAsString)
+            {
+                string number = _stringReference.ToString();
+
+                // validate that the string is a valid number
+                if (nonBase10)
+                {
+                    try
+                    {
+                        if (number.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Convert.ToInt64(number, 16);
+                        }
+                        else
+                        {
+                            Convert.ToInt64(number, 8);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid number.".FormatWith(CultureInfo.InvariantCulture, number), ex);
+                    }
+                }
+                else
+                {
+                    double value;
+                    if (!double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out value))
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid number.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                    }
+                }
+
+                numberType = JsonToken.String;
+                numberValue = number;
+            }
+            else if (readType == ReadType.ReadAsInt32)
+            {
+                if (singleDigit)
+                {
+                    // digit char values start at 48
+                    numberValue = firstChar - 48;
+                }
+                else if (nonBase10)
+                {
+                    string number = _stringReference.ToString();
+
+                    try
+                    {
+                        int integer = number.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? Convert.ToInt32(number, 16) : Convert.ToInt32(number, 8);
+
+                        numberValue = integer;
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid integer.".FormatWith(CultureInfo.InvariantCulture, number), ex);
+                    }
+                }
+                else
+                {
+                    int value;
+                    ParseResult parseResult = ConvertUtils.Int32TryParse(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length, out value);
+                    if (parseResult == ParseResult.Success)
+                    {
+                        numberValue = value;
+                    }
+                    else if (parseResult == ParseResult.Overflow)
+                    {
+                        throw ThrowReaderError("JSON integer {0} is too large or small for an Int32.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                    }
+                    else
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid integer.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                    }
+                }
+
+                numberType = JsonToken.Integer;
+            }
+            else if (readType == ReadType.ReadAsDecimal)
+            {
+                if (singleDigit)
+                {
+                    // digit char values start at 48
+                    numberValue = (decimal)firstChar - 48;
+                }
+                else if (nonBase10)
+                {
+                    string number = _stringReference.ToString();
+
+                    try
+                    {
+                        // decimal.Parse doesn't support parsing hexadecimal values
+                        long integer = number.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? Convert.ToInt64(number, 16) : Convert.ToInt64(number, 8);
+
+                        numberValue = Convert.ToDecimal(integer);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid decimal.".FormatWith(CultureInfo.InvariantCulture, number), ex);
+                    }
+                }
+                else
+                {
+                    string number = _stringReference.ToString();
+
+                    decimal value;
+                    if (decimal.TryParse(number, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out value))
+                    {
+                        numberValue = value;
+                    }
+                    else
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid decimal.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                    }
+                }
+
+                numberType = JsonToken.Float;
+            }
+            else if (readType == ReadType.ReadAsDouble)
+            {
+                if (singleDigit)
+                {
+                    // digit char values start at 48
+                    numberValue = (double)firstChar - 48;
+                }
+                else if (nonBase10)
+                {
+                    string number = _stringReference.ToString();
+
+                    try
+                    {
+                        // double.Parse doesn't support parsing hexadecimal values
+                        long integer = number.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? Convert.ToInt64(number, 16) : Convert.ToInt64(number, 8);
+
+                        numberValue = Convert.ToDouble(integer);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid double.".FormatWith(CultureInfo.InvariantCulture, number), ex);
+                    }
+                }
+                else
+                {
+                    double value;
+                    ParseResult parseResult = ConvertUtils.DoubleTryParse(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length, out value);
+                    if (parseResult == ParseResult.Success)
+                    {
+                        numberValue = value;
+                    }
+                    else
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid double.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                    }
+                }
+
+                numberType = JsonToken.Float;
+            }
+            else
+            {
+                if (singleDigit)
+                {
+                    // digit char values start at 48
+                    numberValue = (long)firstChar - 48;
+                    numberType = JsonToken.Integer;
+                }
+                else if (nonBase10)
+                {
+                    string number = _stringReference.ToString();
+
+                    try
+                    {
+                        numberValue = number.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? Convert.ToInt64(number, 16) : Convert.ToInt64(number, 8);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ThrowReaderError("Input string '{0}' is not a valid number.".FormatWith(CultureInfo.InvariantCulture, number), ex);
+                    }
+
+                    numberType = JsonToken.Integer;
+                }
+                else
+                {
+                    long value;
+                    ParseResult parseResult = ConvertUtils.Int64TryParse(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length, out value);
+                    if (parseResult == ParseResult.Success)
+                    {
+                        numberValue = value;
+                        numberType = JsonToken.Integer;
+                    }
+                    else if (parseResult == ParseResult.Overflow)
+                    {
+#if !(PORTABLE40 || PORTABLE) || NETSTANDARD1_1
+                        string number = _stringReference.ToString();
+
+                        if (number.Length > MaximumJavascriptIntegerCharacterLength)
+                        {
+                            throw ThrowReaderError("JSON integer {0} is too large to parse.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+                        }
+
+                        numberValue = BigIntegerParse(number, CultureInfo.InvariantCulture);
+                        numberType = JsonToken.Integer;
+#else
+                        throw ThrowReaderError("JSON integer {0} is too large or small for an Int64.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
+#endif
+                    }
+                    else
+                    {
+                        string number = _stringReference.ToString();
+
+                        if (_floatParseHandling == FloatParseHandling.Decimal)
+                        {
+                            decimal d;
+                            if (decimal.TryParse(number, NumberStyles.Number | NumberStyles.AllowExponent, CultureInfo.InvariantCulture, out d))
+                            {
+                                numberValue = d;
+                            }
+                            else
+                            {
+                                throw ThrowReaderError("Input string '{0}' is not a valid decimal.".FormatWith(CultureInfo.InvariantCulture, number));
+                            }
+                        }
+                        else
+                        {
+                            double d;
+                            parseResult = ConvertUtils.DoubleTryParse(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length, out d);
+                            if (parseResult == ParseResult.Success)
+                            {
+                                numberValue = d;
+                            }
+                            else
+                            {
+                                throw ThrowReaderError("Input string '{0}' is not a valid number.".FormatWith(CultureInfo.InvariantCulture, number));
+                            }
+                        }
+
+                        numberType = JsonToken.Float;
+                    }
+                }
+            }
+
+            ClearRecentString();
+
+            // index has already been updated
+            SetToken(numberType, numberValue, false);
+        }
+
+        private Task ParseUndefinedAsync(CancellationToken cancellationToken)
+        {
+            return MatchAndSetAsync(JsonConvert.Undefined, JsonToken.Undefined, null, cancellationToken);
+        }
+
+        private async Task<bool> ParsePropertyAsync(CancellationToken cancellationToken)
+        {
+            char firstChar = _chars[_charPos];
+            char quoteChar;
+
+            if (firstChar == '"' || firstChar == '\'')
+            {
+                _charPos++;
+                quoteChar = firstChar;
+                ShiftBufferIfNeeded();
+                await ReadStringIntoBufferAsync(quoteChar, cancellationToken).ConfigureAwait(false);
+            }
+            else if (ValidIdentifierChar(firstChar))
+            {
+                quoteChar = '\0';
+                ShiftBufferIfNeeded();
+                await ParseUnquotedPropertyAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                throw JsonReaderException.Create(this, "Invalid property identifier character: {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+            }
+
+            string propertyName;
+
+            if (NameTable != null)
+            {
+                propertyName = NameTable.Get(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length)
+                    // no match in name table
+                    ?? _stringReference.ToString();
+            }
+            else
+            {
+                propertyName = _stringReference.ToString();
+            }
+
+            await EatWhitespaceAsync(false, cancellationToken).ConfigureAwait(false);
+
+            if (_chars[_charPos] != ':')
+            {
+                throw JsonReaderException.Create(this, "Invalid character after parsing property name. Expected ':' but got: {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+            }
+
+            _charPos++;
+
+            SetToken(JsonToken.PropertyName, propertyName);
+            _quoteChar = quoteChar;
+            ClearRecentString();
+
+            return true;
+        }
+
+        private async Task ReadNumberIntoBufferAsync(CancellationToken cancellationToken)
+        {
+            int charPos = _charPos;
+
+            for (;;)
+            {
+                switch (_chars[charPos])
+                {
+                    case '\0':
+                        _charPos = charPos;
+
+                        if (_charsUsed == charPos)
+                        {
+                            if (await ReadDataAsync(true, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            return;
+                        }
+
+                        break;
+                    case '-':
+                    case '+':
+                    case 'a':
+                    case 'A':
+                    case 'b':
+                    case 'B':
+                    case 'c':
+                    case 'C':
+                    case 'd':
+                    case 'D':
+                    case 'e':
+                    case 'E':
+                    case 'f':
+                    case 'F':
+                    case 'x':
+                    case 'X':
+                    case '.':
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        charPos++;
+                        break;
+                    default:
+                        _charPos = charPos;
+
+                        char currentChar = _chars[_charPos];
+                        if (char.IsWhiteSpace(currentChar) || currentChar == ',' || currentChar == '}' || currentChar == ']' || currentChar == ')' || currentChar == '/')
+                        {
+                            return;
+                        }
+
+                        throw JsonReaderException.Create(this, "Unexpected character encountered while parsing number: {0}.".FormatWith(CultureInfo.InvariantCulture, currentChar));
+                }
+            }
+        }
+
+        private async Task ParseUnquotedPropertyAsync(CancellationToken cancellationToken)
+        {
+            int initialPosition = _charPos;
+
+            // parse unquoted property name until whitespace or colon
+            for (;;)
+            {
+                switch (_chars[_charPos])
+                {
+                    case '\0':
+                        if (_charsUsed == _charPos)
+                        {
+                            if (await ReadDataAsync(true, cancellationToken).ConfigureAwait(false) == 0)
+                            {
+                                throw JsonReaderException.Create(this, "Unexpected end while parsing unquoted property name.");
+                            }
+
+                            break;
+                        }
+
+                        _stringReference = new StringReference(_chars, initialPosition, _charPos - initialPosition);
+                        return;
+                    default:
+                        char currentChar = _chars[_charPos];
+
+                        if (ValidIdentifierChar(currentChar))
+                        {
+                            _charPos++;
+                            break;
+                        }
+                        else if (char.IsWhiteSpace(currentChar) || currentChar == ':')
+                        {
+                            _stringReference = new StringReference(_chars, initialPosition, _charPos - initialPosition);
+                            return;
+                        }
+
+                        throw JsonReaderException.Create(this, "Invalid JavaScript property identifier character: {0}.".FormatWith(CultureInfo.InvariantCulture, currentChar));
+                }
+            }
+        }
+
+        private async Task<bool> ReadNullCharAsync(CancellationToken cancellationToken)
+        {
+            if (_charsUsed == _charPos)
+            {
+                if (await ReadDataAsync(false, cancellationToken).ConfigureAwait(false) == 0)
+                {
+                    _isEndOfFile = true;
+                    return true;
+                }
+            }
+            else
+            {
+                _charPos++;
+            }
+
+            return false;
+        }
+
+        private async Task HandleNullAsync(CancellationToken cancellationToken)
+        {
+            if (await EnsureCharsAsync(1, true, cancellationToken).ConfigureAwait(false))
+            {
+                char next = _chars[_charPos + 1];
+
+                if (next == 'u')
+                {
+                    await ParseNullAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                _charPos += 2;
+                throw CreateUnexpectedCharacterException(_chars[_charPos - 1]);
+            }
+
+            _charPos = _charsUsed;
+            throw CreateUnexpectedEndException();
+        }
+
+        private async Task ReadFinishedAsync(CancellationToken cancellationToken)
+        {
+            if (await EnsureCharsAsync(0, false, cancellationToken).ConfigureAwait(false))
+            {
+                await EatWhitespaceAsync(false, cancellationToken).ConfigureAwait(false);
+                if (_isEndOfFile)
+                {
+                    return;
+                }
+
+                if (_chars[_charPos] == '/')
+                {
+                    await ParseCommentAsync(false, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw JsonReaderException.Create(this, "Additional text encountered after finished reading JSON content: {0}.".FormatWith(CultureInfo.InvariantCulture, _chars[_charPos]));
+                }
+            }
+
+            SetToken(JsonToken.None);
+        }
+
+        private async Task<object> ReadStringValueAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureBuffer();
+
+            switch (_currentState)
+            {
+                case State.Start:
+                case State.Property:
+                case State.Array:
+                case State.ArrayStart:
+                case State.Constructor:
+                case State.ConstructorStart:
+                case State.PostValue:
+                    for (;;)
+                    {
+                        char currentChar = _chars[_charPos];
+
+                        switch (currentChar)
+                        {
+                            case '\0':
+                                if (await ReadNullCharAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    SetToken(JsonToken.None, null, false);
+                                    return null;
+                                }
+
+                                break;
+                            case '"':
+                            case '\'':
+                                await ParseStringAsync(currentChar, readType, cancellationToken).ConfigureAwait(false);
+                                switch (readType)
+                                {
+                                    case ReadType.ReadAsBytes:
+                                        return Value;
+                                    case ReadType.ReadAsString:
+                                        return Value;
+                                    case ReadType.ReadAsDateTime:
+                                        if (Value is DateTime)
+                                        {
+                                            return (DateTime)Value;
+                                        }
+
+                                        return ReadDateTimeString((string)Value);
+#if !NET20
+                                    case ReadType.ReadAsDateTimeOffset:
+                                        if (Value is DateTimeOffset)
+                                        {
+                                            return (DateTimeOffset)Value;
+                                        }
+
+                                        return ReadDateTimeOffsetString((string)Value);
+#endif
+                                    default:
+                                        throw new ArgumentOutOfRangeException(nameof(readType));
+                                }
+                            case '-':
+                                if (await EnsureCharsAsync(1, true, cancellationToken).ConfigureAwait(false) && _chars[_charPos + 1] == 'I')
+                                {
+                                    return ParseNumberNegativeInfinity(readType);
+                                }
+                                else
+                                {
+                                    await ParseNumberAsync(readType, cancellationToken).ConfigureAwait(false);
+                                    return Value;
+                                }
+                            case '.':
+                            case '0':
+                            case '1':
+                            case '2':
+                            case '3':
+                            case '4':
+                            case '5':
+                            case '6':
+                            case '7':
+                            case '8':
+                            case '9':
+                                if (readType != ReadType.ReadAsString)
+                                {
+                                    _charPos++;
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                await ParseNumberAsync(ReadType.ReadAsString, cancellationToken).ConfigureAwait(false);
+                                return Value;
+                            case 't':
+                            case 'f':
+                                if (readType != ReadType.ReadAsString)
+                                {
+                                    _charPos++;
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                string expected = currentChar == 't' ? JsonConvert.True : JsonConvert.False;
+                                if (!await MatchValueWithTrailingSeparatorAsync(expected, cancellationToken).ConfigureAwait(false))
+                                {
+                                    throw CreateUnexpectedCharacterException(_chars[_charPos]);
+                                }
+
+                                SetToken(JsonToken.String, expected);
+                                return expected;
+                            case 'I':
+                                return await ParseNumberPositiveInfinityAsync(readType, cancellationToken).ConfigureAwait(false);
+                            case 'N':
+                                return await ParseNumberNaNAsync(readType, cancellationToken).ConfigureAwait(false);
+                            case 'n':
+                                await HandleNullAsync(cancellationToken).ConfigureAwait(false);
+                                return null;
+                            case '/':
+                                await ParseCommentAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case ',':
+                                ProcessValueComma();
+                                break;
+                            case ']':
+                                _charPos++;
+                                if (_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.PostValue)
+                                {
+                                    SetToken(JsonToken.EndArray);
+                                    return null;
+                                }
+
+                                throw CreateUnexpectedCharacterException(currentChar);
+                            case StringUtils.CarriageReturn:
+                                await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case StringUtils.LineFeed:
+                                ProcessLineFeed();
+                                break;
+                            case ' ':
+                            case StringUtils.Tab:
+
+                                // eat
+                                _charPos++;
+                                break;
+                            default:
+                                _charPos++;
+
+                                if (!char.IsWhiteSpace(currentChar))
+                                {
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                // eat
+                                break;
+                        }
+                    }
+                case State.Finished:
+                    await ReadFinishedAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+                default:
+                    throw JsonReaderException.Create(this, "Unexpected state: {0}.".FormatWith(CultureInfo.InvariantCulture, CurrentState));
+            }
+        }
+
+        private async Task<object> ReadNumberValueAsync(ReadType readType, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureBuffer();
+
+            switch (_currentState)
+            {
+                case State.Start:
+                case State.Property:
+                case State.Array:
+                case State.ArrayStart:
+                case State.Constructor:
+                case State.ConstructorStart:
+                case State.PostValue:
+                    for (;;)
+                    {
+                        char currentChar = _chars[_charPos];
+
+                        switch (currentChar)
+                        {
+                            case '\0':
+                                if (await ReadNullCharAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    SetToken(JsonToken.None, null, false);
+                                    return null;
+                                }
+
+                                break;
+                            case '"':
+                            case '\'':
+                                await ParseStringAsync(currentChar, readType, cancellationToken).ConfigureAwait(false);
+                                switch (readType)
+                                {
+                                    case ReadType.ReadAsInt32:
+                                        return ReadInt32String(_stringReference.ToString());
+                                    case ReadType.ReadAsDecimal:
+                                        return ReadDecimalString(_stringReference.ToString());
+                                    case ReadType.ReadAsDouble:
+                                        return ReadDoubleString(_stringReference.ToString());
+                                    default:
+                                        throw new ArgumentOutOfRangeException(nameof(readType));
+                                }
+                            case 'n':
+                                await HandleNullAsync(cancellationToken).ConfigureAwait(false);
+                                return null;
+                            case 'N':
+                                return await ParseNumberNaNAsync(readType, cancellationToken).ConfigureAwait(false);
+                            case 'I':
+                                return await ParseNumberPositiveInfinityAsync(readType, cancellationToken).ConfigureAwait(false);
+                            case '-':
+                                if (await EnsureCharsAsync(1, true, cancellationToken).ConfigureAwait(false) && _chars[_charPos + 1] == 'I')
+                                {
+                                    return await ParseNumberNegativeInfinityAsync(readType, cancellationToken).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    await ParseNumberAsync(readType, cancellationToken).ConfigureAwait(false);
+                                    return Value;
+                                }
+                            case '.':
+                            case '0':
+                            case '1':
+                            case '2':
+                            case '3':
+                            case '4':
+                            case '5':
+                            case '6':
+                            case '7':
+                            case '8':
+                            case '9':
+                                await ParseNumberAsync(readType, cancellationToken).ConfigureAwait(false);
+                                return Value;
+                            case '/':
+                                await ParseCommentAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case ',':
+                                ProcessValueComma();
+                                break;
+                            case ']':
+                                _charPos++;
+                                if (_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.PostValue)
+                                {
+                                    SetToken(JsonToken.EndArray);
+                                    return null;
+                                }
+
+                                throw CreateUnexpectedCharacterException(currentChar);
+                            case StringUtils.CarriageReturn:
+                                await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case StringUtils.LineFeed:
+                                ProcessLineFeed();
+                                break;
+                            case ' ':
+                            case StringUtils.Tab:
+
+                                // eat
+                                _charPos++;
+                                break;
+                            default:
+                                _charPos++;
+
+                                if (!char.IsWhiteSpace(currentChar))
+                                {
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                // eat
+                                break;
+                        }
+                    }
+                case State.Finished:
+                    await ReadFinishedAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+                default:
+                    throw JsonReaderException.Create(this, "Unexpected state: {0}.".FormatWith(CultureInfo.InvariantCulture, CurrentState));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="bool"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="bool"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<bool?> ReadAsBooleanAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsBooleanAsync(cancellationToken) : base.ReadAsBooleanAsync(cancellationToken);
+        }
+
+        internal async Task<bool?> DoReadAsBooleanAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureBuffer();
+
+            switch (_currentState)
+            {
+                case State.Start:
+                case State.Property:
+                case State.Array:
+                case State.ArrayStart:
+                case State.Constructor:
+                case State.ConstructorStart:
+                case State.PostValue:
+                    while (true)
+                    {
+                        char currentChar = _chars[_charPos];
+
+                        switch (currentChar)
+                        {
+                            case '\0':
+                                if (await ReadNullCharAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    SetToken(JsonToken.None, null, false);
+                                    return null;
+                                }
+
+                                break;
+                            case '"':
+                            case '\'':
+                                await ParseStringAsync(currentChar, ReadType.Read, cancellationToken).ConfigureAwait(false);
+                                return ReadBooleanString(_stringReference.ToString());
+                            case 'n':
+                                await HandleNullAsync(cancellationToken).ConfigureAwait(false);
+                                return null;
+                            case '-':
+                            case '.':
+                            case '0':
+                            case '1':
+                            case '2':
+                            case '3':
+                            case '4':
+                            case '5':
+                            case '6':
+                            case '7':
+                            case '8':
+                            case '9':
+                                await ParseNumberAsync(ReadType.Read, cancellationToken).ConfigureAwait(false);
+                                bool b;
+#if !(PORTABLE40 || PORTABLE) || NETSTANDARD1_1
+                                if (Value is BigInteger)
+                                {
+                                    b = (BigInteger)Value != 0;
+                                }
+                                else
+#endif
+                                {
+                                    b = Convert.ToBoolean(Value, CultureInfo.InvariantCulture);
+                                }
+                                SetToken(JsonToken.Boolean, b, false);
+                                return b;
+                            case 't':
+                            case 'f':
+                                bool isTrue = currentChar == 't';
+                                string expected = isTrue ? JsonConvert.True : JsonConvert.False;
+
+                                if (!await MatchValueWithTrailingSeparatorAsync(expected, cancellationToken).ConfigureAwait(false))
+                                {
+                                    throw CreateUnexpectedCharacterException(_chars[_charPos]);
+                                }
+
+                                SetToken(JsonToken.Boolean, isTrue);
+                                return isTrue;
+                            case '/':
+                                await ParseCommentAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case ',':
+                                ProcessValueComma();
+                                break;
+                            case ']':
+                                _charPos++;
+                                if (_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.PostValue)
+                                {
+                                    SetToken(JsonToken.EndArray);
+                                    return null;
+                                }
+
+                                throw CreateUnexpectedCharacterException(currentChar);
+                            case StringUtils.CarriageReturn:
+                                await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case StringUtils.LineFeed:
+                                ProcessLineFeed();
+                                break;
+                            case ' ':
+                            case StringUtils.Tab:
+
+                                // eat
+                                _charPos++;
+                                break;
+                            default:
+                                _charPos++;
+
+                                if (!char.IsWhiteSpace(currentChar))
+                                {
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                // eat
+                                break;
+                        }
+                    }
+                case State.Finished:
+                    await ReadFinishedAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+                default:
+                    throw JsonReaderException.Create(this, "Unexpected state: {0}.".FormatWith(CultureInfo.InvariantCulture, CurrentState));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="byte"/>[].
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="byte"/>[]. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<byte[]> ReadAsBytesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsBytesAsync(cancellationToken) : base.ReadAsBytesAsync(cancellationToken);
+        }
+
+        internal async Task<byte[]> DoReadAsBytesAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureBuffer();
+            bool isWrapped = false;
+
+            switch (_currentState)
+            {
+                case State.Start:
+                case State.Property:
+                case State.Array:
+                case State.ArrayStart:
+                case State.Constructor:
+                case State.ConstructorStart:
+                case State.PostValue:
+                    for (;;)
+                    {
+                        char currentChar = _chars[_charPos];
+
+                        switch (currentChar)
+                        {
+                            case '\0':
+                                if (await ReadNullCharAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    SetToken(JsonToken.None, null, false);
+                                    return null;
+                                }
+
+                                break;
+                            case '"':
+                            case '\'':
+                                await ParseStringAsync(currentChar, ReadType.ReadAsBytes, cancellationToken).ConfigureAwait(false);
+                                byte[] data = (byte[])Value;
+                                if (isWrapped)
+                                {
+                                    await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                                    if (TokenType != JsonToken.EndObject)
+                                    {
+                                        throw JsonReaderException.Create(this, "Error reading bytes. Unexpected token: {0}.".FormatWith(CultureInfo.InvariantCulture, TokenType));
+                                    }
+
+                                    SetToken(JsonToken.Bytes, data, false);
+                                }
+
+                                return data;
+                            case '{':
+                                _charPos++;
+                                SetToken(JsonToken.StartObject);
+                                await ReadIntoWrappedTypeObjectAsync(cancellationToken).ConfigureAwait(false);
+                                isWrapped = true;
+                                break;
+                            case '[':
+                                _charPos++;
+                                SetToken(JsonToken.StartArray);
+                                return await ReadArrayIntoByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                            case 'n':
+                                await HandleNullAsync(cancellationToken);
+                                return null;
+                            case '/':
+                                await ParseCommentAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case ',':
+                                ProcessValueComma();
+                                break;
+                            case ']':
+                                _charPos++;
+                                if (_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.PostValue)
+                                {
+                                    SetToken(JsonToken.EndArray);
+                                    return null;
+                                }
+
+                                throw CreateUnexpectedCharacterException(currentChar);
+                            case StringUtils.CarriageReturn:
+                                await ProcessCarriageReturnAsync(false, cancellationToken).ConfigureAwait(false);
+                                break;
+                            case StringUtils.LineFeed:
+                                ProcessLineFeed();
+                                break;
+                            case ' ':
+                            case StringUtils.Tab:
+
+                                // eat
+                                _charPos++;
+                                break;
+                            default:
+                                _charPos++;
+
+                                if (!char.IsWhiteSpace(currentChar))
+                                {
+                                    throw CreateUnexpectedCharacterException(currentChar);
+                                }
+
+                                // eat
+                                break;
+                        }
+                    }
+                case State.Finished:
+                    await ReadFinishedAsync(cancellationToken).ConfigureAwait(false);
+                    return null;
+                default:
+                    throw JsonReaderException.Create(this, "Unexpected state: {0}.".FormatWith(CultureInfo.InvariantCulture, CurrentState));
+            }
+        }
+
+        private async Task ReadIntoWrappedTypeObjectAsync(CancellationToken cancellationToken)
+        {
+            await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+            if (Value != null && Value.ToString() == JsonTypeReflector.TypePropertyName)
+            {
+                await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                if (Value != null && Value.ToString().StartsWith("System.Byte[]", StringComparison.Ordinal))
+                {
+                    await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
+                    if (Value.ToString() == JsonTypeReflector.ValuePropertyName)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            throw JsonReaderException.Create(this, "Error reading bytes. Unexpected token: {0}.".FormatWith(CultureInfo.InvariantCulture, JsonToken.StartObject));
+        }
+
+        private async Task<byte[]> ReadArrayIntoByteArrayAsync(CancellationToken cancellationToken)
+        {
+            List<byte> buffer = new List<byte>();
+
+            for (;;)
+            {
+                if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    SetToken(JsonToken.None);
+                }
+
+                switch (TokenType)
+                {
+                    case JsonToken.None:
+                        throw JsonReaderException.Create(this, "Unexpected end when reading bytes.");
+                    case JsonToken.Integer:
+                        buffer.Add(Convert.ToByte(Value, CultureInfo.InvariantCulture));
+                        break;
+                    case JsonToken.EndArray:
+                        byte[] d = buffer.ToArray();
+                        SetToken(JsonToken.Bytes, d, false);
+                        return d;
+                    case JsonToken.Comment:
+                        continue;
+                    default:
+                        throw JsonReaderException.Create(this, "Unexpected token when reading bytes: {0}.".FormatWith(CultureInfo.InvariantCulture, TokenType));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="DateTime"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="DateTime"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<DateTime?> ReadAsDateTimeAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsDateTimeAsync(cancellationToken) : base.ReadAsDateTimeAsync(cancellationToken);
+        }
+
+        internal async Task<DateTime?> DoReadAsDateTimeAsync(CancellationToken cancellationToken)
+        {
+            return (DateTime?)await ReadStringValueAsync(ReadType.ReadAsDateTime, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<DateTimeOffset?> ReadAsDateTimeOffsetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsDateTimeOffsetAsync(cancellationToken) : base.ReadAsDateTimeOffsetAsync(cancellationToken);
+        }
+
+        internal async Task<DateTimeOffset?> DoReadAsDateTimeOffsetAsync(CancellationToken cancellationToken)
+        {
+            return (DateTimeOffset?)await ReadStringValueAsync(ReadType.ReadAsDateTimeOffset, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="decimal"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="decimal"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<decimal?> ReadAsDecimalAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsDecimalAsync(cancellationToken) : base.ReadAsDecimalAsync(cancellationToken);
+        }
+
+        internal async Task<decimal?> DoReadAsDecimalAsync(CancellationToken cancellationToken)
+        {
+            return (decimal?)await ReadNumberValueAsync(ReadType.ReadAsDecimal, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="double"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="double"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<double?> ReadAsDoubleAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsDoubleAsync(cancellationToken) : base.ReadAsDoubleAsync(cancellationToken);
+        }
+
+        internal async Task<double?> DoReadAsDoubleAsync(CancellationToken cancellationToken)
+        {
+            return (double?)await ReadNumberValueAsync(ReadType.ReadAsDouble, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="Nullable{T}"/> of <see cref="int"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="Nullable{T}"/> of <see cref="int"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<int?> ReadAsInt32Async(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsInt32Async(cancellationToken) : base.ReadAsInt32Async(cancellationToken);
+        }
+
+        internal async Task<int?> DoReadAsInt32Async(CancellationToken cancellationToken)
+        {
+            return (int?)await ReadNumberValueAsync(ReadType.ReadAsInt32, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next JSON token from the source as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous read. The <see cref="Task{TResult}.Result"/>
+        /// property returns the <see cref="string"/>. This result will be <c>null</c> at the end of an array.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task<string> ReadAsStringAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoReadAsStringAsync(cancellationToken) : base.ReadAsStringAsync(cancellationToken);
+        }
+
+        internal async Task<string> DoReadAsStringAsync(CancellationToken cancellationToken)
+        {
+            return (string)await ReadStringValueAsync(ReadType.ReadAsString, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal sealed partial class JsonTextReaderImpl
+    {
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsync(cancellationToken);
+        }
+
+        public override Task<bool?> ReadAsBooleanAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsBooleanAsync(cancellationToken);
+        }
+
+        public override Task<byte[]> ReadAsBytesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsBytesAsync(cancellationToken);
+        }
+
+        public override Task<DateTime?> ReadAsDateTimeAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsDateTimeAsync(cancellationToken);
+        }
+
+        public override Task<DateTimeOffset?> ReadAsDateTimeOffsetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsDateTimeOffsetAsync(cancellationToken);
+        }
+
+        public override Task<decimal?> ReadAsDecimalAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsDecimalAsync(cancellationToken);
+        }
+
+        public override Task<double?> ReadAsDoubleAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsDoubleAsync(cancellationToken);
+        }
+
+        public override Task<int?> ReadAsInt32Async(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsInt32Async(cancellationToken);
+        }
+
+        public override Task<string> ReadAsStringAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoReadAsStringAsync(cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -55,7 +55,7 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to JSON text data.
     /// </summary>
-    public class JsonTextReader : JsonReader, IJsonLineInfo
+    public partial class JsonTextReader : JsonReader, IJsonLineInfo
     {
         private const char UnicodeReplacementChar = '\uFFFD';
         private const int MaximumJavascriptIntegerCharacterLength = 380;
@@ -2465,6 +2465,14 @@ namespace Newtonsoft.Json
         public int LinePosition
         {
             get { return _charPos - _lineStartPos; }
+        }
+    }
+
+    internal sealed partial class JsonTextReaderImpl : JsonTextReader
+    {
+        public JsonTextReaderImpl(TextReader reader)
+            : base(reader)
+        {
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonTextWriter.Async.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.Async.cs
@@ -1,0 +1,1490 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Threading;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public partial class JsonTextWriter
+    {
+        private bool SafeAsync => GetType() == typeof(JsonTextWriter);
+
+        /// <summary>
+        /// Asynchronously flushes whatever is in the buffer to the destination and also flushes the destination.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoFlushAsync(cancellationToken) : base.FlushAsync(cancellationToken);
+        }
+
+        internal Task DoFlushAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.CancelIfRequesedAsync() ?? _writer.FlushAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously writes the JSON value delimiter.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        protected override Task WriteValueDelimiterAsync(CancellationToken cancellationToken)
+        {
+            return SafeAsync ? DoWriteValueDelimiterAsync(cancellationToken) : base.WriteValueDelimiterAsync(cancellationToken);
+        }
+
+        internal Task DoWriteValueDelimiterAsync(CancellationToken cancellationToken)
+        {
+            return _writer.WriteAsync(',', cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the specified end token.
+        /// </summary>
+        /// <param name="token">The end token to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        protected override Task WriteEndAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            return SafeAsync ? DoWriteEndAsync(token, cancellationToken) : base.WriteEndAsync(token, cancellationToken);
+        }
+
+        internal Task DoWriteEndAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            switch (token)
+            {
+                case JsonToken.EndObject:
+                    return _writer.WriteAsync('}', cancellationToken);
+                case JsonToken.EndArray:
+                    return _writer.WriteAsync(']', cancellationToken);
+                case JsonToken.EndConstructor:
+                    return _writer.WriteAsync(')', cancellationToken);
+                default:
+                    throw JsonWriterException.Create(this, "Invalid JsonToken: " + token, null);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously closes this writer.
+        /// If <see cref="JsonWriter.CloseOutput"/> is set to <c>true</c>, the destination is also closed.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoCloseAsync(cancellationToken) : base.CloseAsync(cancellationToken);
+        }
+
+        internal async Task DoCloseAsync(CancellationToken cancellationToken)
+        {
+            while (Top > 0)
+            {
+                await WriteEndAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_writeBuffer != null)
+            {
+                BufferUtils.ReturnBuffer(_arrayPool, _writeBuffer);
+                _writeBuffer = null;
+            }
+
+            if (CloseOutput)
+            {
+#if !(DOTNET || PORTABLE40 || PORTABLE)
+                _writer?.Close();
+#else
+                _writer?.Dispose();
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of the current JSON object or array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteEndAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteEndInternalAsync(cancellationToken) : base.WriteEndAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes indent characters.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        protected override Task WriteIndentAsync(CancellationToken cancellationToken)
+        {
+            return SafeAsync ? DoWriteIndentAsync(cancellationToken) : base.WriteIndentAsync(cancellationToken);
+        }
+
+        internal async Task DoWriteIndentAsync(CancellationToken cancellationToken)
+        {
+            await _writer.WriteLineAsync(cancellationToken).ConfigureAwait(false);
+
+            // levels of indentation multiplied by the indent count
+            int currentIndentCount = Top * _indentation;
+
+            if (currentIndentCount > 0)
+            {
+                if (_indentChars == null)
+                {
+                    _indentChars = new string(_indentChar, 10).ToCharArray();
+                }
+
+                while (currentIndentCount > 0)
+                {
+                    int writeCount = Math.Min(currentIndentCount, 10);
+
+                    await _writer.WriteAsync(_indentChars, 0, writeCount, cancellationToken).ConfigureAwait(false);
+
+                    currentIndentCount -= writeCount;
+                }
+            }
+        }
+
+        private Task WriteValueInternalAsync(string value, CancellationToken cancellationToken)
+        {
+            return _writer.WriteAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes an indent space.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        protected override Task WriteIndentSpaceAsync(CancellationToken cancellationToken)
+        {
+            return SafeAsync ? DoWriteIndentSpaceAsync(cancellationToken) : base.WriteIndentSpaceAsync(cancellationToken);
+        }
+
+        internal Task DoWriteIndentSpaceAsync(CancellationToken cancellationToken)
+        {
+            return _writer.WriteAsync(' ', cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes raw JSON without changing the writer's state.
+        /// </summary>
+        /// <param name="json">The raw JSON to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteRawAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteRawAsync(json, cancellationToken) : base.WriteRawAsync(json, cancellationToken);
+        }
+
+        internal Task DoWriteRawAsync(string json, CancellationToken cancellationToken)
+        {
+            return _writer.WriteAsync(json, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a null value.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteNullAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteNullAsync(cancellationToken) : base.WriteNullAsync(cancellationToken);
+        }
+
+        internal async Task DoWriteNullAsync(CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Null, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.Null, cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task WriteDigitsAsync(ulong uvalue, CancellationToken cancellationToken)
+        {
+            if (uvalue <= 9)
+            {
+                return _writer.WriteAsync((char)('0' + uvalue), cancellationToken);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            EnsureWriteBuffer();
+
+            int totalLength = MathUtils.IntLength(uvalue);
+            int length = 0;
+
+            do
+            {
+                _writeBuffer[totalLength - ++length] = (char)('0' + uvalue % 10);
+                uvalue /= 10;
+            } while (uvalue != 0);
+
+            return _writer.WriteAsync(_writeBuffer, 0, length, cancellationToken);
+        }
+
+        internal async Task WriteIntegerValueAsync(long value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Integer, cancellationToken).ConfigureAwait(false);
+            if (value < 0)
+            {
+                await _writer.WriteAsync('-', cancellationToken).ConfigureAwait(false);
+            }
+
+            await WriteDigitsAsync(value < 0 ? (ulong)-value : (ulong)value, cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task WriteIntegerValueAsync(ulong uvalue, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Integer, cancellationToken).ConfigureAwait(false);
+            await WriteDigitsAsync(uvalue, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteEscapedStringAsync(string value, bool quote, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureWriteBuffer();
+            _writeBuffer = await JavaScriptUtils.WriteEscapedJavaScriptStringAsync(_writer, value, _quoteChar, quote, _charEscapeFlags, StringEscapeHandling, _arrayPool, _writeBuffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the property name of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WritePropertyNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWritePropertyNameAsync(name, cancellationToken) : base.WritePropertyNameAsync(name, cancellationToken);
+        }
+
+        internal async Task DoWritePropertyNameAsync(string name, CancellationToken cancellationToken)
+        {
+            await InternalWritePropertyNameAsync(name, cancellationToken).ConfigureAwait(false);
+
+            await WriteEscapedStringAsync(name, _quoteName, cancellationToken).ConfigureAwait(false);
+
+            await _writer.WriteAsync(':', cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the property name of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="escape">A flag to indicate whether the text should be escaped when it is written as a JSON property name.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWritePropertyNameAsync(name, escape, cancellationToken) : base.WritePropertyNameAsync(name, escape, cancellationToken);
+        }
+
+        internal async Task DoWritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken)
+        {
+            await InternalWritePropertyNameAsync(name, cancellationToken).ConfigureAwait(false);
+
+            if (escape)
+            {
+                await WriteEscapedStringAsync(name, _quoteName, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (_quoteName)
+                {
+                    await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+                }
+
+                await _writer.WriteAsync(name, cancellationToken).ConfigureAwait(false);
+
+                if (_quoteName)
+                {
+                    await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            await _writer.WriteAsync(':', cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the beginning of a JSON array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteStartArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteStartArrayAsync(cancellationToken) : base.WriteStartArrayAsync(cancellationToken);
+        }
+
+        internal async Task DoWriteStartArrayAsync(CancellationToken cancellationToken)
+        {
+            await InternalWriteStartAsync(JsonToken.StartArray, JsonContainerType.Array, cancellationToken).ConfigureAwait(false);
+
+            await _writer.WriteAsync('[', cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the given white space.
+        /// </summary>
+        /// <param name="ws">The string of white space characters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteWhitespaceAsync(string ws, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteWhitespaceAsync(ws, cancellationToken) : base.WriteWhitespaceAsync(ws, cancellationToken);
+        }
+
+        internal Task DoWriteWhitespaceAsync(string ws, CancellationToken cancellationToken)
+        {
+            InternalWriteWhitespace(ws);
+            return _writer.WriteAsync(ws, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="bool"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="bool"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(bool value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(bool value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Boolean, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.ToString(value), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="bool"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="bool"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(bool? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(bool? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="byte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(byte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="byte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="byte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(byte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(byte? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="byte"/>[] value.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/>[] value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(byte[] value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? (value == null ? WriteNullAsync(cancellationToken) : WriteValueNonNullAsync(value, cancellationToken)) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task WriteValueNonNullAsync(byte[] value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Bytes, cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+            await Base64Encoder.EncodeAsync(value, 0, value.Length, cancellationToken).ConfigureAwait(false);
+            await Base64Encoder.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="char"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="char"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(char value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(char value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.String, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.ToString(value), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="char"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="char"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(char? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(char? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="DateTime"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(DateTime value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(DateTime value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Date, cancellationToken).ConfigureAwait(false);
+            value = DateTimeUtils.EnsureDateTime(value, DateTimeZoneHandling);
+
+            if (string.IsNullOrEmpty(DateFormatString))
+            {
+                EnsureWriteBuffer();
+
+                int pos = 0;
+                _writeBuffer[pos++] = _quoteChar;
+                pos = DateTimeUtils.WriteDateTimeString(_writeBuffer, pos, value, null, value.Kind, DateFormatHandling);
+                _writeBuffer[pos++] = _quoteChar;
+
+                await _writer.WriteAsync(_writeBuffer, 0, pos, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+                await _writer.WriteAsync(value.ToString(DateFormatString, Culture), cancellationToken).ConfigureAwait(false);
+                await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="DateTime"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(DateTime? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(DateTime? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="DateTimeOffset"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(DateTimeOffset value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(DateTimeOffset value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Date, cancellationToken).ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(DateFormatString))
+            {
+                EnsureWriteBuffer();
+
+                int pos = 0;
+                _writeBuffer[pos++] = _quoteChar;
+                pos = DateTimeUtils.WriteDateTimeString(_writeBuffer, pos, DateFormatHandling == DateFormatHandling.IsoDateFormat ? value.DateTime : value.UtcDateTime, value.Offset, DateTimeKind.Local, DateFormatHandling);
+                _writeBuffer[pos++] = _quoteChar;
+
+                await _writer.WriteAsync(_writeBuffer, 0, pos, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+                await _writer.WriteAsync(value.ToString(DateFormatString, Culture), cancellationToken).ConfigureAwait(false);
+                await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(DateTimeOffset? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(DateTimeOffset? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="decimal"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="decimal"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(decimal value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(decimal value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Float, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.ToString(value), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="decimal"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="decimal"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(decimal? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(decimal? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="double"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="double"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(double value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteValueAsync(value, false, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task WriteValueAsync(double value, bool nullable, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Float, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.ToString(value, FloatFormatHandling, QuoteChar, nullable), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="double"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="double"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(double? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? (value.HasValue ? WriteValueAsync(value.GetValueOrDefault(), true, cancellationToken) : WriteNullAsync(cancellationToken)) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="float"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="float"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(float value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteValueAsync(value, false, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task WriteValueAsync(float value, bool nullable, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Float, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(JsonConvert.ToString(value, FloatFormatHandling, QuoteChar, nullable), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="float"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="float"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(float? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? (value.HasValue ? WriteValueAsync(value.GetValueOrDefault(), true, cancellationToken) : WriteNullAsync(cancellationToken)) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Guid"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Guid"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(Guid value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(Guid value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.String, cancellationToken).ConfigureAwait(false);
+
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+#if !(DOTNET || PORTABLE40 || PORTABLE)
+            await _writer.WriteAsync(value.ToString("D", CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
+#else
+            await _writer.WriteAsync(value.ToString("D"), cancellationToken).ConfigureAwait(false);
+#endif
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="Guid"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="Guid"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(Guid? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(Guid? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="int"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="int"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(int value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="int"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="int"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(int? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(int? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="long"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="long"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(long value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="long"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="long"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(long? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(long? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+
+#if !(PORTABLE || PORTABLE40) || NETSTANDARD1_1
+        internal async Task WriteValueAsync(BigInteger value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.Integer, cancellationToken).ConfigureAwait(false);
+            await WriteValueInternalAsync(value.ToString(CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
+        }
+#endif
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="object"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="object"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (SafeAsync)
+            {
+                if (value == null)
+                {
+                    return WriteNullAsync(cancellationToken);
+                }
+#if !(PORTABLE || PORTABLE40) || NETSTANDARD1_1
+                if (value is BigInteger)
+                {
+                    return WriteValueAsync((BigInteger)value, cancellationToken);
+                }
+#endif
+
+                return WriteValueAsync(this, ConvertUtils.GetTypeCode(value.GetType()), value, cancellationToken);
+            }
+
+            return base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="sbyte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="sbyte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(sbyte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="sbyte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="sbyte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(sbyte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(sbyte? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="short"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="short"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(short value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="short"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="short"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(short? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(short? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="string"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(string value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.String, cancellationToken).ConfigureAwait(false);
+            await (value == null ? WriteValueInternalAsync(JsonConvert.Null, cancellationToken) : WriteEscapedStringAsync(value, true, cancellationToken)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="TimeSpan"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="TimeSpan"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(TimeSpan value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task DoWriteValueAsync(TimeSpan value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.String, cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(value.ToString(null, CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(_quoteChar, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="TimeSpan"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="TimeSpan"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(TimeSpan? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(TimeSpan? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : DoWriteValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="uint"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(uint value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="uint"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="uint"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(uint? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(uint? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="ulong"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(ulong value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="ulong"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="ulong"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(ulong? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(ulong? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Uri"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Uri"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteValueAsync(Uri value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? (value == null ? WriteNullAsync(cancellationToken) : WriteValueNotNullAsync(value, cancellationToken)) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal async Task WriteValueNotNullAsync(Uri value, CancellationToken cancellationToken)
+        {
+            await InternalWriteValueAsync(JsonToken.String, cancellationToken).ConfigureAwait(false);
+            await WriteEscapedStringAsync(value.OriginalString, true, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="ushort"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ushort"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(ushort value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? WriteIntegerValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="ushort"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="ushort"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        [CLSCompliant(false)]
+        public override Task WriteValueAsync(ushort? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteValueAsync(value, cancellationToken) : base.WriteValueAsync(value, cancellationToken);
+        }
+
+        internal Task DoWriteValueAsync(ushort? value, CancellationToken cancellationToken)
+        {
+            return value == null ? DoWriteNullAsync(cancellationToken) : WriteIntegerValueAsync(value.GetValueOrDefault(), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a comment <c>/*...*/</c> containing the specified text.
+        /// </summary>
+        /// <param name="text">Text to place inside the comment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteCommentAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteCommentAsync(text, cancellationToken) : base.WriteCommentAsync(text, cancellationToken);
+        }
+
+        internal async Task DoWriteCommentAsync(string text, CancellationToken cancellationToken)
+        {
+            await InternalWriteCommentAsync(cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync("/*", cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync(text, cancellationToken).ConfigureAwait(false);
+            await _writer.WriteAsync("*/", cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of an array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteEndArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? InternalWriteEndAsync(JsonContainerType.Array, cancellationToken) : base.WriteEndArrayAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of a constructor.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteEndConstructorAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? InternalWriteEndAsync(JsonContainerType.Constructor, cancellationToken) : base.WriteEndConstructorAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of a JSON object.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteEndObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? InternalWriteEndAsync(JsonContainerType.Object, cancellationToken) : base.WriteEndObjectAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes raw JSON where a value is expected and updates the writer's state.
+        /// </summary>
+        /// <param name="json">The raw JSON to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteRawValueAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SafeAsync ? DoWriteRawValueAsync(json, cancellationToken) : base.WriteRawValueAsync(json, cancellationToken);
+        }
+
+        internal async Task DoWriteRawValueAsync(string json, CancellationToken cancellationToken)
+        {
+            UpdateScopeWithFinishedValue();
+            await AutoCompleteAsync(JsonToken.Undefined, cancellationToken).ConfigureAwait(false);
+            await WriteRawAsync(json, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal sealed partial class JsonTextWriterImpl
+    {
+        public override Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoFlushAsync(cancellationToken);
+        }
+
+        protected override Task WriteValueDelimiterAsync(CancellationToken cancellationToken)
+        {
+            return DoWriteValueDelimiterAsync(cancellationToken);
+        }
+
+        protected override Task WriteEndAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            return DoWriteEndAsync(token, cancellationToken);
+        }
+
+        public override Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoCloseAsync(cancellationToken);
+        }
+
+        public override Task WriteEndAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteEndInternalAsync(cancellationToken);
+        }
+
+        protected override Task WriteIndentAsync(CancellationToken cancellationToken)
+        {
+            return DoWriteIndentAsync(cancellationToken);
+        }
+
+        protected override Task WriteIndentSpaceAsync(CancellationToken cancellationToken)
+        {
+            return DoWriteIndentSpaceAsync(cancellationToken);
+        }
+
+        public override Task WriteRawAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteRawAsync(json, cancellationToken);
+        }
+
+        public override Task WriteNullAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteNullAsync(cancellationToken);
+        }
+
+        public override Task WritePropertyNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWritePropertyNameAsync(name, cancellationToken);
+        }
+
+        public override Task WritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWritePropertyNameAsync(name, escape, cancellationToken);
+        }
+
+        public override Task WriteStartArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteStartArrayAsync(cancellationToken);
+        }
+
+        public override Task WriteWhitespaceAsync(string ws, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteWhitespaceAsync(ws, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(bool value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(bool? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(byte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(byte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(byte[] value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return value == null ? WriteNullAsync(cancellationToken) : WriteValueNonNullAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(char value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(char? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(DateTime value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(DateTime? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(DateTimeOffset value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(DateTimeOffset? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(decimal value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(decimal? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(double value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteValueAsync(value, false, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(double? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return value.HasValue ? WriteValueAsync(value.GetValueOrDefault(), true, cancellationToken) : WriteNullAsync(cancellationToken);
+        }
+
+        public override Task WriteValueAsync(float value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteValueAsync(value, false, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(float? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return value.HasValue ? WriteValueAsync(value.GetValueOrDefault(), true, cancellationToken) : WriteNullAsync(cancellationToken);
+        }
+
+        public override Task WriteValueAsync(Guid value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(Guid? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(int value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(int? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(long value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(long? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (value == null)
+            {
+                return WriteNullAsync(cancellationToken);
+            }
+#if !(PORTABLE || PORTABLE40) || NETSTANDARD1_1
+            if (value is BigInteger)
+            {
+                return WriteValueAsync((BigInteger)value, cancellationToken);
+            }
+#endif
+
+            return WriteValueAsync(this, ConvertUtils.GetTypeCode(value.GetType()), value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(sbyte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(sbyte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(short value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(short? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(TimeSpan value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(TimeSpan? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(uint value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(uint? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(ulong value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(ulong? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(Uri value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return value == null ? WriteNullAsync(cancellationToken) : WriteValueNotNullAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(ushort value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteIntegerValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteValueAsync(ushort? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteValueAsync(value, cancellationToken);
+        }
+
+        public override Task WriteCommentAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteCommentAsync(text, cancellationToken);
+        }
+
+        public override Task WriteEndArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return InternalWriteEndAsync(JsonContainerType.Array, cancellationToken);
+        }
+
+        public override Task WriteEndConstructorAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return InternalWriteEndAsync(JsonContainerType.Constructor, cancellationToken);
+        }
+
+        public override Task WriteEndObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return InternalWriteEndAsync(JsonContainerType.Object, cancellationToken);
+        }
+
+        public override Task WriteRawValueAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return DoWriteRawValueAsync(json, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -39,7 +39,7 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public class JsonTextWriter : JsonWriter
+    public partial class JsonTextWriter : JsonWriter
     {
         private readonly TextWriter _writer;
         private Base64Encoder _base64Encoder;
@@ -803,6 +803,14 @@ namespace Newtonsoft.Json
 
                 _writer.Write(_writeBuffer, 0, length);
             }
+        }
+    }
+
+    internal sealed partial class JsonTextWriterImpl : JsonTextWriter
+    {
+        public JsonTextWriterImpl(TextWriter textWriter)
+            : base(textWriter)
+        {
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonWriter.Async.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.Async.cs
@@ -1,0 +1,1573 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Threading;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json
+{
+    public abstract partial class JsonWriter
+    {
+        internal async Task AutoCompleteAsync(JsonToken tokenBeingWritten, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // gets new state based on the current state and what is being written
+            State newState = StateArray[(int)tokenBeingWritten][(int)_currentState];
+
+            if (newState == State.Error)
+            {
+                throw JsonWriterException.Create(this, "Token {0} in state {1} would result in an invalid JSON object.".FormatWith(CultureInfo.InvariantCulture, tokenBeingWritten.ToString(), _currentState.ToString()), null);
+            }
+
+            if ((_currentState == State.Object || _currentState == State.Array || _currentState == State.Constructor) && tokenBeingWritten != JsonToken.Comment)
+            {
+                await WriteValueDelimiterAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (_formatting == Formatting.Indented)
+            {
+                if (_currentState == State.Property)
+                {
+                    await WriteIndentSpaceAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                // don't indent a property when it is the first token to be written (i.e. at the start)
+                if (_currentState == State.Array || _currentState == State.ArrayStart || _currentState == State.Constructor || _currentState == State.ConstructorStart || (tokenBeingWritten == JsonToken.PropertyName && _currentState != State.Start))
+                {
+                    await WriteIndentAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            _currentState = newState;
+        }
+
+        /// <summary>
+        /// Asynchronously closes this writer.
+        /// If <see cref="JsonWriter.CloseOutput"/> is set to <c>true</c>, the destination is also closed.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            Close();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously flushes whatever is in the buffer to the destination and also flushes the destination.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            Flush();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the specified end token.
+        /// </summary>
+        /// <param name="token">The end token to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        protected virtual Task WriteEndAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteEnd(token);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes indent characters.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        protected virtual Task WriteIndentAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteIndent();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the JSON value delimiter.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        protected virtual Task WriteValueDelimiterAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValueDelimiter();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes an indent space.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        protected virtual Task WriteIndentSpaceAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteIndentSpace();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes raw JSON without changing the writer's state.
+        /// </summary>
+        /// <param name="json">The raw JSON to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteRawAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteRaw(json);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of the current JSON object or array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteEndAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteEnd();
+            return AsyncUtils.CompletedTask;
+        }
+
+        internal Task WriteEndInternalAsync(CancellationToken cancellationToken)
+        {
+            JsonContainerType type = Peek();
+            switch (Peek())
+            {
+                case JsonContainerType.Object:
+                    return WriteEndObjectAsync(cancellationToken);
+                case JsonContainerType.Array:
+                    return WriteEndArrayAsync(cancellationToken);
+                case JsonContainerType.Constructor:
+                    return WriteEndConstructorAsync(cancellationToken);
+                default:
+                    throw JsonWriterException.Create(this, "Unexpected type when writing end: " + type, null);
+            }
+        }
+
+        internal async Task InternalWriteEndAsync(JsonContainerType type, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // write closing symbol and calculate new state
+            int levelsToComplete = 0;
+
+            if (_currentPosition.Type == type)
+            {
+                levelsToComplete = 1;
+            }
+            else
+            {
+                int top = Top - 2;
+                for (int i = top; i >= 0; i--)
+                {
+                    int currentLevel = top - i;
+
+                    if (_stack[currentLevel].Type == type)
+                    {
+                        levelsToComplete = i + 2;
+                        break;
+                    }
+                }
+            }
+
+            if (levelsToComplete == 0)
+            {
+                throw JsonWriterException.Create(this, "No token to close.", null);
+            }
+
+            for (int i = 0; i < levelsToComplete; i++)
+            {
+                JsonToken token = GetCloseTokenForType(Pop());
+
+                if (_currentState == State.Property)
+                {
+                    await WriteNullAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (_formatting == Formatting.Indented)
+                {
+                    if (_currentState != State.ObjectStart && _currentState != State.ArrayStart)
+                    {
+                        await WriteIndentAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                await WriteEndAsync(token, cancellationToken).ConfigureAwait(false);
+
+                JsonContainerType currentLevelType = Peek();
+
+                switch (currentLevelType)
+                {
+                    case JsonContainerType.Object:
+                        _currentState = State.Object;
+                        break;
+                    case JsonContainerType.Array:
+                        _currentState = State.Array;
+                        break;
+                    case JsonContainerType.Constructor:
+                        _currentState = State.Array;
+                        break;
+                    case JsonContainerType.None:
+                        _currentState = State.Start;
+                        break;
+                    default:
+                        throw JsonWriterException.Create(this, "Unknown JsonType: " + currentLevelType, null);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of an array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteEndArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteEndArray();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of a constructor.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteEndConstructorAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteEndConstructor();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the end of a JSON object.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteEndObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteEndObject();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a null value.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteNullAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteNull();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the property name of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WritePropertyNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WritePropertyName(name);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the property name of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="escape">A flag to indicate whether the text should be escaped when it is written as a JSON property name.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WritePropertyName(name, escape);
+            return AsyncUtils.CompletedTask;
+        }
+
+        internal Task InternalWritePropertyNameAsync(string name, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            _currentPosition.PropertyName = name;
+            return AutoCompleteAsync(JsonToken.PropertyName, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the beginning of a JSON array.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteStartArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteStartArray();
+            return AsyncUtils.CompletedTask;
+        }
+
+        internal async Task InternalWriteStartAsync(JsonToken token, JsonContainerType container, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            UpdateScopeWithFinishedValue();
+            await AutoCompleteAsync(token, cancellationToken).ConfigureAwait(false);
+            Push(container);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a comment <c>/*...*/</c> containing the specified text.
+        /// </summary>
+        /// <param name="text">Text to place inside the comment.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteCommentAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteComment(text);
+            return AsyncUtils.CompletedTask;
+        }
+
+        internal Task InternalWriteCommentAsync(CancellationToken cancellationToken)
+        {
+            return AutoCompleteAsync(JsonToken.Comment, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes raw JSON where a value is expected and updates the writer's state.
+        /// </summary>
+        /// <param name="json">The raw JSON to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteRawValueAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteRawValue(json);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the start of a constructor with the given name.
+        /// </summary>
+        /// <param name="name">The name of the constructor.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteStartConstructorAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteStartConstructor(name);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the beginning of a JSON object.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteStartObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteStartObject();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the current <see cref="JsonReader"/> token.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read the token from.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public Task WriteTokenAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteTokenAsync(reader, true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the current <see cref="JsonReader"/> token.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read the token from.</param>
+        /// <param name="writeChildren">A flag indicating whether the current token's children should be written.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public Task WriteTokenAsync(JsonReader reader, bool writeChildren, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            return WriteTokenAsync(reader, writeChildren, true, true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="JsonToken"/> token and its value.
+        /// </summary>
+        /// <param name="token">The <see cref="JsonToken"/> to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public Task WriteTokenAsync(JsonToken token, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return WriteTokenAsync(token, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the <see cref="JsonToken"/> token and its value.
+        /// </summary>
+        /// <param name="token">The <see cref="JsonToken"/> to write.</param>
+        /// <param name="value">
+        /// The value to write.
+        /// A value is only required for tokens that have an associated value, e.g. the <see cref="String"/> property name for <see cref="JsonToken.PropertyName"/>.
+        /// <c>null</c> can be passed to the method for tokens that don't have a value, e.g. <see cref="JsonToken.StartObject"/>.
+        /// </param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public Task WriteTokenAsync(JsonToken token, object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return cancellationToken.CancelledAsync();
+            }
+
+            switch (token)
+            {
+                case JsonToken.None:
+
+                    // read to next
+                    return AsyncUtils.CompletedTask;
+                case JsonToken.StartObject:
+                    return WriteStartObjectAsync(cancellationToken);
+                case JsonToken.StartArray:
+                    return WriteStartArrayAsync(cancellationToken);
+                case JsonToken.StartConstructor:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    return WriteStartConstructorAsync(value.ToString(), cancellationToken);
+                case JsonToken.PropertyName:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    return WritePropertyNameAsync(value.ToString(), cancellationToken);
+                case JsonToken.Comment:
+                    return WriteCommentAsync(value?.ToString(), cancellationToken);
+                case JsonToken.Integer:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    return
+#if !(PORTABLE || PORTABLE40) || NETSTANDARD1_1
+                        value is BigInteger ? WriteValueAsync((BigInteger)value, cancellationToken) :
+#endif
+                        WriteValueAsync(Convert.ToInt64(value, CultureInfo.InvariantCulture), cancellationToken);
+                case JsonToken.Float:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    if (value is decimal)
+                    {
+                        return WriteValueAsync((decimal)value, cancellationToken);
+                    }
+
+                    if (value is double)
+                    {
+                        return WriteValueAsync((double)value, cancellationToken);
+                    }
+
+                    if (value is float)
+                    {
+                        return WriteValueAsync((float)value, cancellationToken);
+                    }
+
+                    return WriteValueAsync(Convert.ToDouble(value, CultureInfo.InvariantCulture), cancellationToken);
+                case JsonToken.String:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    return WriteValueAsync(value.ToString(), cancellationToken);
+                case JsonToken.Boolean:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    return WriteValueAsync(Convert.ToBoolean(value, CultureInfo.InvariantCulture), cancellationToken);
+                case JsonToken.Null:
+                    return WriteNullAsync(cancellationToken);
+                case JsonToken.Undefined:
+                    return WriteUndefinedAsync(cancellationToken);
+                case JsonToken.EndObject:
+                    return WriteEndObjectAsync(cancellationToken);
+                case JsonToken.EndArray:
+                    return WriteEndArrayAsync(cancellationToken);
+                case JsonToken.EndConstructor:
+                    return WriteEndConstructorAsync(cancellationToken);
+                case JsonToken.Date:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    if (value is DateTimeOffset)
+                    {
+                        return WriteValueAsync((DateTimeOffset)value, cancellationToken);
+                    }
+
+                    return WriteValueAsync(Convert.ToDateTime(value, CultureInfo.InvariantCulture), cancellationToken);
+                case JsonToken.Raw:
+                    return WriteRawValueAsync(value?.ToString(), cancellationToken);
+                case JsonToken.Bytes:
+                    ValidationUtils.ArgumentNotNull(value, nameof(value));
+                    if (value is Guid)
+                    {
+                        return WriteValueAsync((Guid)value, cancellationToken);
+                    }
+
+                    return WriteValueAsync((byte[])value, cancellationToken);
+                default:
+                    throw MiscellaneousUtils.CreateArgumentOutOfRangeException(nameof(token), token, "Unexpected token type.");
+            }
+        }
+
+        internal virtual async Task WriteTokenAsync(JsonReader reader, bool writeChildren, bool writeDateConstructorAsDate, bool writeComments, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int initialDepth;
+
+            if (reader.TokenType == JsonToken.None)
+            {
+                initialDepth = -1;
+            }
+            else if (!JsonTokenUtils.IsStartToken(reader.TokenType))
+            {
+                initialDepth = reader.Depth + 1;
+            }
+            else
+            {
+                initialDepth = reader.Depth;
+            }
+
+            do
+            {
+                // write a JValue date when the constructor is for a date
+                if (writeDateConstructorAsDate && reader.TokenType == JsonToken.StartConstructor && string.Equals(reader.Value.ToString(), "Date", StringComparison.Ordinal))
+                {
+                    await WriteConstructorDateAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    if (writeComments || reader.TokenType != JsonToken.Comment)
+                    {
+                        await WriteTokenAsync(reader.TokenType, reader.Value, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            } while (
+
+                // stop if we have reached the end of the token being read
+                initialDepth - 1 < reader.Depth - (JsonTokenUtils.IsEndToken(reader.TokenType) ? 1 : 0) && writeChildren && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+        }
+
+        private async Task WriteConstructorDateAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonWriterException.Create(this, "Unexpected end when reading date constructor.", null);
+            }
+            if (reader.TokenType != JsonToken.Integer)
+            {
+                throw JsonWriterException.Create(this, "Unexpected token when reading date constructor. Expected Integer, got " + reader.TokenType, null);
+            }
+
+            long ticks = (long)reader.Value;
+            DateTime date = DateTimeUtils.ConvertJavaScriptTicksToDateTime(ticks);
+
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonWriterException.Create(this, "Unexpected end when reading date constructor.", null);
+            }
+            if (reader.TokenType != JsonToken.EndConstructor)
+            {
+                throw JsonWriterException.Create(this, "Unexpected token when reading date constructor. Expected EndConstructor, got " + reader.TokenType, null);
+            }
+
+            await WriteValueAsync(date, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="bool"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="bool"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(bool value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="bool"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="bool"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(bool? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="byte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(byte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="byte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="byte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(byte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="byte"/>[] value.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/>[] value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(byte[] value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="char"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="char"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(char value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="char"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="char"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(char? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="DateTime"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(DateTime value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="DateTime"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(DateTime? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="DateTimeOffset"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(DateTimeOffset value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="DateTimeOffset"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(DateTimeOffset? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="decimal"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="decimal"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(decimal value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="decimal"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="decimal"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(decimal? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="double"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="double"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(double value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="double"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="double"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(double? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="float"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="float"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(float value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="float"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="float"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(float? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Guid"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Guid"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(Guid value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="Guid"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="Guid"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(Guid? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="int"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="int"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(int value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="int"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="int"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(int? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="long"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="long"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(long value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="long"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="long"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(long? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="object"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="object"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="sbyte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="sbyte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(sbyte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="sbyte"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="sbyte"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(sbyte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="short"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="short"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(short value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="short"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="short"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(short? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="string"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="TimeSpan"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="TimeSpan"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(TimeSpan value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="TimeSpan"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="TimeSpan"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(TimeSpan? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="uint"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(uint value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="uint"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="uint"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(uint? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="ulong"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(ulong value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="ulong"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="ulong"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(ulong? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Uri"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Uri"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteValueAsync(Uri value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="ushort"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ushort"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(ushort value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="Nullable{T}"/> of <see cref="ushort"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Nullable{T}"/> of <see cref="ushort"/> value to write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        [CLSCompliant(false)]
+        public virtual Task WriteValueAsync(ushort? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteValue(value);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes an undefined value.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteUndefinedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteUndefined();
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the given white space.
+        /// </summary>
+        /// <param name="ws">The string of white space characters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteWhitespaceAsync(string ws, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteWhitespace(ws);
+            return AsyncUtils.CompletedTask;
+        }
+
+        internal Task InternalWriteValueAsync(JsonToken token, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            UpdateScopeWithFinishedValue();
+            return AutoCompleteAsync(token, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously ets the state of the <see cref="JsonWriter"/>.
+        /// </summary>
+        /// <param name="token">The <see cref="JsonToken"/> being written.</param>
+        /// <param name="value">The value being written.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        protected Task SetWriteStateAsync(JsonToken token, object value, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return cancellationToken.CancelledAsync();
+            }
+
+            switch (token)
+            {
+                case JsonToken.StartObject:
+                    return InternalWriteStartAsync(token, JsonContainerType.Object, cancellationToken);
+                case JsonToken.StartArray:
+                    return InternalWriteStartAsync(token, JsonContainerType.Array, cancellationToken);
+                case JsonToken.StartConstructor:
+                    return InternalWriteStartAsync(token, JsonContainerType.Constructor, cancellationToken);
+                case JsonToken.PropertyName:
+                    if (!(value is string))
+                    {
+                        throw new ArgumentException("A name is required when setting property name state.", nameof(value));
+                    }
+
+                    return InternalWritePropertyNameAsync((string)value, cancellationToken);
+                case JsonToken.Comment:
+                    return InternalWriteCommentAsync(cancellationToken);
+                case JsonToken.Raw:
+                    return AsyncUtils.CompletedTask;
+                case JsonToken.Integer:
+                case JsonToken.Float:
+                case JsonToken.String:
+                case JsonToken.Boolean:
+                case JsonToken.Date:
+                case JsonToken.Bytes:
+                case JsonToken.Null:
+                case JsonToken.Undefined:
+                    return InternalWriteValueAsync(token, cancellationToken);
+                case JsonToken.EndObject:
+                    return InternalWriteEndAsync(JsonContainerType.Object, cancellationToken);
+                case JsonToken.EndArray:
+                    return InternalWriteEndAsync(JsonContainerType.Array, cancellationToken);
+                case JsonToken.EndConstructor:
+                    return InternalWriteEndAsync(JsonContainerType.Constructor, cancellationToken);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(token));
+            }
+        }
+
+        internal static Task WriteValueAsync(JsonWriter writer, PrimitiveTypeCode typeCode, object value, CancellationToken cancellationToken)
+        {
+            switch (typeCode)
+            {
+                case PrimitiveTypeCode.Char:
+                    return writer.WriteValueAsync((char)value, cancellationToken);
+                case PrimitiveTypeCode.CharNullable:
+                    return writer.WriteValueAsync(value == null ? (char?)null : (char)value, cancellationToken);
+                case PrimitiveTypeCode.Boolean:
+                    return writer.WriteValueAsync((bool)value, cancellationToken);
+                case PrimitiveTypeCode.BooleanNullable:
+                    return writer.WriteValueAsync(value == null ? (bool?)null : (bool)value, cancellationToken);
+                case PrimitiveTypeCode.SByte:
+                    return writer.WriteValueAsync((sbyte)value, cancellationToken);
+                case PrimitiveTypeCode.SByteNullable:
+                    return writer.WriteValueAsync(value == null ? (sbyte?)null : (sbyte)value, cancellationToken);
+                case PrimitiveTypeCode.Int16:
+                    return writer.WriteValueAsync((short)value, cancellationToken);
+                case PrimitiveTypeCode.Int16Nullable:
+                    return writer.WriteValueAsync(value == null ? (short?)null : (short)value, cancellationToken);
+                case PrimitiveTypeCode.UInt16:
+                    return writer.WriteValueAsync((ushort)value, cancellationToken);
+                case PrimitiveTypeCode.UInt16Nullable:
+                    return writer.WriteValueAsync(value == null ? (ushort?)null : (ushort)value, cancellationToken);
+                case PrimitiveTypeCode.Int32:
+                    return writer.WriteValueAsync((int)value, cancellationToken);
+                case PrimitiveTypeCode.Int32Nullable:
+                    return writer.WriteValueAsync(value == null ? (int?)null : (int)value, cancellationToken);
+                case PrimitiveTypeCode.Byte:
+                    return writer.WriteValueAsync((byte)value, cancellationToken);
+                case PrimitiveTypeCode.ByteNullable:
+                    return writer.WriteValueAsync(value == null ? (byte?)null : (byte)value, cancellationToken);
+                case PrimitiveTypeCode.UInt32:
+                    return writer.WriteValueAsync((uint)value, cancellationToken);
+                case PrimitiveTypeCode.UInt32Nullable:
+                    return writer.WriteValueAsync(value == null ? (uint?)null : (uint)value, cancellationToken);
+                case PrimitiveTypeCode.Int64:
+                    return writer.WriteValueAsync((long)value, cancellationToken);
+                case PrimitiveTypeCode.Int64Nullable:
+                    return writer.WriteValueAsync(value == null ? (long?)null : (long)value, cancellationToken);
+                case PrimitiveTypeCode.UInt64:
+                    return writer.WriteValueAsync((ulong)value, cancellationToken);
+                case PrimitiveTypeCode.UInt64Nullable:
+                    return writer.WriteValueAsync(value == null ? (ulong?)null : (ulong)value, cancellationToken);
+                case PrimitiveTypeCode.Single:
+                    return writer.WriteValueAsync((float)value, cancellationToken);
+                case PrimitiveTypeCode.SingleNullable:
+                    return writer.WriteValueAsync(value == null ? (float?)null : (float)value, cancellationToken);
+                case PrimitiveTypeCode.Double:
+                    return writer.WriteValueAsync((double)value, cancellationToken);
+                case PrimitiveTypeCode.DoubleNullable:
+                    return writer.WriteValueAsync(value == null ? (double?)null : (double)value, cancellationToken);
+                case PrimitiveTypeCode.DateTime:
+                    return writer.WriteValueAsync((DateTime)value, cancellationToken);
+                case PrimitiveTypeCode.DateTimeNullable:
+                    return writer.WriteValueAsync(value == null ? (DateTime?)null : (DateTime)value, cancellationToken);
+                case PrimitiveTypeCode.DateTimeOffset:
+                    return writer.WriteValueAsync((DateTimeOffset)value, cancellationToken);
+                case PrimitiveTypeCode.DateTimeOffsetNullable:
+                    return writer.WriteValueAsync(value == null ? (DateTimeOffset?)null : (DateTimeOffset)value, cancellationToken);
+                case PrimitiveTypeCode.Decimal:
+                    return writer.WriteValueAsync((decimal)value, cancellationToken);
+                case PrimitiveTypeCode.DecimalNullable:
+                    return writer.WriteValueAsync(value == null ? (decimal?)null : (decimal)value, cancellationToken);
+                case PrimitiveTypeCode.Guid:
+                    return writer.WriteValueAsync((Guid)value, cancellationToken);
+                case PrimitiveTypeCode.GuidNullable:
+                    return writer.WriteValueAsync(value == null ? (Guid?)null : (Guid)value, cancellationToken);
+                case PrimitiveTypeCode.TimeSpan:
+                    return writer.WriteValueAsync((TimeSpan)value, cancellationToken);
+                case PrimitiveTypeCode.TimeSpanNullable:
+                    return writer.WriteValueAsync(value == null ? (TimeSpan?)null : (TimeSpan)value, cancellationToken);
+#if !(PORTABLE || PORTABLE40) || NETSTANDARD1_1
+                case PrimitiveTypeCode.BigInteger:
+
+                    // this will call to WriteValueAsync(object)
+                    return writer.WriteValueAsync((BigInteger)value, cancellationToken);
+                case PrimitiveTypeCode.BigIntegerNullable:
+
+                    // this will call to WriteValueAsync(object)
+                    return writer.WriteValueAsync(value == null ? (BigInteger?)null : (BigInteger)value, cancellationToken);
+#endif
+                case PrimitiveTypeCode.Uri:
+                    return writer.WriteValueAsync((Uri)value, cancellationToken);
+                case PrimitiveTypeCode.String:
+                    return writer.WriteValueAsync((string)value, cancellationToken);
+                case PrimitiveTypeCode.Bytes:
+                    return writer.WriteValueAsync((byte[])value, cancellationToken);
+#if !(PORTABLE || DOTNET)
+                case PrimitiveTypeCode.DBNull:
+                    return writer.WriteNullAsync(cancellationToken);
+#endif
+                default:
+#if !PORTABLE
+                    IConvertible convertable = value as IConvertible;
+                    if (convertable != null)
+                    {
+                        // the value is a non-standard IConvertible
+                        // convert to the underlying value and retry
+                        TypeInformation typeInformation = ConvertUtils.GetTypeInformation(convertable);
+
+                        // if convertable has an underlying typecode of Object then attempt to convert it to a string
+                        PrimitiveTypeCode resolvedTypeCode = typeInformation.TypeCode == PrimitiveTypeCode.Object ? PrimitiveTypeCode.String : typeInformation.TypeCode;
+                        Type resolvedType = typeInformation.TypeCode == PrimitiveTypeCode.Object ? typeof(string) : typeInformation.Type;
+
+                        object convertedValue = convertable.ToType(resolvedType, CultureInfo.InvariantCulture);
+
+                        return WriteValueAsync(writer, resolvedTypeCode, convertedValue, cancellationToken);
+                    }
+#endif
+                    throw CreateUnsupportedTypeException(writer, value);
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public abstract class JsonWriter : IDisposable
+    public abstract partial class JsonWriter : IDisposable
     {
         internal enum State
         {

--- a/Src/Newtonsoft.Json/Linq/JArray.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JArray.Async.cs
@@ -1,0 +1,110 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JArray
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JArray) ? DoWriteToAsync(writer, cancellationToken, converters) : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        private async Task DoWriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            for (int i = 0; i < _values.Count; i++)
+            {
+                await _values[i].WriteToAsync(writer, cancellationToken, converters).ConfigureAwait(false);
+            }
+
+            await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JArray"/> from a <see cref="JsonReader"/>. 
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JArray"/>.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous load. The <see cref="Task{TResult}.Result"/> property contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static Task<JArray> LoadAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return LoadAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JArray"/> from a <see cref="JsonReader"/>. 
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JArray"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous load. The <see cref="Task{TResult}.Result"/> property contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static async Task<JArray> LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (reader.TokenType == JsonToken.None)
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    throw JsonReaderException.Create(reader, "Error reading JArray from JsonReader.");
+                }
+            }
+
+            await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.StartArray)
+            {
+                throw JsonReaderException.Create(reader, "Error reading JArray from JsonReader. Current JsonReader item is not an array: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            JArray a = new JArray();
+            a.SetLineInfo(reader as IJsonLineInfo, settings);
+
+            await a.ReadTokenFromAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+
+            return a;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JArray.cs
+++ b/Src/Newtonsoft.Json/Linq/JArray.cs
@@ -38,7 +38,7 @@ namespace Newtonsoft.Json.Linq
     /// <example>
     ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParseArray" title="Parsing a JSON Array from Text" />
     /// </example>
-    public class JArray : JContainer, IList<JToken>
+    public partial class JArray : JContainer, IList<JToken>
     {
         private readonly List<JToken> _values = new List<JToken>();
 

--- a/Src/Newtonsoft.Json/Linq/JConstructor.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JConstructor.Async.cs
@@ -1,0 +1,113 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JConstructor
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JConstructor) ? DoWriteToAsync(writer, cancellationToken, converters) : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        private async Task DoWriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            await writer.WriteStartConstructorAsync(_name, cancellationToken).ConfigureAwait(false);
+
+            foreach (JToken token in Children())
+            {
+                await token.WriteToAsync(writer, cancellationToken, converters).ConfigureAwait(false);
+            }
+
+            await writer.WriteEndConstructorAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JConstructor"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JConstructor"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous load. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JConstructor"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static Task<JConstructor> LoadAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return LoadAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JConstructor"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JConstructor"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous load. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JConstructor"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static async Task<JConstructor> LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (reader.TokenType == JsonToken.None)
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    throw JsonReaderException.Create(reader, "Error reading JConstructor from JsonReader.");
+                }
+            }
+
+            await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.StartConstructor)
+            {
+                throw JsonReaderException.Create(reader, "Error reading JConstructor from JsonReader. Current JsonReader item is not a constructor: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            JConstructor c = new JConstructor((string)reader.Value);
+            c.SetLineInfo(reader as IJsonLineInfo, settings);
+
+            await c.ReadTokenFromAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+
+            return c;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JConstructor.cs
+++ b/Src/Newtonsoft.Json/Linq/JConstructor.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a JSON constructor.
     /// </summary>
-    public class JConstructor : JContainer
+    public partial class JConstructor : JContainer
     {
         private string _name;
         private readonly List<JToken> _values = new List<JToken>();

--- a/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
@@ -1,0 +1,175 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public abstract partial class JContainer
+    {
+        internal async Task ReadTokenFromAsync(JsonReader reader, JsonLoadSettings options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+            int startDepth = reader.Depth;
+
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonReaderException.Create(reader, "Error reading {0} from JsonReader.".FormatWith(CultureInfo.InvariantCulture, GetType().Name));
+            }
+
+            await ReadContentFromAsync(reader, options, cancellationToken).ConfigureAwait(false);
+
+            if (reader.Depth > startDepth)
+            {
+                throw JsonReaderException.Create(reader, "Unexpected end of content while loading {0}.".FormatWith(CultureInfo.InvariantCulture, GetType().Name));
+            }
+        }
+
+        private async Task ReadContentFromAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            IJsonLineInfo lineInfo = reader as IJsonLineInfo;
+
+            JContainer parent = this;
+
+            do
+            {
+                if ((parent as JProperty)?.Value != null)
+                {
+                    if (parent == this)
+                    {
+                        return;
+                    }
+
+                    parent = parent.Parent;
+                }
+
+                switch (reader.TokenType)
+                {
+                    case JsonToken.None:
+                        // new reader. move to actual content
+                        break;
+                    case JsonToken.StartArray:
+                        JArray a = new JArray();
+                        a.SetLineInfo(lineInfo, settings);
+                        parent.Add(a);
+                        parent = a;
+                        break;
+
+                    case JsonToken.EndArray:
+                        if (parent == this)
+                        {
+                            return;
+                        }
+
+                        parent = parent.Parent;
+                        break;
+                    case JsonToken.StartObject:
+                        JObject o = new JObject();
+                        o.SetLineInfo(lineInfo, settings);
+                        parent.Add(o);
+                        parent = o;
+                        break;
+                    case JsonToken.EndObject:
+                        if (parent == this)
+                        {
+                            return;
+                        }
+
+                        parent = parent.Parent;
+                        break;
+                    case JsonToken.StartConstructor:
+                        JConstructor constructor = new JConstructor(reader.Value.ToString());
+                        constructor.SetLineInfo(lineInfo, settings);
+                        parent.Add(constructor);
+                        parent = constructor;
+                        break;
+                    case JsonToken.EndConstructor:
+                        if (parent == this)
+                        {
+                            return;
+                        }
+
+                        parent = parent.Parent;
+                        break;
+                    case JsonToken.String:
+                    case JsonToken.Integer:
+                    case JsonToken.Float:
+                    case JsonToken.Date:
+                    case JsonToken.Boolean:
+                    case JsonToken.Bytes:
+                        JValue v = new JValue(reader.Value);
+                        v.SetLineInfo(lineInfo, settings);
+                        parent.Add(v);
+                        break;
+                    case JsonToken.Comment:
+                        if (settings != null && settings.CommentHandling == CommentHandling.Load)
+                        {
+                            v = JValue.CreateComment(reader.Value.ToString());
+                            v.SetLineInfo(lineInfo, settings);
+                            parent.Add(v);
+                        }
+                        break;
+                    case JsonToken.Null:
+                        v = JValue.CreateNull();
+                        v.SetLineInfo(lineInfo, settings);
+                        parent.Add(v);
+                        break;
+                    case JsonToken.Undefined:
+                        v = JValue.CreateUndefined();
+                        v.SetLineInfo(lineInfo, settings);
+                        parent.Add(v);
+                        break;
+                    case JsonToken.PropertyName:
+                        string propertyName = reader.Value.ToString();
+                        JProperty property = new JProperty(propertyName);
+                        property.SetLineInfo(lineInfo, settings);
+                        JObject parentObject = (JObject)parent;
+                        // handle multiple properties with the same name in JSON
+                        JProperty existingPropertyWithName = parentObject.Property(propertyName);
+                        if (existingPropertyWithName == null)
+                        {
+                            parent.Add(property);
+                        }
+                        else
+                        {
+                            existingPropertyWithName.Replace(property);
+                        }
+                        parent = property;
+                        break;
+                    default:
+                        throw new InvalidOperationException("The JsonReader should not be on a token of type {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+                }
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -45,7 +45,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a token that can contain other tokens.
     /// </summary>
-    public abstract class JContainer : JToken, IList<JToken>
+    public abstract partial class JContainer : JToken, IList<JToken>
 #if !(DOTNET || PORTABLE || PORTABLE40)
         , ITypedList, IBindingList
 #endif

--- a/Src/Newtonsoft.Json/Linq/JObject.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.Async.cs
@@ -1,0 +1,115 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JObject
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JObject) ? DoWriteToAsync(writer, cancellationToken, converters) : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        private async Task DoWriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            for (int i = 0; i < _properties.Count; i++)
+            {
+                _properties[i].WriteTo(writer, converters);
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JObject"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JObject"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous load. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JObject"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static Task<JObject> LoadAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return LoadAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JObject"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JObject"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous load. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JObject"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static async Task<JObject> LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            if (reader.TokenType == JsonToken.None)
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    throw JsonReaderException.Create(reader, "Error reading JObject from JsonReader.");
+                }
+            }
+
+            await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                throw JsonReaderException.Create(reader, "Error reading JObject from JsonReader. Current JsonReader item is not an object: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            JObject o = new JObject();
+            o.SetLineInfo(reader as IJsonLineInfo, settings);
+
+            await o.ReadTokenFromAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+
+            return o;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -52,7 +52,7 @@ namespace Newtonsoft.Json.Linq
     /// <example>
     ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParse" title="Parsing a JSON Object from Text" />
     /// </example>
-    public class JObject : JContainer, IDictionary<string, JToken>, INotifyPropertyChanged
+    public partial class JObject : JContainer, IDictionary<string, JToken>, INotifyPropertyChanged
 #if !(DOTNET || PORTABLE40 || PORTABLE)
         , ICustomTypeDescriptor
 #endif

--- a/Src/Newtonsoft.Json/Linq/JProperty.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JProperty.Async.cs
@@ -1,0 +1,114 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JProperty
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JProperty) ? DoWriteToAsync(writer, cancellationToken, converters) : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        private async Task DoWriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            await writer.WritePropertyNameAsync(_name, cancellationToken).ConfigureAwait(false);
+
+            JToken value = Value;
+            if (value != null)
+            {
+                await value.WriteToAsync(writer, cancellationToken, converters).ConfigureAwait(false);
+            }
+            else
+            {
+                await writer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JProperty"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JProperty"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous creation. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JProperty"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static Task<JProperty> LoadAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return LoadAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously loads a <see cref="JProperty"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> that will be read for the content of the <see cref="JProperty"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous creation. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JProperty"/> that contains the JSON that was read from the specified <see cref="JsonReader"/>.</returns>
+        public new static async Task<JProperty> LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (reader.TokenType == JsonToken.None)
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    throw JsonReaderException.Create(reader, "Error reading JProperty from JsonReader.");
+                }
+            }
+
+            await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false);
+
+            if (reader.TokenType != JsonToken.PropertyName)
+            {
+                throw JsonReaderException.Create(reader, "Error reading JProperty from JsonReader. Current JsonReader item is not a property: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+
+            JProperty p = new JProperty((string)reader.Value);
+            p.SetLineInfo(reader as IJsonLineInfo, settings);
+
+            await p.ReadTokenFromAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+
+            return p;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JProperty.cs
+++ b/Src/Newtonsoft.Json/Linq/JProperty.cs
@@ -35,7 +35,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a JSON property.
     /// </summary>
-    public class JProperty : JContainer
+    public partial class JProperty : JContainer
     {
         #region JPropertyList
         private class JPropertyList : IList<JToken>

--- a/Src/Newtonsoft.Json/Linq/JRaw.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JRaw.Async.cs
@@ -1,0 +1,73 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JRaw
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JRaw)
+                ? DoWriteToAsync(writer, cancellationToken, converters)
+                : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        /// <summary>
+        /// Asynchronously creates an instance of <see cref="JRaw"/> with the content of the reader's current token.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous creation. The <see cref="Task{TResult}.Result"/>
+        /// property returns an instance of <see cref="JRaw"/> with the content of the reader's current token.</returns>
+        public static async Task<JRaw> CreateAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (StringWriter sw = new StringWriter(CultureInfo.InvariantCulture))
+            using (JsonTextWriter jsonWriter = new JsonTextWriterImpl(sw))
+            {
+                await jsonWriter.WriteTokenAsync(reader, cancellationToken).ConfigureAwait(false);
+
+                return new JRaw(sw.ToString());
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JRaw.cs
+++ b/Src/Newtonsoft.Json/Linq/JRaw.cs
@@ -31,7 +31,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a raw JSON string.
     /// </summary>
-    public class JRaw : JValue
+    public partial class JRaw : JValue
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JRaw"/> class from another <see cref="JRaw"/> object.

--- a/Src/Newtonsoft.Json/Linq/JToken.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.Async.cs
@@ -1,0 +1,191 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public abstract partial class JToken
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public virtual Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            WriteTo(writer, converters);
+            return AsyncUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>The default behaviour is to execute synchronously, returning an already-completed task. Derived
+        /// classes can override this behaviour for true asychronousity.</remarks>
+        public Task WriteToAsync(JsonWriter writer, params JsonConverter[] converters)
+        {
+            return WriteToAsync(writer, default(CancellationToken), converters);
+        }
+
+        internal static async Task<object> ReadFromAsObjectAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            // implicit cast of Result to object.
+            return await ReadFromAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="JToken"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">An <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous creation. The
+        /// <see cref="Task{TResult}.Result"/> property returns a <see cref="JToken"/> that contains 
+        /// the token and its descendant tokens
+        /// that were read from the reader. The runtime type of the token is determined
+        /// by the token type of the first token encountered in the reader.
+        /// </returns>
+        public static Task<JToken> ReadFromAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReadFromAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="JToken"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">An <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous creation. The
+        /// <see cref="Task{TResult}.Result"/> property returns a <see cref="JToken"/> that contains 
+        /// the token and its descendant tokens
+        /// that were read from the reader. The runtime type of the token is determined
+        /// by the token type of the first token encountered in the reader.
+        /// </returns>
+        public static async Task<JToken> ReadFromAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            if (reader.TokenType == JsonToken.None)
+            {
+                if (!await (settings != null && settings.CommentHandling == CommentHandling.Ignore ? reader.ReadAndMoveToContentAsync(cancellationToken) : reader.ReadAsync(cancellationToken)).ConfigureAwait(false))
+                {
+                    throw JsonReaderException.Create(reader, "Error reading JToken from JsonReader.");
+                }
+            }
+
+            IJsonLineInfo lineInfo = reader as IJsonLineInfo;
+
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartObject:
+                    return await JObject.LoadAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+                case JsonToken.StartArray:
+                    return await JArray.LoadAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+                case JsonToken.StartConstructor:
+                    return await JConstructor.LoadAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+                case JsonToken.PropertyName:
+                    return await JProperty.LoadAsync(reader, settings, cancellationToken).ConfigureAwait(false);
+                case JsonToken.String:
+                case JsonToken.Integer:
+                case JsonToken.Float:
+                case JsonToken.Date:
+                case JsonToken.Boolean:
+                case JsonToken.Bytes:
+                    JValue v = new JValue(reader.Value);
+                    v.SetLineInfo(lineInfo, settings);
+                    return v;
+                case JsonToken.Comment:
+                    v = JValue.CreateComment(reader.Value.ToString());
+                    v.SetLineInfo(lineInfo, settings);
+                    return v;
+                case JsonToken.Null:
+                    v = JValue.CreateNull();
+                    v.SetLineInfo(lineInfo, settings);
+                    return v;
+                case JsonToken.Undefined:
+                    v = JValue.CreateUndefined();
+                    v.SetLineInfo(lineInfo, settings);
+                    return v;
+                default:
+                    throw JsonReaderException.Create(reader, "Error reading JToken from JsonReader. Unexpected token: {0}".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="JToken"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous creation. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JToken"/> that contains the token and its descendant tokens
+        /// that were read from the reader. The runtime type of the token is determined
+        /// by the token type of the first token encountered in the reader.
+        /// </returns>
+        public static Task<JToken> LoadAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return LoadAsync(reader, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a <see cref="JToken"/> from a <see cref="JsonReader"/>.
+        /// </summary>
+        /// <param name="reader">A <see cref="JsonReader"/> positioned at the token to read into this <see cref="JToken"/>.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that represents the asynchronous creation. The <see cref="Task{TResult}.Result"/>
+        /// property returns a <see cref="JToken"/> that contains the token and its descendant tokens
+        /// that were read from the reader. The runtime type of the token is determined
+        /// by the token type of the first token encountered in the reader.
+        /// </returns>
+        public static Task<JToken> LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReadFromAsync(reader, settings, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -51,7 +51,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents an abstract JSON token.
     /// </summary>
-    public abstract class JToken : IJEnumerable<JToken>, IJsonLineInfo
+    public abstract partial class JToken : IJEnumerable<JToken>, IJsonLineInfo
 #if !(DOTNET || PORTABLE40 || PORTABLE)
         , ICloneable
 #endif

--- a/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -35,7 +35,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a writer that provides a fast, non-cached, forward-only way of generating JSON data.
     /// </summary>
-    public class JTokenWriter : JsonWriter
+    public partial class JTokenWriter : JsonWriter
     {
         private JContainer _token;
         private JContainer _parent;

--- a/Src/Newtonsoft.Json/Linq/JValue.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.Async.cs
@@ -1,0 +1,143 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Globalization;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Linq
+{
+    public partial class JValue
+    {
+        /// <summary>
+        /// Writes this token to a <see cref="JsonWriter"/> asynchronously.
+        /// </summary>
+        /// <param name="writer">A <see cref="JsonWriter"/> into which this method will write.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="converters">A collection of <see cref="JsonConverter"/> which will be used when writing the token.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous write operation.</returns>
+        /// <remarks>Derived classes must override this method to get asynchronous behaviour. Otherwise it will
+        /// execute synchronously, returning an already-completed task.</remarks>
+        public override Task WriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            return GetType() == typeof(JValue) ? DoWriteToAsync(writer, cancellationToken, converters) : base.WriteToAsync(writer, cancellationToken, converters);
+        }
+
+        internal Task DoWriteToAsync(JsonWriter writer, CancellationToken cancellationToken, params JsonConverter[] converters)
+        {
+            if (converters != null && converters.Length > 0 && _value != null)
+            {
+                JsonConverter matchingConverter = JsonSerializer.GetMatchingConverter(converters, _value.GetType());
+                if (matchingConverter != null && matchingConverter.CanWrite)
+                {
+                    return matchingConverter.WriteJsonAsync(writer, _value, JsonSerializer.CreateDefault(), cancellationToken);
+                }
+            }
+
+            switch (_valueType)
+            {
+                case JTokenType.Comment:
+                    return writer.WriteCommentAsync(_value != null ? _value.ToString() : null, cancellationToken);
+                case JTokenType.Raw:
+                    return writer.WriteRawValueAsync(_value != null ? _value.ToString() : null, cancellationToken);
+                case JTokenType.Null:
+                    return writer.WriteNullAsync(cancellationToken);
+                case JTokenType.Undefined:
+                    return writer.WriteUndefinedAsync(cancellationToken);
+                case JTokenType.Integer:
+                    if (_value is int)
+                    {
+                        return writer.WriteValueAsync((int)_value, cancellationToken);
+                    }
+
+                    if (_value is long)
+                    {
+                        return writer.WriteValueAsync((long)_value, cancellationToken);
+                    }
+
+                    if (_value is ulong)
+                    {
+                        return writer.WriteValueAsync((ulong)_value, cancellationToken);
+                    }
+
+#if !(PORTABLE) || NETSTANDARD1_1
+                    if (_value is BigInteger)
+                    {
+                        return writer.WriteValueAsync((BigInteger)_value, cancellationToken);
+                    }
+#endif
+
+                    return writer.WriteValueAsync(Convert.ToInt64(_value, CultureInfo.InvariantCulture), cancellationToken);
+                case JTokenType.Float:
+                    if (_value is decimal)
+                    {
+                        return writer.WriteValueAsync((decimal)_value, cancellationToken);
+                    }
+
+                    if (_value is double)
+                    {
+                        return writer.WriteValueAsync((double)_value, cancellationToken);
+                    }
+
+                    if (_value is float)
+                    {
+                        return writer.WriteValueAsync((float)_value, cancellationToken);
+                    }
+
+                    return writer.WriteValueAsync(Convert.ToDouble(_value, CultureInfo.InvariantCulture), cancellationToken);
+                case JTokenType.String:
+                    return writer.WriteValueAsync(_value != null ? _value.ToString() : null, cancellationToken);
+                case JTokenType.Boolean:
+                    return writer.WriteValueAsync(Convert.ToBoolean(_value, CultureInfo.InvariantCulture), cancellationToken);
+                case JTokenType.Date:
+                    if (_value is DateTimeOffset)
+                    {
+                        return writer.WriteValueAsync((DateTimeOffset)_value, cancellationToken);
+                    }
+
+                    return writer.WriteValueAsync(Convert.ToDateTime(_value, CultureInfo.InvariantCulture), cancellationToken);
+                case JTokenType.Bytes:
+                    return writer.WriteValueAsync((byte[])_value, cancellationToken);
+                case JTokenType.Guid:
+                    return writer.WriteValueAsync(_value != null ? (Guid?)_value : null, cancellationToken);
+                case JTokenType.TimeSpan:
+                    return writer.WriteValueAsync(_value != null ? (TimeSpan?)_value : null, cancellationToken);
+                case JTokenType.Uri:
+                    return writer.WriteValueAsync((Uri)_value, cancellationToken);
+            }
+
+            throw MiscellaneousUtils.CreateArgumentOutOfRangeException("TokenType", _valueType, "Unexpected token type.");
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -41,7 +41,7 @@ namespace Newtonsoft.Json.Linq
     /// <summary>
     /// Represents a value in JSON (string, integer, date, etc).
     /// </summary>
-    public class JValue : JToken, IEquatable<JValue>, IFormattable, IComparable, IComparable<JValue>
+    public partial class JValue : JToken, IEquatable<JValue>, IFormattable, IComparable, IComparable<JValue>
 #if !PORTABLE
         , IConvertible
 #endif

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -56,21 +56,35 @@
     <Compile Include="Bson\BsonType.cs" />
     <Compile Include="Bson\BsonWriter.cs" />
     <Compile Include="ConstructorHandling.cs" />
+    <Compile Include="Converters\BinaryConverter.Async.cs" />
     <Compile Include="Converters\BinaryConverter.cs" />
+    <Compile Include="Converters\BsonObjectIdConverter.Async.cs" />
     <Compile Include="Converters\BsonObjectIdConverter.cs" />
+    <Compile Include="Converters\CustomCreationConverter.Async.cs" />
     <Compile Include="Converters\CustomCreationConverter.cs" />
+    <Compile Include="Converters\DataSetConverter.Async.cs" />
     <Compile Include="Converters\DataSetConverter.cs" />
+    <Compile Include="Converters\DataTableConverter.Async.cs" />
     <Compile Include="Converters\DataTableConverter.cs" />
     <Compile Include="Converters\DateTimeConverterBase.cs" />
+    <Compile Include="Converters\DiscriminatedUnionConverter.Async.cs" />
     <Compile Include="Converters\DiscriminatedUnionConverter.cs" />
+    <Compile Include="Converters\EntityKeyMemberConverter.Async.cs" />
     <Compile Include="Converters\EntityKeyMemberConverter.cs" />
+    <Compile Include="Converters\ExpandoObjectConverter.Async.cs" />
     <Compile Include="Converters\ExpandoObjectConverter.cs" />
     <Compile Include="Converters\IsoDateTimeConverter.cs" />
+    <Compile Include="Converters\JavaScriptDateTimeConverter.Async.cs" />
     <Compile Include="Converters\JavaScriptDateTimeConverter.cs" />
+    <Compile Include="Converters\KeyValuePairConverter.Async.cs" />
     <Compile Include="Converters\KeyValuePairConverter.cs" />
+    <Compile Include="Converters\RegexConverter.Async.cs" />
     <Compile Include="Converters\RegexConverter.cs" />
+    <Compile Include="Converters\StringEnumConverter.Async.cs" />
     <Compile Include="Converters\StringEnumConverter.cs" />
+    <Compile Include="Converters\VersionConverter.Async.cs" />
     <Compile Include="Converters\VersionConverter.cs" />
+    <Compile Include="Converters\XmlNodeConverter.Async.cs" />
     <Compile Include="Converters\XmlNodeConverter.cs" />
     <Compile Include="FloatParseHandling.cs" />
     <Compile Include="DateFormatHandling.cs" />
@@ -82,6 +96,28 @@
     <Compile Include="Formatting.cs" />
     <Compile Include="IArrayPool.cs" />
     <Compile Include="IJsonLineInfo.cs" />
+    <Compile Include="JsonConverter.Async.cs" />
+    <Compile Include="JsonSerializer.Async.cs" />
+    <Compile Include="Serialization\JsonSerializerProxy.Async.cs" />
+    <Compile Include="JsonTextReader.Async.cs" />
+    <Compile Include="Linq\JArray.Async.cs" />
+    <Compile Include="Linq\JConstructor.Async.cs" />
+    <Compile Include="Linq\JContainer.Async.cs" />
+    <Compile Include="Linq\JObject.Async.cs" />
+    <Compile Include="Linq\JProperty.Async.cs" />
+    <Compile Include="Linq\JRaw.Async.cs" />
+    <Compile Include="Linq\JToken.Async.cs" />
+    <Compile Include="JsonReader.Async.cs" />
+    <Compile Include="Linq\JValue.Async.cs" />
+    <Compile Include="Serialization\JsonProperty.Async.cs" />
+    <Compile Include="Serialization\JsonSerializerInternalReader.Async.cs" />
+    <Compile Include="Serialization\JsonSerializerInternalWriter.Async.cs" />
+    <Compile Include="Serialization\TraceJsonReader.Async.cs" />
+    <Compile Include="Serialization\TraceJsonWriter.Async.cs" />
+    <Compile Include="Utilities\AsyncUtils.cs" />
+    <Compile Include="Utilities\Base64Encoder.Async.cs" />
+    <Compile Include="Utilities\DateTimeUtils.Async.cs" />
+    <Compile Include="Utilities\JavaScriptUtils.Async.cs" />
     <Compile Include="JsonArrayAttribute.cs" />
     <Compile Include="JsonConstructorAttribute.cs" />
     <Compile Include="JsonContainerAttribute.cs" />
@@ -103,9 +139,11 @@
     <Compile Include="JsonSerializer.cs" />
     <Compile Include="JsonSerializerSettings.cs" />
     <Compile Include="JsonTextReader.cs" />
+    <Compile Include="JsonTextWriter.Async.cs" />
     <Compile Include="JsonTextWriter.cs" />
     <Compile Include="JsonToken.cs" />
     <Compile Include="JsonValidatingReader.cs" />
+    <Compile Include="JsonWriter.Async.cs" />
     <Compile Include="JsonWriter.cs" />
     <Compile Include="JsonWriterException.cs" />
     <Compile Include="Linq\CommentHandling.cs" />
@@ -258,6 +296,9 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Dynamic.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Converters\IsoDateTimeConverter.Async.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -108,25 +108,25 @@ namespace Newtonsoft.Json.Serialization
         private static readonly JsonConverter[] BuiltInConverters =
         {
 #if !(NET20 || DOTNET || PORTABLE40 || PORTABLE)
-            new EntityKeyMemberConverter(),
+            EntityKeyMemberConverterImpl.Instance,
 #endif
 #if !(NET35 || NET20 || PORTABLE40)
-            new ExpandoObjectConverter(),
+            ExpandoObjectConverterImpl.Instance,
 #endif
 #if !(PORTABLE40)
-            new XmlNodeConverter(),
+            new XmlNodeConverterImpl(),
 #endif
 #if !(DOTNET || PORTABLE40 || PORTABLE)
-            new BinaryConverter(),
-            new DataSetConverter(),
-            new DataTableConverter(),
+            BinaryConverterImpl.Instance,
+            DataSetConverterImpl.Instance, 
+            DataTableConverterImpl.Instance,
 #endif
 #if !(NET35 || NET20)
-            new DiscriminatedUnionConverter(),
+            DiscriminatedUnionConverterImpl.Instance,
 #endif
-            new KeyValuePairConverter(),
-            new BsonObjectIdConverter(),
-            new RegexConverter()
+            KeyValuePairConverterImpl.Instance,
+            BsonObjectIdConverterImpl.Instance, 
+            RegexConverterImpl.Instance
         };
 
         private static readonly object TypeContractCacheLock = new object();

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.Async.cs
@@ -1,0 +1,44 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Serialization
+{
+    public partial class JsonProperty
+    {
+        internal Task WritePropertyNameAsync(JsonWriter writer, CancellationToken cancellationToken)
+        {
+            return _skipPropertyNameEscape
+                ? writer.WritePropertyNameAsync(PropertyName, false, cancellationToken)
+                : writer.WritePropertyNameAsync(PropertyName, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -36,7 +36,7 @@ namespace Newtonsoft.Json.Serialization
     /// <summary>
     /// Maps a JSON property to a .NET member or constructor parameter.
     /// </summary>
-    public class JsonProperty
+    public partial class JsonProperty
     {
         internal Required? _required;
         internal bool _hasExplicitDefaultValue;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.Async.cs
@@ -1,0 +1,1807 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Dynamic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Serialization
+{
+    internal partial class JsonSerializerInternalReader
+    {
+        internal async Task ReadAndAssertAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected end when reading JSON.");
+            }
+        }
+
+        public async Task PopulateAsync(JsonReader reader, object target, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(target, nameof(target));
+
+            Type objectType = target.GetType();
+
+            JsonContract contract = Serializer._contractResolver.ResolveContract(objectType);
+
+            if (!await reader.MoveToContentAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw JsonSerializationException.Create(reader, "No JSON content found.");
+            }
+
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                if (contract.ContractType == JsonContractType.Array)
+                {
+                    JsonArrayContract arrayContract = (JsonArrayContract)contract;
+
+                    await PopulateListAsync(arrayContract.ShouldCreateWrapper ? arrayContract.CreateWrapper(target) : (IList)target, reader, arrayContract, null, null, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot populate JSON array onto type '{0}'.".FormatWith(CultureInfo.InvariantCulture, objectType));
+                }
+            }
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+
+                string id = null;
+                if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore && reader.TokenType == JsonToken.PropertyName && string.Equals(reader.Value.ToString(), JsonTypeReflector.IdPropertyName, StringComparison.Ordinal))
+                {
+                    await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+                    id = reader.Value != null ? reader.Value.ToString() : null;
+                    await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (contract.ContractType == JsonContractType.Dictionary)
+                {
+                    JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)contract;
+                    await PopulateDictionaryAsync(dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(target) : (IDictionary)target, reader, dictionaryContract, null, id, cancellationToken).ConfigureAwait(false);
+                }
+                else if (contract.ContractType == JsonContractType.Object)
+                {
+                    await PopulateObjectAsync(target, reader, (JsonObjectContract)contract, null, id, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot populate JSON object onto type '{0}'.".FormatWith(CultureInfo.InvariantCulture, objectType));
+                }
+            }
+            else
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected initial token '{0}' when populating object. Expected JSON object or array.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+            }
+        }
+
+        private async Task<object> PopulateListAsync(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, string id, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IWrappedCollection wrappedCollection = list as IWrappedCollection;
+            object underlyingList = wrappedCollection != null ? wrappedCollection.UnderlyingCollection : list;
+
+            if (id != null)
+            {
+                AddReference(reader, id, underlyingList);
+            }
+
+            // can't populate an existing array
+            if (list.IsFixedSize)
+            {
+                await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+                return underlyingList;
+            }
+
+            OnDeserializing(reader, contract, underlyingList);
+
+            int initialDepth = reader.Depth;
+
+            if (contract.ItemContract == null)
+            {
+                contract.ItemContract = GetContractSafe(contract.CollectionItemType);
+            }
+
+            JsonConverter collectionItemConverter = GetConverter(contract.ItemContract, null, contract, containerProperty);
+
+            int? previousErrorIndex = null;
+
+            bool finished = false;
+            do
+            {
+                try
+                {
+                    if (await ReadForTypeAsync(reader, contract.ItemContract, collectionItemConverter != null, cancellationToken).ConfigureAwait(false))
+                    {
+                        switch (reader.TokenType)
+                        {
+                            case JsonToken.EndArray:
+                                finished = true;
+                                break;
+                            default:
+                                object value;
+
+                                if (collectionItemConverter != null && collectionItemConverter.CanRead)
+                                {
+                                    value = await DeserializeConvertableAsync(collectionItemConverter, reader, contract.CollectionItemType, null, cancellationToken).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    value = await CreateValueInternalAsync(reader, contract.CollectionItemType, contract.ItemContract, null, contract, containerProperty, null, cancellationToken).ConfigureAwait(false);
+                                }
+
+                                list.Add(value);
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    JsonPosition errorPosition = reader.GetPosition(initialDepth);
+
+                    if (IsErrorHandled(underlyingList, contract, errorPosition.Position, reader as IJsonLineInfo, reader.Path, ex))
+                    {
+                        await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+
+                        if (previousErrorIndex != null && previousErrorIndex == errorPosition.Position)
+                        {
+                            // reader index has not moved since previous error handling
+                            // break out of reading array to prevent infinite loop
+                            throw JsonSerializationException.Create(reader, "Infinite loop detected from error handling.", ex);
+                        }
+                        else
+                        {
+                            previousErrorIndex = errorPosition.Position;
+                        }
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            } while (!finished);
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, underlyingList, "Unexpected end when deserializing array.");
+            }
+
+            OnDeserialized(reader, contract, underlyingList);
+            return underlyingList;
+        }
+
+        private async Task<object> PopulateDictionaryAsync(IDictionary dictionary, JsonReader reader, JsonDictionaryContract contract, JsonProperty containerProperty, string id, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IWrappedDictionary wrappedDictionary = dictionary as IWrappedDictionary;
+            object underlyingDictionary = wrappedDictionary != null ? wrappedDictionary.UnderlyingDictionary : dictionary;
+
+            if (id != null)
+            {
+                AddReference(reader, id, underlyingDictionary);
+            }
+
+            OnDeserializing(reader, contract, underlyingDictionary);
+
+            int initialDepth = reader.Depth;
+
+            if (contract.KeyContract == null)
+            {
+                contract.KeyContract = GetContractSafe(contract.DictionaryKeyType);
+            }
+
+            if (contract.ItemContract == null)
+            {
+                contract.ItemContract = GetContractSafe(contract.DictionaryValueType);
+            }
+
+            JsonConverter dictionaryValueConverter = contract.ItemConverter ?? GetConverter(contract.ItemContract, null, contract, containerProperty);
+            PrimitiveTypeCode keyTypeCode = contract.KeyContract is JsonPrimitiveContract ? ((JsonPrimitiveContract)contract.KeyContract).TypeCode : PrimitiveTypeCode.Empty;
+
+            bool finished = false;
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        object keyValue = reader.Value;
+                        if (await CheckPropertyNameAsync(reader, keyValue.ToString(), cancellationToken).ConfigureAwait(false))
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            try
+                            {
+                                // this is for correctly reading ISO and MS formatted dictionary keys
+                                switch (keyTypeCode)
+                                {
+                                    case PrimitiveTypeCode.DateTime:
+                                    case PrimitiveTypeCode.DateTimeNullable:
+                                    {
+                                        DateTime dt;
+                                        if (DateTimeUtils.TryParseDateTime(keyValue.ToString(), reader.DateTimeZoneHandling, reader.DateFormatString, reader.Culture, out dt))
+                                        {
+                                            keyValue = dt;
+                                        }
+                                        else
+                                        {
+                                            keyValue = EnsureType(reader, keyValue, CultureInfo.InvariantCulture, contract.KeyContract, contract.DictionaryKeyType);
+                                        }
+                                        break;
+                                    }
+#if !NET20
+                                    case PrimitiveTypeCode.DateTimeOffset:
+                                    case PrimitiveTypeCode.DateTimeOffsetNullable:
+                                    {
+                                        DateTimeOffset dt;
+                                        if (DateTimeUtils.TryParseDateTimeOffset(keyValue.ToString(), reader.DateFormatString, reader.Culture, out dt))
+                                        {
+                                            keyValue = dt;
+                                        }
+                                        else
+                                        {
+                                            keyValue = EnsureType(reader, keyValue, CultureInfo.InvariantCulture, contract.KeyContract, contract.DictionaryKeyType);
+                                        }
+                                        break;
+                                    }
+#endif
+                                    default:
+                                        keyValue = EnsureType(reader, keyValue, CultureInfo.InvariantCulture, contract.KeyContract, contract.DictionaryKeyType);
+                                        break;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                throw JsonSerializationException.Create(reader, "Could not convert string '{0}' to dictionary key type '{1}'. Create a TypeConverter to convert from the string to the key type object.".FormatWith(CultureInfo.InvariantCulture, reader.Value, contract.DictionaryKeyType), ex);
+                            }
+
+                            if (!await ReadForTypeAsync(reader, contract.ItemContract, dictionaryValueConverter != null, cancellationToken).ConfigureAwait(false))
+                            {
+                                throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
+                            }
+
+                            object itemValue;
+                            if (dictionaryValueConverter != null && dictionaryValueConverter.CanRead)
+                            {
+                                itemValue = await DeserializeConvertableAsync(dictionaryValueConverter, reader, contract.DictionaryValueType, null, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                itemValue = await CreateValueInternalAsync(reader, contract.DictionaryValueType, contract.ItemContract, null, contract, containerProperty, null, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            dictionary[keyValue] = itemValue;
+                        }
+                        catch (Exception ex)
+                        {
+                            if (IsErrorHandled(underlyingDictionary, contract, keyValue, reader as IJsonLineInfo, reader.Path, ex))
+                            {
+                                await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                throw;
+                            }
+                        }
+
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        finished = true;
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
+                }
+            } while (!finished && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, underlyingDictionary, "Unexpected end when deserializing object.");
+            }
+
+            OnDeserialized(reader, contract, underlyingDictionary);
+            return underlyingDictionary;
+        }
+
+        private async Task<object> PopulateObjectAsync(object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, string id, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OnDeserializing(reader, contract, newObject);
+
+            // only need to keep a track of properies presence if they are required or a value should be defaulted if missing
+            Dictionary<JsonProperty, PropertyPresence> propertiesPresence = contract.HasRequiredOrDefaultValueProperties || HasFlag(Serializer._defaultValueHandling, DefaultValueHandling.Populate) ? contract.Properties.ToDictionary(m => m, m => PropertyPresence.None) : null;
+
+            if (id != null)
+            {
+                AddReference(reader, id, newObject);
+            }
+
+            int initialDepth = reader.Depth;
+
+            bool finished = false;
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                    {
+                        string memberName = reader.Value.ToString();
+
+                        if (await CheckPropertyNameAsync(reader, memberName, cancellationToken).ConfigureAwait(false))
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            // attempt exact case match first
+                            // then try match ignoring case
+                            JsonProperty property = contract.Properties.GetClosestMatchProperty(memberName);
+
+                            if (property == null)
+                            {
+                                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                                {
+                                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
+                                }
+
+                                if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
+                                {
+                                    throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType.Name));
+                                }
+
+                                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    break;
+                                }
+
+                                await SetExtensionDataAsync(contract, member, reader, memberName, newObject, cancellationToken).ConfigureAwait(false);
+                                continue;
+                            }
+
+                            if (property.Ignored || !ShouldDeserialize(reader, property, newObject))
+                            {
+                                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                                {
+                                    break;
+                                }
+
+                                SetPropertyPresence(reader, property, propertiesPresence);
+                                await SetExtensionDataAsync(contract, member, reader, memberName, newObject, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                if (property.PropertyContract == null)
+                                {
+                                    property.PropertyContract = GetContractSafe(property.PropertyType);
+                                }
+
+                                JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.MemberConverter, contract, member);
+
+                                if (!await ReadForTypeAsync(reader, property.PropertyContract, propertyConverter != null, cancellationToken).ConfigureAwait(false))
+                                {
+                                    throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+                                }
+
+                                SetPropertyPresence(reader, property, propertiesPresence);
+
+                                // set extension data if property is ignored or readonly
+                                if (!await SetPropertyValueAsync(property, propertyConverter, contract, member, reader, newObject, cancellationToken).ConfigureAwait(false))
+                                {
+                                    await SetExtensionDataAsync(contract, member, reader, memberName, newObject, cancellationToken).ConfigureAwait(false);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            if (IsErrorHandled(newObject, contract, memberName, reader as IJsonLineInfo, reader.Path, ex))
+                            {
+                                await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                throw;
+                            }
+                        }
+
+                        break;
+                    }
+                    case JsonToken.EndObject:
+                        finished = true;
+                        break;
+                    case JsonToken.Comment:
+
+                        // ignore
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
+                }
+            } while (!finished && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, newObject, "Unexpected end when deserializing object.");
+            }
+
+            if (propertiesPresence != null)
+            {
+                foreach (KeyValuePair<JsonProperty, PropertyPresence> propertyPresence in propertiesPresence)
+                {
+                    JsonProperty property = propertyPresence.Key;
+                    PropertyPresence presence = propertyPresence.Value;
+
+                    await EndProcessPropertyAsync(newObject, reader, contract, initialDepth, property, presence, true, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            OnDeserialized(reader, contract, newObject);
+            return newObject;
+        }
+
+        private static async Task<bool> ReadForTypeAsync(JsonReader reader, JsonContract contract, bool hasConverter, CancellationToken cancellationToken)
+        {
+            // don't read properties with converters as a specific value
+            // the value might be a string which will then get converted which will error if read as date for example
+            if (hasConverter)
+            {
+                return await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            ReadType t = contract != null ? contract.InternalReadType : ReadType.Read;
+
+            switch (t)
+            {
+                case ReadType.Read:
+                    return await reader.ReadAndMoveToContentAsync(cancellationToken).ConfigureAwait(false);
+                case ReadType.ReadAsInt32:
+                    await reader.ReadAsInt32Async(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsDecimal:
+                    await reader.ReadAsDecimalAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsDouble:
+                    await reader.ReadAsDoubleAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsBytes:
+                    await reader.ReadAsBytesAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsBoolean:
+                    await reader.ReadAsBooleanAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsString:
+                    await reader.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsDateTime:
+                    await reader.ReadAsDateTimeAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case ReadType.ReadAsDateTimeOffset:
+                    await reader.ReadAsDateTimeOffsetAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return reader.TokenType != JsonToken.None;
+        }
+
+        private async Task<object> DeserializeConvertableAsync(JsonConverter converter, JsonReader reader, Type objectType, object existingValue, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+            {
+                TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Started deserializing {0} with converter {1}.".FormatWith(CultureInfo.InvariantCulture, objectType, converter.GetType())), null);
+            }
+
+            object value = await converter.ReadJsonAsync(reader, objectType, existingValue, GetInternalSerializer(), cancellationToken).ConfigureAwait(false);
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+            {
+                TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Finished deserializing {0} with converter {1}.".FormatWith(CultureInfo.InvariantCulture, objectType, converter.GetType())), null);
+            }
+
+            return value;
+        }
+
+        private async Task<object> CreateValueInternalAsync(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, object existingValue, CancellationToken cancellationToken)
+        {
+            if (contract != null && contract.ContractType == JsonContractType.Linq)
+            {
+                return await CreateJTokenAsync(reader, contract, cancellationToken).ConfigureAwait(false);
+            }
+
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    // populate a typed object or generic dictionary/array
+                    // depending upon whether an objectType was supplied
+                    case JsonToken.StartObject:
+                        return await CreateObjectAsync(reader, objectType, contract, member, containerContract, containerMember, existingValue, cancellationToken).ConfigureAwait(false);
+                    case JsonToken.StartArray:
+                        return await CreateListAsync(reader, objectType, contract, member, existingValue, null, cancellationToken).ConfigureAwait(false);
+                    case JsonToken.Integer:
+                    case JsonToken.Float:
+                    case JsonToken.Boolean:
+                    case JsonToken.Date:
+                    case JsonToken.Bytes:
+                        return EnsureType(reader, reader.Value, CultureInfo.InvariantCulture, contract, objectType);
+                    case JsonToken.String:
+                        string s = (string)reader.Value;
+
+                        // convert empty string to null automatically for nullable types
+                        if (CoerceEmptyStringToNull(objectType, contract, s))
+                        {
+                            return null;
+                        }
+
+                        // string that needs to be returned as a byte array should be base 64 decoded
+                        if (objectType == typeof(byte[]))
+                        {
+                            return Convert.FromBase64String(s);
+                        }
+
+                        return EnsureType(reader, s, CultureInfo.InvariantCulture, contract, objectType);
+                    case JsonToken.StartConstructor:
+                        string constructorName = reader.Value.ToString();
+
+                        return EnsureType(reader, constructorName, CultureInfo.InvariantCulture, contract, objectType);
+                    case JsonToken.Null:
+                    case JsonToken.Undefined:
+#if !(DOTNET || PORTABLE40 || PORTABLE)
+                        if (objectType == typeof(DBNull))
+                        {
+                            return DBNull.Value;
+                        }
+#endif
+
+                        return EnsureType(reader, reader.Value, CultureInfo.InvariantCulture, contract, objectType);
+                    case JsonToken.Raw:
+                        return new JRaw((string)reader.Value);
+                    case JsonToken.Comment:
+
+                        // ignore
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token while deserializing object: " + reader.TokenType);
+                }
+            } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
+        }
+
+        private async Task HandleErrorAsync(JsonReader reader, bool readPastError, int initialDepth, CancellationToken cancellationToken)
+        {
+            ClearErrorContext();
+
+            if (readPastError)
+            {
+                await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+
+                while (reader.Depth > initialDepth + 1)
+                {
+                    if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        private Task<bool> CheckPropertyNameAsync(JsonReader reader, string memberName, CancellationToken cancellationToken)
+        {
+            if (Serializer.MetadataPropertyHandling == MetadataPropertyHandling.ReadAhead)
+            {
+                switch (memberName)
+                {
+                    case JsonTypeReflector.IdPropertyName:
+                    case JsonTypeReflector.RefPropertyName:
+                    case JsonTypeReflector.TypePropertyName:
+                    case JsonTypeReflector.ArrayValuesPropertyName:
+                        return SkipAndTrueAsync(reader, cancellationToken);
+                }
+            }
+
+            return AsyncUtils.False;
+        }
+
+        private async Task<bool> SkipAndTrueAsync(JsonReader reader, CancellationToken cancellationToken)
+        {
+            await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        private async Task SetExtensionDataAsync(JsonObjectContract contract, JsonProperty member, JsonReader reader, string memberName, object o, CancellationToken cancellationToken)
+        {
+            if (contract.ExtensionDataSetter != null)
+            {
+                try
+                {
+                    object value = await ReadExtensionDataValueAsync(contract, member, reader, cancellationToken).ConfigureAwait(false);
+
+                    contract.ExtensionDataSetter(o, memberName, value);
+                }
+                catch (Exception ex)
+                {
+                    throw JsonSerializationException.Create(reader, "Error setting value in extension data for type '{0}'.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType), ex);
+                }
+            }
+            else
+            {
+                await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private Task<object> ReadExtensionDataValueAsync(JsonObjectContract contract, JsonProperty member, JsonReader reader, CancellationToken cancellationToken)
+        {
+            return contract.ExtensionDataIsJToken ? JToken.ReadFromAsObjectAsync(reader, cancellationToken) : CreateValueInternalAsync(reader, null, null, null, contract, member, null, cancellationToken);
+        }
+
+        private async Task<bool> SetPropertyValueAsync(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, object target, CancellationToken cancellationToken)
+        {
+            object currentValue;
+            bool useExistingValue;
+            JsonContract propertyContract;
+            bool gottenCurrentValue;
+
+            if (CalculatePropertyDetails(property, ref propertyConverter, containerContract, containerProperty, reader, target, out useExistingValue, out currentValue, out propertyContract, out gottenCurrentValue))
+            {
+                return false;
+            }
+
+            object value;
+
+            if (propertyConverter != null && propertyConverter.CanRead)
+            {
+                if (!gottenCurrentValue && target != null && property.Readable)
+                {
+                    currentValue = property.ValueProvider.GetValue(target);
+                }
+
+                value = await DeserializeConvertableAsync(propertyConverter, reader, property.PropertyType, currentValue, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                value = await CreateValueInternalAsync(reader, property.PropertyType, propertyContract, property, containerContract, containerProperty, useExistingValue ? currentValue : null, cancellationToken).ConfigureAwait(false);
+            }
+
+            // always set the value if useExistingValue is false,
+            // otherwise also set it if CreateValue returns a new value compared to the currentValue
+            // this could happen because of a JsonConverter against the type
+            if ((!useExistingValue || value != currentValue) && ShouldSetPropertyValue(property, value))
+            {
+                property.ValueProvider.SetValue(target, value);
+
+                if (property.SetIsSpecified != null)
+                {
+                    if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                    {
+                        TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "IsSpecified for property '{0}' on {1} set to true.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName, property.DeclaringType)), null);
+                    }
+
+                    property.SetIsSpecified(target, true);
+                }
+
+                return true;
+            }
+
+            // the value wasn't set be JSON was populated onto the existing value
+            return useExistingValue;
+        }
+
+        private async Task EndProcessPropertyAsync(object newObject, JsonReader reader, JsonObjectContract contract, int initialDepth, JsonProperty property, PropertyPresence presence, bool setDefaultValue, CancellationToken cancellationToken)
+        {
+            if (presence == PropertyPresence.None || presence == PropertyPresence.Null)
+            {
+                try
+                {
+                    Required resolvedRequired = property._required ?? contract.ItemRequired ?? Required.Default;
+
+                    switch (presence)
+                    {
+                        case PropertyPresence.None:
+                            if (resolvedRequired == Required.AllowNull || resolvedRequired == Required.Always)
+                            {
+                                throw JsonSerializationException.Create(reader, "Required property '{0}' not found in JSON.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                            }
+
+                            if (setDefaultValue && !property.Ignored)
+                            {
+                                if (property.PropertyContract == null)
+                                {
+                                    property.PropertyContract = GetContractSafe(property.PropertyType);
+                                }
+
+                                if (HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Populate) && property.Writable)
+                                {
+                                    property.ValueProvider.SetValue(newObject, EnsureType(reader, property.GetResolvedDefaultValue(), CultureInfo.InvariantCulture, property.PropertyContract, property.PropertyType));
+                                }
+                            }
+                            break;
+                        case PropertyPresence.Null:
+                            if (resolvedRequired == Required.Always)
+                            {
+                                throw JsonSerializationException.Create(reader, "Required property '{0}' expects a value but got null.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                            }
+                            if (resolvedRequired == Required.DisallowNull)
+                            {
+                                throw JsonSerializationException.Create(reader, "Required property '{0}' expects a non-null value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                            }
+
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (IsErrorHandled(newObject, contract, property.PropertyName, reader as IJsonLineInfo, reader.Path, ex))
+                    {
+                        await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        private async Task<JToken> CreateJTokenAsync(JsonReader reader, JsonContract contract, CancellationToken cancellationToken)
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            if (contract != null)
+            {
+                if (contract.UnderlyingType == typeof(JRaw))
+                {
+                    return await JRaw.CreateAsync(reader, cancellationToken).ConfigureAwait(false);
+                }
+                if (reader.TokenType == JsonToken.Null && !(contract.UnderlyingType == typeof(JValue) || contract.UnderlyingType == typeof(JToken)))
+                {
+                    return null;
+                }
+            }
+
+            using (JTokenWriter writer = new JTokenWriter())
+            {
+                await writer.WriteTokenAsync(reader, cancellationToken).ConfigureAwait(false);
+                return writer.Token;
+            }
+        }
+
+        private async Task<object> CreateObjectAsync(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, object existingValue, CancellationToken cancellationToken)
+        {
+            string id;
+            Type resolvedObjectType = objectType;
+
+            if (Serializer.MetadataPropertyHandling == MetadataPropertyHandling.Ignore)
+            {
+                // don't look for metadata properties
+                await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+                id = null;
+            }
+            else if (Serializer.MetadataPropertyHandling == MetadataPropertyHandling.ReadAhead)
+            {
+                JTokenReader tokenReader = reader as JTokenReader;
+                if (tokenReader == null)
+                {
+                    JToken t = await JToken.ReadFromAsync(reader, cancellationToken).ConfigureAwait(false);
+                    tokenReader = (JTokenReader)t.CreateReader();
+                    tokenReader.Culture = reader.Culture;
+                    tokenReader.DateFormatString = reader.DateFormatString;
+                    tokenReader.DateParseHandling = reader.DateParseHandling;
+                    tokenReader.DateTimeZoneHandling = reader.DateTimeZoneHandling;
+                    tokenReader.FloatParseHandling = reader.FloatParseHandling;
+                    tokenReader.SupportMultipleContent = reader.SupportMultipleContent;
+
+                    // start
+                    tokenReader.ReadAndAssert();
+
+                    reader = tokenReader;
+                }
+
+                object newValue;
+                if (ReadMetadataPropertiesToken(tokenReader, ref resolvedObjectType, ref contract, member, containerContract, containerMember, existingValue, out newValue, out id))
+                {
+                    return newValue;
+                }
+            }
+            else
+            {
+                await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+                object newValue;
+                if (ReadMetadataProperties(reader, ref resolvedObjectType, ref contract, member, containerContract, containerMember, existingValue, out newValue, out id))
+                {
+                    return newValue;
+                }
+            }
+
+            if (HasNoDefinedType(contract))
+            {
+                return await CreateJObjectAsync(reader, cancellationToken).ConfigureAwait(false);
+            }
+
+            switch (contract.ContractType)
+            {
+                case JsonContractType.Object:
+                {
+                    JsonObjectContract objectContract = (JsonObjectContract)contract;
+                    object targetObject;
+
+                    // check that if type name handling is being used that the existing value is compatible with the specified type
+                    if (existingValue != null && (resolvedObjectType == objectType || resolvedObjectType.IsAssignableFrom(existingValue.GetType())))
+                    {
+                        targetObject = existingValue;
+                    }
+                    else
+                    {
+                        var created = await CreateNewObjectAsync(reader, objectContract, member, containerMember, id, cancellationToken).ConfigureAwait(false);
+                        if (created.Item2)
+                        {
+                            // don't populate if read from non-default creator because the object has already been read
+                            return created.Item1;
+                        }
+
+                        targetObject = created.Item1;
+                    }
+
+                    return await PopulateObjectAsync(targetObject, reader, objectContract, member, id, cancellationToken).ConfigureAwait(false);
+                }
+                case JsonContractType.Primitive:
+                {
+                    JsonPrimitiveContract primitiveContract = (JsonPrimitiveContract)contract;
+
+                    // if the content is inside $value then read past it
+                    if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore && reader.TokenType == JsonToken.PropertyName && string.Equals(reader.Value.ToString(), JsonTypeReflector.ValuePropertyName, StringComparison.Ordinal))
+                    {
+                        await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+
+                        // the token should not be an object because the $type value could have been included in the object
+                        // without needing the $value property
+                        if (reader.TokenType == JsonToken.StartObject)
+                        {
+                            throw JsonSerializationException.Create(reader, "Unexpected token when deserializing primitive value: " + reader.TokenType);
+                        }
+
+                        object value = await CreateValueInternalAsync(reader, resolvedObjectType, primitiveContract, member, null, null, existingValue, cancellationToken).ConfigureAwait(false);
+
+                        await ReadAndAssertAsync(reader, cancellationToken).ConfigureAwait(false);
+                        return value;
+                    }
+
+                    break;
+                }
+                case JsonContractType.Dictionary:
+                {
+                    JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)contract;
+                    object targetDictionary;
+
+                    if (existingValue == null)
+                    {
+                        bool createdFromNonDefaultCreator;
+                        IDictionary dictionary = CreateNewDictionary(reader, dictionaryContract, out createdFromNonDefaultCreator);
+
+                        if (createdFromNonDefaultCreator)
+                        {
+                            if (id != null)
+                            {
+                                throw JsonSerializationException.Create(reader, "Cannot preserve reference to readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            }
+
+                            if (contract.OnSerializingCallbacks.Count > 0)
+                            {
+                                throw JsonSerializationException.Create(reader, "Cannot call OnSerializing on readonly dictionary, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            }
+
+                            if (contract.OnErrorCallbacks.Count > 0)
+                            {
+                                throw JsonSerializationException.Create(reader, "Cannot call OnError on readonly list, or dictionary created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            }
+
+                            if (!dictionaryContract.HasParameterizedCreatorInternal)
+                            {
+                                throw JsonSerializationException.Create(reader, "Cannot deserialize readonly or fixed size dictionary: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                            }
+                        }
+
+                        await PopulateDictionaryAsync(dictionary, reader, dictionaryContract, member, id, cancellationToken).ConfigureAwait(false);
+
+                        if (createdFromNonDefaultCreator)
+                        {
+                            ObjectConstructor<object> creator = dictionaryContract.OverrideCreator ?? dictionaryContract.ParameterizedCreator;
+
+                            return creator(dictionary);
+                        }
+                        else if (dictionary is IWrappedDictionary)
+                        {
+                            return ((IWrappedDictionary)dictionary).UnderlyingDictionary;
+                        }
+
+                        targetDictionary = dictionary;
+                    }
+                    else
+                    {
+                        targetDictionary = await PopulateDictionaryAsync(dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(existingValue) : (IDictionary)existingValue, reader, dictionaryContract, member, id, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return targetDictionary;
+                }
+#if !(PORTABLE40)
+                case JsonContractType.Dynamic:
+                    JsonDynamicContract dynamicContract = (JsonDynamicContract)contract;
+                    return await CreateDynamicAsync(reader, dynamicContract, member, id, cancellationToken).ConfigureAwait(false);
+#endif
+#if !(DOTNET || PORTABLE40 || PORTABLE)
+                case JsonContractType.Serializable:
+                    JsonISerializableContract serializableContract = (JsonISerializableContract)contract;
+                    return await CreateISerializableAsync(reader, serializableContract, member, id, cancellationToken).ConfigureAwait(false);
+#endif
+            }
+
+            string message = @"Cannot deserialize the current JSON object (e.g. {{""name"":""value""}}) into type '{0}' because the type requires a {1} to deserialize correctly." + Environment.NewLine + @"To fix this error either change the JSON to a {1} or change the deserialized type so that it is a normal .NET type (e.g. not a primitive type like integer, not a collection type like an array or List<T>) that can be deserialized from a JSON object. JsonObjectAttribute can also be added to the type to force it to deserialize from a JSON object." + Environment.NewLine;
+            message = message.FormatWith(CultureInfo.InvariantCulture, resolvedObjectType, GetExpectedDescription(contract));
+
+            throw JsonSerializationException.Create(reader, message);
+        }
+
+        private async Task<object> CreateListAsync(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, object existingValue, string id, CancellationToken cancellationToken)
+        {
+            object value;
+
+            if (HasNoDefinedType(contract))
+            {
+                return CreateJToken(reader, contract);
+            }
+
+            JsonArrayContract arrayContract = EnsureArrayContract(reader, objectType, contract);
+
+            if (existingValue == null)
+            {
+                bool createdFromNonDefaultCreator;
+                IList list = CreateNewList(reader, arrayContract, out createdFromNonDefaultCreator);
+
+                if (createdFromNonDefaultCreator)
+                {
+                    if (id != null)
+                    {
+                        throw JsonSerializationException.Create(reader, "Cannot preserve reference to array or readonly list, or list created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                    }
+
+                    if (contract.OnSerializingCallbacks.Count > 0)
+                    {
+                        throw JsonSerializationException.Create(reader, "Cannot call OnSerializing on an array or readonly list, or list created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                    }
+
+                    if (contract.OnErrorCallbacks.Count > 0)
+                    {
+                        throw JsonSerializationException.Create(reader, "Cannot call OnError on an array or readonly list, or list created from a non-default constructor: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                    }
+
+                    if (!arrayContract.HasParameterizedCreatorInternal && !arrayContract.IsArray)
+                    {
+                        throw JsonSerializationException.Create(reader, "Cannot deserialize readonly or fixed size list: {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                    }
+                }
+
+                if (!arrayContract.IsMultidimensionalArray)
+                {
+                    await PopulateListAsync(list, reader, arrayContract, member, id, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await PopulateMultidimensionalArrayAsync(list, reader, arrayContract, member, id, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (createdFromNonDefaultCreator)
+                {
+                    if (arrayContract.IsMultidimensionalArray)
+                    {
+                        list = CollectionUtils.ToMultidimensionalArray(list, arrayContract.CollectionItemType, contract.CreatedType.GetArrayRank());
+                    }
+                    else if (arrayContract.IsArray)
+                    {
+                        Array a = Array.CreateInstance(arrayContract.CollectionItemType, list.Count);
+                        list.CopyTo(a, 0);
+                        list = a;
+                    }
+                    else
+                    {
+                        ObjectConstructor<object> creator = arrayContract.OverrideCreator ?? arrayContract.ParameterizedCreator;
+
+                        return creator(list);
+                    }
+                }
+                else if (list is IWrappedCollection)
+                {
+                    return ((IWrappedCollection)list).UnderlyingCollection;
+                }
+
+                value = list;
+            }
+            else
+            {
+                if (!arrayContract.CanDeserialize)
+                {
+                    throw JsonSerializationException.Create(reader, "Cannot populate list type {0}.".FormatWith(CultureInfo.InvariantCulture, contract.CreatedType));
+                }
+
+                value = PopulateListAsync(arrayContract.ShouldCreateWrapper ? arrayContract.CreateWrapper(existingValue) : (IList)existingValue, reader, arrayContract, member, id, cancellationToken);
+            }
+
+            return value;
+        }
+
+        public async Task<Tuple<object, bool>> CreateNewObjectAsync(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, string id, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            object newObject = null;
+            if (objectContract.OverrideCreator != null)
+            {
+                if (objectContract.CreatorParameters.Count > 0)
+                {
+                    return Tuple.Create(await CreateObjectUsingCreatorWithParametersAsync(reader, objectContract, containerMember, objectContract.OverrideCreator, id, cancellationToken).ConfigureAwait(false), true);
+                }
+
+                newObject = objectContract.OverrideCreator(new object[0]);
+            }
+            else if (objectContract.DefaultCreator != null && (!objectContract.DefaultCreatorNonPublic || Serializer._constructorHandling == ConstructorHandling.AllowNonPublicDefaultConstructor || objectContract.ParameterizedCreator == null))
+            {
+                // use the default constructor if it is...
+                // public
+                // non-public and the user has change constructor handling settings
+                // non-public and there is no other creator
+                newObject = objectContract.DefaultCreator();
+            }
+            else if (objectContract.ParameterizedCreator != null)
+            {
+                return Tuple.Create(await CreateObjectUsingCreatorWithParametersAsync(reader, objectContract, containerMember, objectContract.ParameterizedCreator, id, cancellationToken).ConfigureAwait(false), true);
+            }
+
+            if (newObject == null)
+            {
+                if (!objectContract.IsInstantiable)
+                {
+                    throw JsonSerializationException.Create(reader, "Could not create an instance of type {0}. Type is an interface or abstract class and cannot be instantiated.".FormatWith(CultureInfo.InvariantCulture, objectContract.UnderlyingType));
+                }
+
+                throw JsonSerializationException.Create(reader, "Unable to find a constructor to use for type {0}. A class should either have a default constructor, one constructor with arguments or a constructor marked with the JsonConstructor attribute.".FormatWith(CultureInfo.InvariantCulture, objectContract.UnderlyingType));
+            }
+
+            return Tuple.Create(newObject, false);
+        }
+
+        private async Task<object> CreateObjectUsingCreatorWithParametersAsync(JsonReader reader, JsonObjectContract contract, JsonProperty containerProperty, ObjectConstructor<object> creator, string id, CancellationToken cancellationToken)
+        {
+            ValidationUtils.ArgumentNotNull(creator, nameof(creator));
+
+            // only need to keep a track of properies presence if they are required or a value should be defaulted if missing
+            bool trackPresence = contract.HasRequiredOrDefaultValueProperties || HasFlag(Serializer._defaultValueHandling, DefaultValueHandling.Populate);
+
+            Type objectType = contract.UnderlyingType;
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+            {
+                string parameters = string.Join(", ", contract.CreatorParameters.Select(p => p.PropertyName).ToArray());
+                TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Deserializing {0} using creator with parameters: {1}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType, parameters)), null);
+            }
+
+            List<CreatorPropertyContext> propertyContexts = await ResolvePropertyAndCreatorValuesAsync(contract, containerProperty, reader, objectType, cancellationToken).ConfigureAwait(false);
+            if (trackPresence)
+            {
+                foreach (JsonProperty property in contract.Properties)
+                {
+                    if (propertyContexts.All(p => p.Property != property))
+                    {
+                        propertyContexts.Add(new CreatorPropertyContext {Property = property, Name = property.PropertyName, Presence = PropertyPresence.None});
+                    }
+                }
+            }
+
+            object[] creatorParameterValues = new object[contract.CreatorParameters.Count];
+
+            foreach (CreatorPropertyContext context in propertyContexts)
+            {
+                // set presence of read values
+                if (trackPresence)
+                {
+                    if (context.Property != null && context.Presence == null)
+                    {
+                        object v = context.Value;
+                        PropertyPresence propertyPresence;
+                        if (v == null)
+                        {
+                            propertyPresence = PropertyPresence.Null;
+                        }
+                        else if (v is string)
+                        {
+                            propertyPresence = CoerceEmptyStringToNull(context.Property.PropertyType, context.Property.PropertyContract, (string)v) ? PropertyPresence.Null : PropertyPresence.Value;
+                        }
+                        else
+                        {
+                            propertyPresence = PropertyPresence.Value;
+                        }
+
+                        context.Presence = propertyPresence;
+                    }
+                }
+
+                JsonProperty constructorProperty = context.ConstructorProperty;
+                if (constructorProperty == null && context.Property != null)
+                {
+                    constructorProperty = contract.CreatorParameters.ForgivingCaseSensitiveFind(p => p.PropertyName, context.Property.UnderlyingName);
+                }
+
+                if (constructorProperty != null && !constructorProperty.Ignored)
+                {
+                    // handle giving default values to creator parameters
+                    // this needs to happen before the call to creator
+                    if (trackPresence)
+                    {
+                        if (context.Presence == PropertyPresence.None || context.Presence == PropertyPresence.Null)
+                        {
+                            if (constructorProperty.PropertyContract == null)
+                            {
+                                constructorProperty.PropertyContract = GetContractSafe(constructorProperty.PropertyType);
+                            }
+
+                            if (HasFlag(constructorProperty.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Populate))
+                            {
+                                context.Value = EnsureType(reader, constructorProperty.GetResolvedDefaultValue(), CultureInfo.InvariantCulture, constructorProperty.PropertyContract, constructorProperty.PropertyType);
+                            }
+                        }
+                    }
+
+                    creatorParameterValues[contract.CreatorParameters.IndexOf(constructorProperty)] = context.Value;
+
+                    context.Used = true;
+                }
+            }
+
+            object createdObject = creator(creatorParameterValues);
+
+            if (id != null)
+            {
+                AddReference(reader, id, createdObject);
+            }
+
+            OnDeserializing(reader, contract, createdObject);
+
+            // go through unused values and set the newly created object's properties
+            foreach (CreatorPropertyContext context in propertyContexts)
+            {
+                if (context.Used || context.Property == null || context.Property.Ignored || context.Presence == PropertyPresence.None)
+                {
+                    continue;
+                }
+
+                JsonProperty property = context.Property;
+                object value = context.Value;
+
+                if (ShouldSetPropertyValue(property, value))
+                {
+                    property.ValueProvider.SetValue(createdObject, value);
+                    context.Used = true;
+                }
+                else if (!property.Writable && value != null)
+                {
+                    // handle readonly collection/dictionary properties
+                    JsonContract propertyContract = Serializer._contractResolver.ResolveContract(property.PropertyType);
+
+                    if (propertyContract.ContractType == JsonContractType.Array)
+                    {
+                        JsonArrayContract propertyArrayContract = (JsonArrayContract)propertyContract;
+
+                        object createdObjectCollection = property.ValueProvider.GetValue(createdObject);
+                        if (createdObjectCollection != null)
+                        {
+                            IWrappedCollection createdObjectCollectionWrapper = propertyArrayContract.CreateWrapper(createdObjectCollection);
+                            IWrappedCollection newValues = propertyArrayContract.CreateWrapper(value);
+
+                            foreach (object newValue in newValues)
+                            {
+                                createdObjectCollectionWrapper.Add(newValue);
+                            }
+                        }
+                    }
+                    else if (propertyContract.ContractType == JsonContractType.Dictionary)
+                    {
+                        JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)propertyContract;
+
+                        object createdObjectDictionary = property.ValueProvider.GetValue(createdObject);
+                        if (createdObjectDictionary != null)
+                        {
+                            IDictionary targetDictionary = dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(createdObjectDictionary) : (IDictionary)createdObjectDictionary;
+                            IDictionary newValues = dictionaryContract.ShouldCreateWrapper ? dictionaryContract.CreateWrapper(value) : (IDictionary)value;
+
+                            // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+                            IDictionaryEnumerator e = newValues.GetEnumerator();
+                            try
+                            {
+                                while (e.MoveNext())
+                                {
+                                    DictionaryEntry entry = e.Entry;
+                                    targetDictionary[entry.Key] = entry.Value;
+                                }
+                            }
+                            finally
+                            {
+                                (e as IDisposable)?.Dispose();
+                            }
+                        }
+                    }
+
+                    context.Used = true;
+                }
+            }
+
+            if (contract.ExtensionDataSetter != null)
+            {
+                foreach (CreatorPropertyContext propertyValue in propertyContexts)
+                {
+                    if (!propertyValue.Used)
+                    {
+                        contract.ExtensionDataSetter(createdObject, propertyValue.Name, propertyValue.Value);
+                    }
+                }
+            }
+
+            if (trackPresence)
+            {
+                foreach (CreatorPropertyContext context in propertyContexts)
+                {
+                    if (context.Property == null)
+                    {
+                        continue;
+                    }
+
+                    await EndProcessPropertyAsync(createdObject, reader, contract, reader.Depth, context.Property, context.Presence.GetValueOrDefault(), !context.Used, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            OnDeserialized(reader, contract, createdObject);
+            return createdObject;
+        }
+
+        private async Task<List<CreatorPropertyContext>> ResolvePropertyAndCreatorValuesAsync(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            List<CreatorPropertyContext> propertyValues = new List<CreatorPropertyContext>();
+            bool exit = false;
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string memberName = reader.Value.ToString();
+
+                        CreatorPropertyContext creatorPropertyContext = new CreatorPropertyContext {Name = reader.Value.ToString(), ConstructorProperty = contract.CreatorParameters.GetClosestMatchProperty(memberName), Property = contract.Properties.GetClosestMatchProperty(memberName)};
+                        propertyValues.Add(creatorPropertyContext);
+
+                        JsonProperty property = creatorPropertyContext.ConstructorProperty ?? creatorPropertyContext.Property;
+                        if (property != null && !property.Ignored)
+                        {
+                            if (property.PropertyContract == null)
+                            {
+                                property.PropertyContract = GetContractSafe(property.PropertyType);
+                            }
+
+                            JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.MemberConverter, contract, containerProperty);
+
+                            if (!await ReadForTypeAsync(reader, property.PropertyContract, propertyConverter != null, cancellationToken).ConfigureAwait(false))
+                            {
+                                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+                            }
+
+                            if (propertyConverter != null && propertyConverter.CanRead)
+                            {
+                                creatorPropertyContext.Value = await DeserializeConvertableAsync(propertyConverter, reader, property.PropertyType, null, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                creatorPropertyContext.Value = await CreateValueInternalAsync(reader, property.PropertyType, property.PropertyContract, property, contract, containerProperty, null, cancellationToken).ConfigureAwait(false);
+                            }
+
+                            continue;
+                        }
+                        else
+                        {
+                            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                            {
+                                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+                            }
+
+                            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                            {
+                                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}.".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
+                            }
+
+                            if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
+                            {
+                                throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
+                            }
+                        }
+
+                        if (contract.ExtensionDataSetter != null)
+                        {
+                            creatorPropertyContext.Value = await ReadExtensionDataValueAsync(contract, containerProperty, reader, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        exit = true;
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
+                }
+            } while (!exit && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            if (!exit)
+            {
+                ThrowUnexpectedEndException(reader, contract, null, "Unexpected end when deserializing object.");
+            }
+
+            return propertyValues;
+        }
+
+        public async Task<object> DeserializeAsync(JsonReader reader, Type objectType, bool checkAdditionalContent, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            JsonContract contract = GetContractSafe(objectType);
+
+            try
+            {
+                JsonConverter converter = GetConverter(contract, null, null, null);
+
+                if (reader.TokenType == JsonToken.None && !await ReadForTypeAsync(reader, contract, converter != null, cancellationToken).ConfigureAwait(false))
+                {
+                    if (contract != null && !contract.IsNullable)
+                    {
+                        throw JsonSerializationException.Create(reader, "No JSON content found and type '{0}' is not nullable.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+                    }
+
+                    return null;
+                }
+
+                object deserializedValue;
+
+                if (converter != null && converter.CanRead)
+                {
+                    deserializedValue = await DeserializeConvertableAsync(converter, reader, objectType, null, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    deserializedValue = await CreateValueInternalAsync(reader, objectType, contract, null, null, null, null, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (checkAdditionalContent)
+                {
+                    if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false) && reader.TokenType != JsonToken.Comment)
+                    {
+                        throw new JsonSerializationException("Additional text found in JSON string after finishing deserializing object.");
+                    }
+                }
+
+                return deserializedValue;
+            }
+            catch (Exception ex)
+            {
+                if (IsErrorHandled(null, contract, null, reader as IJsonLineInfo, reader.Path, ex))
+                {
+                    await HandleErrorAsync(reader, false, 0, cancellationToken).ConfigureAwait(false);
+                    return null;
+                }
+                else
+                {
+                    // clear context in case serializer is being used inside a converter
+                    // if the converter wraps the error then not clearing the context will cause this error:
+                    // "Current error context error is different to requested error."
+                    ClearErrorContext();
+                    throw;
+                }
+            }
+        }
+
+#if !(PORTABLE40)
+        private async Task<object> CreateDynamicAsync(JsonReader reader, JsonDynamicContract contract, JsonProperty member, string id, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!contract.IsInstantiable)
+            {
+                throw JsonSerializationException.Create(reader, "Could not create an instance of type {0}. Type is an interface or abstract class and cannot be instantiated.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+            }
+
+            IDynamicMetaObjectProvider newObject;
+
+            if (contract.DefaultCreator != null && (!contract.DefaultCreatorNonPublic || Serializer._constructorHandling == ConstructorHandling.AllowNonPublicDefaultConstructor))
+            {
+                newObject = (IDynamicMetaObjectProvider)contract.DefaultCreator();
+            }
+            else
+            {
+                throw JsonSerializationException.Create(reader, "Unable to find a default constructor to use for type {0}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType));
+            }
+
+            if (id != null)
+            {
+                AddReference(reader, id, newObject);
+            }
+
+            OnDeserializing(reader, contract, newObject);
+
+            int initialDepth = reader.Depth;
+
+            bool finished = false;
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string memberName = reader.Value.ToString();
+
+                        try
+                        {
+                            if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                            {
+                                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+                            }
+
+                            // first attempt to find a settable property, otherwise fall back to a dynamic set without type
+                            JsonProperty property = contract.Properties.GetClosestMatchProperty(memberName);
+
+                            if (property != null && property.Writable && !property.Ignored)
+                            {
+                                if (property.PropertyContract == null)
+                                {
+                                    property.PropertyContract = GetContractSafe(property.PropertyType);
+                                }
+
+                                JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.MemberConverter, null, null);
+
+                                if (!await SetPropertyValueAsync(property, propertyConverter, null, member, reader, newObject, cancellationToken).ConfigureAwait(false))
+                                {
+                                    await reader.SkipAsync(cancellationToken).ConfigureAwait(false);
+                                }
+                            }
+                            else
+                            {
+                                Type t = JsonTokenUtils.IsPrimitiveToken(reader.TokenType) ? reader.ValueType : typeof(IDynamicMetaObjectProvider);
+
+                                JsonContract dynamicMemberContract = GetContractSafe(t);
+                                JsonConverter dynamicMemberConverter = GetConverter(dynamicMemberContract, null, null, member);
+
+                                object value;
+                                if (dynamicMemberConverter != null && dynamicMemberConverter.CanRead)
+                                {
+                                    value = await DeserializeConvertableAsync(dynamicMemberConverter, reader, t, null, cancellationToken).ConfigureAwait(false);
+                                }
+                                else
+                                {
+                                    value = await CreateValueInternalAsync(reader, t, dynamicMemberContract, null, null, member, null, cancellationToken).ConfigureAwait(false);
+                                }
+
+                                contract.TrySetMember(newObject, memberName, value);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            if (IsErrorHandled(newObject, contract, memberName, reader as IJsonLineInfo, reader.Path, ex))
+                            {
+                                await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                throw;
+                            }
+                        }
+
+                        break;
+                    case JsonToken.EndObject:
+                        finished = true;
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
+                }
+            } while (!finished && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, newObject, "Unexpected end when deserializing object.");
+            }
+
+            OnDeserialized(reader, contract, newObject);
+
+            return newObject;
+        }
+
+        private async Task<JToken> CreateJObjectAsync(JsonReader reader, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ValidationUtils.ArgumentNotNull(reader, nameof(reader));
+
+            // this is needed because we've already read inside the object, looking for metadata properties
+            using (JTokenWriter writer = new JTokenWriter())
+            {
+                writer.WriteStartObject();
+
+                do
+                {
+                    if (reader.TokenType == JsonToken.PropertyName)
+                    {
+                        string propertyName = (string)reader.Value;
+                        if (!await reader.ReadAndMoveToContentAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            break;
+                        }
+
+                        if (await CheckPropertyNameAsync(reader, propertyName, cancellationToken).ConfigureAwait(false))
+                        {
+                            continue;
+                        }
+
+                        writer.WritePropertyName(propertyName);
+                        await writer.WriteTokenAsync(reader, true, true, false, cancellationToken).ConfigureAwait(false);
+                    }
+                    else if (reader.TokenType == JsonToken.Comment)
+                    {
+                        // eat
+                    }
+                    else
+                    {
+                        await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+                        return writer.Token;
+                    }
+                } while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+                throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
+            }
+        }
+
+        private async Task<object> PopulateMultidimensionalArrayAsync(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, string id, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int rank = contract.UnderlyingType.GetArrayRank();
+
+            if (id != null)
+            {
+                AddReference(reader, id, list);
+            }
+
+            OnDeserializing(reader, contract, list);
+
+            JsonContract collectionItemContract = GetContractSafe(contract.CollectionItemType);
+            JsonConverter collectionItemConverter = GetConverter(collectionItemContract, null, contract, containerProperty);
+
+            int? previousErrorIndex = null;
+            Stack<IList> listStack = new Stack<IList>();
+            listStack.Push(list);
+            IList currentList = list;
+
+            bool finished = false;
+            do
+            {
+                int initialDepth = reader.Depth;
+
+                if (listStack.Count == rank)
+                {
+                    try
+                    {
+                        if (await ReadForTypeAsync(reader, collectionItemContract, collectionItemConverter != null, cancellationToken).ConfigureAwait(false))
+                        {
+                            switch (reader.TokenType)
+                            {
+                                case JsonToken.EndArray:
+                                    listStack.Pop();
+                                    currentList = listStack.Peek();
+                                    previousErrorIndex = null;
+                                    break;
+                                default:
+                                    object value;
+
+                                    if (collectionItemConverter != null && collectionItemConverter.CanRead)
+                                    {
+                                        value = await DeserializeConvertableAsync(collectionItemConverter, reader, contract.CollectionItemType, null, cancellationToken).ConfigureAwait(false);
+                                    }
+                                    else
+                                    {
+                                        value = await CreateValueInternalAsync(reader, contract.CollectionItemType, collectionItemContract, null, contract, containerProperty, null, cancellationToken).ConfigureAwait(false);
+                                    }
+
+                                    currentList.Add(value);
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        JsonPosition errorPosition = reader.GetPosition(initialDepth);
+
+                        if (IsErrorHandled(list, contract, errorPosition.Position, reader as IJsonLineInfo, reader.Path, ex))
+                        {
+                            await HandleErrorAsync(reader, true, initialDepth, cancellationToken).ConfigureAwait(false);
+
+                            if (previousErrorIndex != null && previousErrorIndex == errorPosition.Position)
+                            {
+                                // reader index has not moved since previous error handling
+                                // break out of reading array to prevent infinite loop
+                                throw JsonSerializationException.Create(reader, "Infinite loop detected from error handling.", ex);
+                            }
+                            else
+                            {
+                                previousErrorIndex = errorPosition.Position;
+                            }
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+                else
+                {
+                    if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        switch (reader.TokenType)
+                        {
+                            case JsonToken.StartArray:
+                                IList newList = new List<object>();
+                                currentList.Add(newList);
+                                listStack.Push(newList);
+                                currentList = newList;
+                                break;
+                            case JsonToken.EndArray:
+                                listStack.Pop();
+
+                                if (listStack.Count > 0)
+                                {
+                                    currentList = listStack.Peek();
+                                }
+                                else
+                                {
+                                    finished = true;
+                                }
+                                break;
+                            case JsonToken.Comment:
+                                break;
+                            default:
+                                throw JsonSerializationException.Create(reader, "Unexpected token when deserializing multidimensional array: " + reader.TokenType);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            } while (!finished);
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, list, "Unexpected end when deserializing array.");
+            }
+
+            OnDeserialized(reader, contract, list);
+            return list;
+        }
+#endif
+#if !(DOTNET || PORTABLE40 || PORTABLE)
+        private async Task<object> CreateISerializableAsync(JsonReader reader, JsonISerializableContract contract, JsonProperty member, string id, CancellationToken cancellationToken)
+        {
+            Type objectType = contract.UnderlyingType;
+
+            if (!JsonTypeReflector.FullyTrusted)
+            {
+                string message = @"Type '{0}' implements ISerializable but cannot be deserialized using the ISerializable interface because the current application is not fully trusted and ISerializable can expose secure data." + Environment.NewLine + @"To fix this error either change the environment to be fully trusted, change the application to not deserialize the type, add JsonObjectAttribute to the type or change the JsonSerializer setting ContractResolver to use a new DefaultContractResolver with IgnoreSerializableInterface set to true." + Environment.NewLine;
+                message = message.FormatWith(CultureInfo.InvariantCulture, objectType);
+
+                throw JsonSerializationException.Create(reader, message);
+            }
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+            {
+                TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Deserializing {0} using ISerializable constructor.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType)), null);
+            }
+
+            SerializationInfo serializationInfo = new SerializationInfo(contract.UnderlyingType, new JsonFormatterConverter(this, contract, member));
+
+            bool finished = false;
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.PropertyName:
+                        string memberName = reader.Value.ToString();
+                        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+                        }
+
+                        serializationInfo.AddValue(memberName, JToken.ReadFrom(reader));
+                        break;
+                    case JsonToken.Comment:
+                        break;
+                    case JsonToken.EndObject:
+                        finished = true;
+                        break;
+                    default:
+                        throw JsonSerializationException.Create(reader, "Unexpected token when deserializing object: " + reader.TokenType);
+                }
+            } while (!finished && await reader.ReadAsync(cancellationToken).ConfigureAwait(false));
+
+            if (!finished)
+            {
+                ThrowUnexpectedEndException(reader, contract, serializationInfo, "Unexpected end when deserializing object.");
+            }
+
+            if (contract.ISerializableCreator == null)
+            {
+                throw JsonSerializationException.Create(reader, "ISerializable type '{0}' does not have a valid constructor. To correctly implement ISerializable a constructor that takes SerializationInfo and StreamingContext parameters should be present.".FormatWith(CultureInfo.InvariantCulture, objectType));
+            }
+
+            object createdObject = contract.ISerializableCreator(serializationInfo, Serializer._context);
+
+            if (id != null)
+            {
+                AddReference(reader, id, createdObject);
+            }
+
+            // these are together because OnDeserializing takes an object but for an ISerializable the object is fully created in the constructor
+            OnDeserializing(reader, contract, createdObject);
+            OnDeserialized(reader, contract, createdObject);
+
+            return createdObject;
+        }
+#endif
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -49,7 +49,7 @@ using System.Linq;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal class JsonSerializerInternalReader : JsonSerializerInternalBase
+    internal partial class JsonSerializerInternalReader : JsonSerializerInternalBase
     {
         internal enum PropertyPresence
         {

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.Async.cs
@@ -1,0 +1,866 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Dynamic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Utilities;
+
+namespace Newtonsoft.Json.Serialization
+{
+    internal partial class JsonSerializerInternalWriter
+    {
+        public async Task SerializeAsync(JsonWriter jsonWriter, object value, Type objectType, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (jsonWriter == null)
+            {
+                throw new ArgumentNullException(nameof(jsonWriter));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _rootType = objectType;
+            _rootLevel = _serializeStack.Count + 1;
+
+            JsonContract contract = GetContractSafe(value);
+
+            try
+            {
+                if (ShouldWriteReference(value, null, contract, null, null))
+                {
+                    await WriteReferenceAsync(jsonWriter, value, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await SerializeValueAsync(jsonWriter, value, contract, null, null, null, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (IsErrorHandled(null, contract, null, null, jsonWriter.Path, ex))
+                {
+                    await HandleErrorAsync(jsonWriter, 0, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // clear context in case serializer is being used inside a converter
+                    // if the converter wraps the error then not clearing the context will cause this error:
+                    // "Current error context error is different to requested error."
+                    ClearErrorContext();
+                    throw;
+                }
+            }
+            finally
+            {
+                // clear root contract to ensure that if level was > 1 then it won't
+                // accidently be used for non root values
+                _rootType = null;
+            }
+        }
+
+        private async Task WriteReferenceAsync(JsonWriter writer, object value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string reference = GetReference(writer, value);
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+            {
+                TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(null, writer.Path, "Writing object reference to Id '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, reference, value.GetType())), null);
+            }
+
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+            await writer.WritePropertyNameAsync(JsonTypeReflector.RefPropertyName, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(reference, cancellationToken).ConfigureAwait(false);
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private Task SerializeValueAsync(JsonWriter writer, object value, JsonContract valueContract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+            if (value == null)
+            {
+                return writer.WriteNullAsync(cancellationToken);
+            }
+
+            JsonConverter converter =
+                member?.Converter ??
+                containerProperty?.ItemConverter ??
+                containerContract?.ItemConverter ??
+                valueContract.Converter ??
+                Serializer.GetMatchingConverter(valueContract.UnderlyingType) ??
+                valueContract.InternalConverter;
+
+            if (converter != null && converter.CanWrite)
+            {
+                return SerializeConvertableAsync(writer, converter, value, valueContract, containerContract, containerProperty, cancellationToken);
+            }
+
+            switch (valueContract.ContractType)
+            {
+                case JsonContractType.Object:
+                    return SerializeObjectAsync(writer, value, (JsonObjectContract)valueContract, member, containerContract, containerProperty, cancellationToken);
+                case JsonContractType.Array:
+                    JsonArrayContract arrayContract = (JsonArrayContract)valueContract;
+                    if (!arrayContract.IsMultidimensionalArray)
+                    {
+                        return SerializeListAsync(writer, (IEnumerable)value, arrayContract, member, containerContract, containerProperty, cancellationToken);
+                    }
+
+                    return SerializeMultidimensionalArrayAsync(writer, (Array)value, arrayContract, member, containerContract, containerProperty, cancellationToken);
+                case JsonContractType.Primitive:
+                    return SerializePrimitiveAsync(writer, value, (JsonPrimitiveContract)valueContract, member, containerContract, containerProperty, cancellationToken);
+                case JsonContractType.String:
+                    return SerializeStringAsync(writer, value, (JsonStringContract)valueContract, cancellationToken);
+                case JsonContractType.Dictionary:
+                    JsonDictionaryContract dictionaryContract = (JsonDictionaryContract)valueContract;
+                    return SerializeDictionaryAsync(writer, value is IDictionary ? (IDictionary)value : dictionaryContract.CreateWrapper(value), dictionaryContract, member, containerContract, containerProperty, cancellationToken);
+                case JsonContractType.Dynamic:
+                    return SerializeDynamicAsync(writer, (IDynamicMetaObjectProvider)value, (JsonDynamicContract)valueContract, member, containerContract, containerProperty, cancellationToken);
+#if !(DOTNET || PORTABLE)
+                case JsonContractType.Serializable:
+                    return SerializeISerializableAsync(writer, (ISerializable)value, (JsonISerializableContract)valueContract, member, containerContract, containerProperty, cancellationToken);
+#endif
+                case JsonContractType.Linq:
+                    return ((JToken)value).WriteToAsync(writer, cancellationToken, Serializer.Converters.ToArray());
+            }
+
+            return AsyncUtils.CompletedTask;
+        }
+
+        private async Task SerializeConvertableAsync(JsonWriter writer, JsonConverter converter, object value, JsonContract contract, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            if (ShouldWriteReference(value, null, contract, collectionContract, containerProperty))
+            {
+                await WriteReferenceAsync(writer, value, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (!CheckForCircularReference(writer, value, null, contract, collectionContract, containerProperty))
+                {
+                    return;
+                }
+
+                _serializeStack.Add(value);
+
+                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+                {
+                    TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(null, writer.Path, "Started serializing {0} with converter {1}.".FormatWith(CultureInfo.InvariantCulture, value.GetType(), converter.GetType())), null);
+                }
+
+                await converter.WriteJsonAsync(writer, value, GetInternalSerializer(), cancellationToken).ConfigureAwait(false);
+
+                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
+                {
+                    TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(null, writer.Path, "Finished serializing {0} with converter {1}.".FormatWith(CultureInfo.InvariantCulture, value.GetType(), converter.GetType())), null);
+                }
+
+                _serializeStack.RemoveAt(_serializeStack.Count - 1);
+            }
+        }
+
+        private async Task SerializeObjectAsync(JsonWriter writer, object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OnSerializing(writer, contract, value);
+
+            _serializeStack.Add(value);
+
+            await WriteObjectStartAsync(writer, value, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            int initialDepth = writer.Top;
+
+            for (int index = 0; index < contract.Properties.Count; index++)
+            {
+                JsonProperty property = contract.Properties[index];
+                try
+                {
+                    Tuple<object, JsonContract> propValues = await CalculatePropertyValuesAsync(writer, value, contract, member, property, cancellationToken).ConfigureAwait(false);
+                    if (propValues == null)
+                    {
+                        continue;
+                    }
+
+                    await property.WritePropertyNameAsync(writer, cancellationToken).ConfigureAwait(false);
+                    await SerializeValueAsync(writer, propValues.Item1, propValues.Item2, property, contract, member, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    if (IsErrorHandled(value, contract, property.PropertyName, null, writer.ContainerPath, ex))
+                    {
+                        await HandleErrorAsync(writer, initialDepth, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            IEnumerable<KeyValuePair<object, object>> extensionData = contract.ExtensionDataGetter?.Invoke(value);
+            if (extensionData != null)
+            {
+                foreach (KeyValuePair<object, object> e in extensionData)
+                {
+                    JsonContract keyContract = GetContractSafe(e.Key);
+                    JsonContract valueContract = GetContractSafe(e.Value);
+
+                    string propertyName = (await GetPropertyNameAsync(writer, e.Key, keyContract, cancellationToken).ConfigureAwait(false)).Item1;
+
+                    if (ShouldWriteReference(e.Value, null, valueContract, contract, member))
+                    {
+                        await writer.WritePropertyNameAsync(propertyName, cancellationToken).ConfigureAwait(false);
+                        await WriteReferenceAsync(writer, e.Value, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (!CheckForCircularReference(writer, e.Value, null, valueContract, contract, member))
+                        {
+                            continue;
+                        }
+
+                        await writer.WritePropertyNameAsync(propertyName, cancellationToken).ConfigureAwait(false);
+
+                        await SerializeValueAsync(writer, e.Value, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+
+            OnSerialized(writer, contract, value);
+        }
+
+        private async Task SerializeListAsync(JsonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IWrappedCollection wrappedCollection = values as IWrappedCollection;
+            object underlyingList = wrappedCollection != null ? wrappedCollection.UnderlyingCollection : values;
+
+            OnSerializing(writer, contract, underlyingList);
+
+            _serializeStack.Add(underlyingList);
+
+            bool hasWrittenMetadataObject = await WriteStartArrayAsync(writer, underlyingList, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            int initialDepth = writer.Top;
+
+            int index = 0;
+            // note that an error in the IEnumerable won't be caught
+            foreach (object value in values)
+            {
+                try
+                {
+                    JsonContract valueContract = contract.FinalItemContract ?? GetContractSafe(value);
+
+                    if (ShouldWriteReference(value, null, valueContract, contract, member))
+                    {
+                        await WriteReferenceAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (CheckForCircularReference(writer, value, null, valueContract, contract, member))
+                        {
+                            await SerializeValueAsync(writer, value, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (IsErrorHandled(underlyingList, contract, index, null, writer.ContainerPath, ex))
+                    {
+                        await HandleErrorAsync(writer, initialDepth, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                finally
+                {
+                    index++;
+                }
+            }
+
+            await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            if (hasWrittenMetadataObject)
+            {
+                await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+
+            OnSerialized(writer, contract, underlyingList);
+        }
+
+        private async Task SerializeMultidimensionalArrayAsync(JsonWriter writer, Array values, JsonArrayContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            OnSerializing(writer, contract, values);
+
+            _serializeStack.Add(values);
+
+            bool hasWrittenMetadataObject = await WriteStartArrayAsync(writer, values, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            await SerializeMultidimensionalArrayAsync(writer, values, contract, member, writer.Top, new int[0], cancellationToken).ConfigureAwait(false);
+
+            if (hasWrittenMetadataObject)
+            {
+                await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+
+            OnSerialized(writer, contract, values);
+        }
+
+        private async Task HandleErrorAsync(JsonWriter writer, int initialDepth, CancellationToken cancellationToken)
+        {
+            ClearErrorContext();
+
+            if (writer.WriteState == WriteState.Property)
+            {
+                await writer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            while (writer.Top > initialDepth)
+            {
+                await writer.WriteEndAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task SerializePrimitiveAsync(JsonWriter writer, object value, JsonPrimitiveContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (contract.TypeCode == PrimitiveTypeCode.Bytes)
+            {
+                // if type name handling is enabled then wrap the base64 byte string in an object with the type name
+                bool includeTypeDetails = ShouldWriteType(TypeNameHandling.Objects, contract, member, containerContract, containerProperty);
+                if (includeTypeDetails)
+                {
+                    await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+                    await WriteTypePropertyAsync(writer, contract.CreatedType, cancellationToken).ConfigureAwait(false);
+                    await writer.WritePropertyNameAsync(JsonTypeReflector.ValuePropertyName, false, cancellationToken).ConfigureAwait(false);
+
+                    await JsonWriter.WriteValueAsync(writer, contract.TypeCode, value, cancellationToken).ConfigureAwait(false);
+
+                    await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+            }
+
+            await JsonWriter.WriteValueAsync(writer, contract.TypeCode, value, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task SerializeStringAsync(JsonWriter writer, object value, JsonStringContract contract, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OnSerializing(writer, contract, value);
+
+            string s;
+            TryConvertToString(value, contract.UnderlyingType, out s);
+            await writer.WriteValueAsync(s, cancellationToken).ConfigureAwait(false);
+
+            OnSerialized(writer, contract, value);
+        }
+
+        private async Task SerializeDictionaryAsync(JsonWriter writer, IDictionary values, JsonDictionaryContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            IWrappedDictionary wrappedDictionary = values as IWrappedDictionary;
+            object underlyingDictionary = wrappedDictionary != null ? wrappedDictionary.UnderlyingDictionary : values;
+
+            OnSerializing(writer, contract, underlyingDictionary);
+            _serializeStack.Add(underlyingDictionary);
+
+            await WriteObjectStartAsync(writer, underlyingDictionary, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            if (contract.ItemContract == null)
+            {
+                contract.ItemContract = Serializer._contractResolver.ResolveContract(contract.DictionaryValueType ?? typeof(object));
+            }
+
+            if (contract.KeyContract == null)
+            {
+                contract.KeyContract = Serializer._contractResolver.ResolveContract(contract.DictionaryKeyType ?? typeof(object));
+            }
+
+            int initialDepth = writer.Top;
+
+            // Manual use of IDictionaryEnumerator instead of foreach to avoid DictionaryEntry box allocations.
+            IDictionaryEnumerator e = values.GetEnumerator();
+            try
+            {
+                while (e.MoveNext())
+                {
+                    DictionaryEntry entry = e.Entry;
+
+                    var propNameAndEscape = await GetPropertyNameAsync(writer, entry.Key, contract.KeyContract, cancellationToken).ConfigureAwait(false);
+                    string propertyName = propNameAndEscape.Item1;
+                    bool escape = propNameAndEscape.Item2;
+
+                    propertyName = contract.DictionaryKeyResolver != null
+                        ? contract.DictionaryKeyResolver(propertyName)
+                        : propertyName;
+
+                    try
+                    {
+                        object value = entry.Value;
+                        JsonContract valueContract = contract.FinalItemContract ?? GetContractSafe(value);
+
+                        if (ShouldWriteReference(value, null, valueContract, contract, member))
+                        {
+                            await writer.WritePropertyNameAsync(propertyName, escape, cancellationToken).ConfigureAwait(false);
+                            await WriteReferenceAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            if (!CheckForCircularReference(writer, value, null, valueContract, contract, member))
+                            {
+                                continue;
+                            }
+
+                            await writer.WritePropertyNameAsync(propertyName, escape, cancellationToken).ConfigureAwait(false);
+
+                            await SerializeValueAsync(writer, value, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (IsErrorHandled(underlyingDictionary, contract, propertyName, null, writer.ContainerPath, ex))
+                        {
+                            await HandleErrorAsync(writer, initialDepth, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                (e as IDisposable)?.Dispose();
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+
+            OnSerialized(writer, contract, underlyingDictionary);
+        }
+
+        private async Task<Tuple<string, bool>> GetPropertyNameAsync(JsonWriter writer, object name, JsonContract contract, CancellationToken cancellationToken)
+        {
+            string propertyName;
+
+            if (contract.ContractType == JsonContractType.Primitive)
+            {
+                JsonPrimitiveContract primitiveContract = (JsonPrimitiveContract)contract;
+                switch (primitiveContract.TypeCode)
+                {
+                    case PrimitiveTypeCode.DateTime:
+                    case PrimitiveTypeCode.DateTimeNullable:
+                        {
+                            DateTime dt = DateTimeUtils.EnsureDateTime((DateTime)name, writer.DateTimeZoneHandling);
+
+                            StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+                            await DateTimeUtils.WriteDateTimeStringAsync(sw, dt, writer.DateFormatHandling, writer.DateFormatString, writer.Culture, cancellationToken).ConfigureAwait(false);
+                            return Tuple.Create(sw.ToString(), false);
+                        }
+                    case PrimitiveTypeCode.DateTimeOffset:
+                    case PrimitiveTypeCode.DateTimeOffsetNullable:
+                        {
+                            StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+                            await DateTimeUtils.WriteDateTimeOffsetStringAsync(sw, (DateTimeOffset)name, writer.DateFormatHandling, writer.DateFormatString, writer.Culture, cancellationToken).ConfigureAwait(false);
+                            return Tuple.Create(sw.ToString(), false);
+                        }
+                    case PrimitiveTypeCode.Double:
+                    case PrimitiveTypeCode.DoubleNullable:
+                        {
+                            double d = (double)name;
+
+                            return Tuple.Create(d.ToString("R", CultureInfo.InvariantCulture), false);
+                        }
+                    case PrimitiveTypeCode.Single:
+                    case PrimitiveTypeCode.SingleNullable:
+                        {
+                            float f = (float)name;
+
+                            return Tuple.Create(f.ToString("R", CultureInfo.InvariantCulture), false);
+                        }
+                    default:
+                        {
+                            return Tuple.Create(Convert.ToString(name, CultureInfo.InvariantCulture), true);
+                        }
+                }
+            }
+            else if (TryConvertToString(name, name.GetType(), out propertyName))
+            {
+                return Tuple.Create(propertyName, true);
+            }
+            else
+            {
+                return Tuple.Create(name.ToString(), true);
+            }
+        }
+
+        private async Task SerializeDynamicAsync(JsonWriter writer, IDynamicMetaObjectProvider value, JsonDynamicContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OnSerializing(writer, contract, value);
+            _serializeStack.Add(value);
+
+            await WriteObjectStartAsync(writer, value, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            int initialDepth = writer.Top;
+
+            for (int index = 0; index < contract.Properties.Count; index++)
+            {
+                JsonProperty property = contract.Properties[index];
+
+                // only write non-dynamic properties that have an explicit attribute
+                if (property.HasMemberAttribute)
+                {
+                    try
+                    {
+                        Tuple<object, JsonContract> propValues = await CalculatePropertyValuesAsync(writer, value, contract, member, property, cancellationToken).ConfigureAwait(false);
+
+                        if (propValues == null)
+                        {
+                            continue;
+                        }
+
+                        await property.WritePropertyNameAsync(writer, cancellationToken).ConfigureAwait(false);
+                        await SerializeValueAsync(writer, propValues.Item1, propValues.Item2, property, contract, member, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (IsErrorHandled(value, contract, property.PropertyName, null, writer.ContainerPath, ex))
+                        {
+                            await HandleErrorAsync(writer, initialDepth, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+
+            foreach (string memberName in value.GetDynamicMemberNames())
+            {
+                object memberValue;
+                if (contract.TryGetMember(value, memberName, out memberValue))
+                {
+                    try
+                    {
+                        JsonContract valueContract = GetContractSafe(memberValue);
+
+                        if (!ShouldWriteDynamicProperty(memberValue))
+                        {
+                            continue;
+                        }
+
+                        if (CheckForCircularReference(writer, memberValue, null, valueContract, contract, member))
+                        {
+                            string resolvedPropertyName = contract.PropertyNameResolver != null
+                                ? contract.PropertyNameResolver(memberName)
+                                : memberName;
+
+                            await writer.WritePropertyNameAsync(resolvedPropertyName, cancellationToken).ConfigureAwait(false);
+                            await SerializeValueAsync(writer, memberValue, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (IsErrorHandled(value, contract, memberName, null, writer.ContainerPath, ex))
+                        {
+                            await HandleErrorAsync(writer, initialDepth, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+            OnSerialized(writer, contract, value);
+        }
+
+#if !(DOTNET || PORTABLE)
+        [SecuritySafeCritical]
+        private static void GetObjectData(ISerializable value, SerializationInfo info, StreamingContext context)
+        {
+            value.GetObjectData(info, context);
+        }
+
+        private async Task SerializeISerializableAsync(JsonWriter writer, ISerializable value, JsonISerializableContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!JsonTypeReflector.FullyTrusted)
+            {
+                string message = @"Type '{0}' implements ISerializable but cannot be serialized using the ISerializable interface because the current application is not fully trusted and ISerializable can expose secure data." + Environment.NewLine +
+                                 @"To fix this error either change the environment to be fully trusted, change the application to not deserialize the type, add JsonObjectAttribute to the type or change the JsonSerializer setting ContractResolver to use a new DefaultContractResolver with IgnoreSerializableInterface set to true." + Environment.NewLine;
+                message = message.FormatWith(CultureInfo.InvariantCulture, value.GetType());
+
+                throw JsonSerializationException.Create(null, writer.ContainerPath, message, null);
+            }
+
+            OnSerializing(writer, contract, value);
+            _serializeStack.Add(value);
+
+            await WriteObjectStartAsync(writer, value, contract, member, collectionContract, containerProperty, cancellationToken).ConfigureAwait(false);
+
+            SerializationInfo serializationInfo = new SerializationInfo(contract.UnderlyingType, new FormatterConverter());
+            GetObjectData(value, serializationInfo, Serializer._context);
+
+            foreach (SerializationEntry serializationEntry in serializationInfo)
+            {
+                JsonContract valueContract = GetContractSafe(serializationEntry.Value);
+
+                if (ShouldWriteReference(serializationEntry.Value, null, valueContract, contract, member))
+                {
+                    await writer.WritePropertyNameAsync(serializationEntry.Name, cancellationToken).ConfigureAwait(false);
+                    await WriteReferenceAsync(writer, serializationEntry.Value, cancellationToken).ConfigureAwait(false);
+                }
+                else if (CheckForCircularReference(writer, serializationEntry.Value, null, valueContract, contract, member))
+                {
+                    await writer.WritePropertyNameAsync(serializationEntry.Name, cancellationToken).ConfigureAwait(false);
+                    await SerializeValueAsync(writer, serializationEntry.Value, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            await writer.WriteEndObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            _serializeStack.RemoveAt(_serializeStack.Count - 1);
+            OnSerialized(writer, contract, value);
+        }
+#endif
+        private async Task WriteObjectStartAsync(JsonWriter writer, object value, JsonContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+            bool isReference = ResolveIsReference(contract, member, collectionContract, containerProperty) ?? HasFlag(Serializer._preserveReferencesHandling, PreserveReferencesHandling.Objects);
+            // don't make readonly fields that aren't creator parameters the referenced value because they can't be deserialized to
+            if (isReference && (member == null || member.Writable || HasCreatorParameter(collectionContract, member)))
+            {
+                await WriteReferenceIdPropertyAsync(writer, contract.UnderlyingType, value, cancellationToken).ConfigureAwait(false);
+            }
+            if (ShouldWriteType(TypeNameHandling.Objects, contract, member, collectionContract, containerProperty))
+            {
+                await WriteTypePropertyAsync(writer, contract.UnderlyingType, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<Tuple<object, JsonContract>> CalculatePropertyValuesAsync(JsonWriter writer, object value, JsonContainerContract contract, JsonProperty member, JsonProperty property, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!property.Ignored && property.Readable && ShouldSerialize(writer, property, value) && IsSpecified(writer, property, value))
+            {
+                if (property.PropertyContract == null)
+                {
+                    property.PropertyContract = Serializer._contractResolver.ResolveContract(property.PropertyType);
+                }
+
+                object memberValue = property.ValueProvider.GetValue(value);
+                JsonContract memberContract = property.PropertyContract.IsSealed ? property.PropertyContract : GetContractSafe(memberValue);
+
+                if (ShouldWriteProperty(memberValue, property))
+                {
+                    if (ShouldWriteReference(memberValue, property, memberContract, contract, member))
+                    {
+                        await property.WritePropertyNameAsync(writer, cancellationToken).ConfigureAwait(false);
+                        await WriteReferenceAsync(writer, memberValue, cancellationToken).ConfigureAwait(false);
+                        return null;
+                    }
+
+                    if (!CheckForCircularReference(writer, memberValue, property, memberContract, contract, member))
+                    {
+                        return null;
+                    }
+
+                    if (memberValue == null)
+                    {
+                        JsonObjectContract objectContract = contract as JsonObjectContract;
+                        Required resolvedRequired = property._required ?? objectContract?.ItemRequired ?? Required.Default;
+                        if (resolvedRequired == Required.Always)
+                        {
+                            throw JsonSerializationException.Create(null, writer.ContainerPath, "Cannot write a null value for property '{0}'. Property requires a value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName), null);
+                        }
+                        if (resolvedRequired == Required.DisallowNull)
+                        {
+                            throw JsonSerializationException.Create(null, writer.ContainerPath, "Cannot write a null value for property '{0}'. Property requires a non-null value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName), null);
+                        }
+                    }
+
+                    return Tuple.Create(memberValue, memberContract);
+                }
+            }
+
+            return null;
+        }
+
+        private async Task<bool> WriteStartArrayAsync(JsonWriter writer, object values, JsonArrayContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty, CancellationToken cancellationToken)
+        {
+            bool isReference = ResolveIsReference(contract, member, containerContract, containerProperty) ?? HasFlag(Serializer._preserveReferencesHandling, PreserveReferencesHandling.Arrays);
+            // don't make readonly fields that aren't creator parameters the referenced value because they can't be deserialized to
+            isReference = isReference && (member == null || member.Writable || HasCreatorParameter(containerContract, member));
+
+            bool includeTypeDetails = ShouldWriteType(TypeNameHandling.Arrays, contract, member, containerContract, containerProperty);
+            bool writeMetadataObject = isReference || includeTypeDetails;
+
+            if (writeMetadataObject)
+            {
+                await writer.WriteStartObjectAsync(cancellationToken).ConfigureAwait(false);
+
+                if (isReference)
+                {
+                    await WriteReferenceIdPropertyAsync(writer, contract.UnderlyingType, values, cancellationToken).ConfigureAwait(false);
+                }
+                if (includeTypeDetails)
+                {
+                    await WriteTypePropertyAsync(writer, values.GetType(), cancellationToken).ConfigureAwait(false);
+                }
+                await writer.WritePropertyNameAsync(JsonTypeReflector.ArrayValuesPropertyName, false, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (contract.ItemContract == null)
+            {
+                contract.ItemContract = Serializer._contractResolver.ResolveContract(contract.CollectionItemType ?? typeof(object));
+            }
+
+            return writeMetadataObject;
+        }
+
+        private async Task SerializeMultidimensionalArrayAsync(JsonWriter writer, Array values, JsonArrayContract contract, JsonProperty member, int initialDepth, int[] indices, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int dimension = indices.Length;
+            int[] newIndices = new int[dimension + 1];
+            for (int i = 0; i < dimension; i++)
+            {
+                newIndices[i] = indices[i];
+            }
+
+            await writer.WriteStartArrayAsync(cancellationToken).ConfigureAwait(false);
+
+            for (int i = values.GetLowerBound(dimension); i <= values.GetUpperBound(dimension); i++)
+            {
+                newIndices[dimension] = i;
+                bool isTopLevel = newIndices.Length == values.Rank;
+
+                if (isTopLevel)
+                {
+                    object value = values.GetValue(newIndices);
+
+                    try
+                    {
+                        JsonContract valueContract = contract.FinalItemContract ?? GetContractSafe(value);
+
+                        if (ShouldWriteReference(value, null, valueContract, contract, member))
+                        {
+                            await WriteReferenceAsync(writer, value, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            if (CheckForCircularReference(writer, value, null, valueContract, contract, member))
+                            {
+                                await SerializeValueAsync(writer, value, valueContract, null, contract, member, cancellationToken).ConfigureAwait(false);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (IsErrorHandled(values, contract, i, null, writer.ContainerPath, ex))
+                        {
+                            await HandleErrorAsync(writer, initialDepth + 1, cancellationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+                else
+                {
+                    await SerializeMultidimensionalArrayAsync(writer, values, contract, member, initialDepth + 1, newIndices, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            await writer.WriteEndArrayAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteTypePropertyAsync(JsonWriter writer, Type type, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormatHandling, Serializer._serializationBinder);
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+            {
+                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
+            }
+
+            await writer.WritePropertyNameAsync(JsonTypeReflector.TypePropertyName, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(typeName, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteReferenceIdPropertyAsync(JsonWriter writer, Type type, object value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string reference = GetReference(writer, value);
+
+            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+            {
+                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing object reference Id '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, reference, type)), null);
+            }
+
+            await writer.WritePropertyNameAsync(JsonTypeReflector.IdPropertyName, false, cancellationToken).ConfigureAwait(false);
+            await writer.WriteValueAsync(reference, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.Async.cs
@@ -241,6 +241,10 @@ namespace Newtonsoft.Json.Serialization
 
                     string propertyName = (await GetPropertyNameAsync(writer, e.Key, keyContract, cancellationToken).ConfigureAwait(false)).Item1;
 
+                    propertyName = contract.ExtensionDataNameResolver != null
+                            ? contract.ExtensionDataNameResolver(propertyName)
+                            : propertyName;
+
                     if (ShouldWriteReference(e.Value, null, valueContract, contract, member))
                     {
                         await writer.WritePropertyNameAsync(propertyName, cancellationToken).ConfigureAwait(false);

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -46,7 +46,7 @@ using System.Linq;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal class JsonSerializerInternalWriter : JsonSerializerInternalBase
+    internal partial class JsonSerializerInternalWriter : JsonSerializerInternalBase
     {
         private Type _rootType;
         private int _rootLevel;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.Async.cs
@@ -1,0 +1,59 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Serialization
+{
+    internal partial class JsonSerializerProxy
+    {
+        internal override Task<object> DeserializeInternalAsync(JsonReader reader, Type objectType, CancellationToken cancellationToken)
+        {
+            return _serializerReader != null
+                ? _serializerReader.DeserializeAsync(reader, objectType, false, cancellationToken)
+                : _serializer.DeserializeAsync(reader, objectType, cancellationToken);
+        }
+
+        internal override Task SerializeInternalAsync(JsonWriter jsonWriter, object value, Type rootType, CancellationToken cancellationToken)
+        {
+            return _serializerWriter != null
+                ? _serializerWriter.SerializeAsync(jsonWriter, value, rootType, cancellationToken)
+                : _serializer.SerializeAsync(jsonWriter, value, cancellationToken);
+        }
+
+        internal override Task PopulateInternalAsync(JsonReader reader, object target, CancellationToken cancellationToken)
+        {
+            return _serializerReader != null
+                ? _serializerReader.PopulateAsync(reader, target, cancellationToken)
+                : _serializer.PopulateAsync(reader, target, cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.cs
@@ -32,7 +32,7 @@ using System.Runtime.Serialization;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal class JsonSerializerProxy : JsonSerializer
+    internal partial class JsonSerializerProxy : JsonSerializer
     {
         private readonly JsonSerializerInternalReader _serializerReader;
         private readonly JsonSerializerInternalWriter _serializerWriter;

--- a/Src/Newtonsoft.Json/Serialization/TraceJsonReader.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/TraceJsonReader.Async.cs
@@ -1,0 +1,101 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Serialization
+{
+    internal partial class TraceJsonReader
+    {
+        public override async Task<bool> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            bool value = await _innerReader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<int?> ReadAsInt32Async(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            int? value = await _innerReader.ReadAsInt32Async(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<bool?> ReadAsBooleanAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            bool? value = await _innerReader.ReadAsBooleanAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<byte[]> ReadAsBytesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            byte[] value = await _innerReader.ReadAsBytesAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<DateTime?> ReadAsDateTimeAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            DateTime? value = await _innerReader.ReadAsDateTimeAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<DateTimeOffset?> ReadAsDateTimeOffsetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            DateTimeOffset? value = await _innerReader.ReadAsDateTimeOffsetAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<decimal?> ReadAsDecimalAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            decimal? value = await _innerReader.ReadAsDecimalAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<double?> ReadAsDoubleAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            double? value = await _innerReader.ReadAsDoubleAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+
+        public override async Task<string> ReadAsStringAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            string value = await _innerReader.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _textWriter.WriteToken(_innerReader, false, false, true);
+            return value;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/TraceJsonReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/TraceJsonReader.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal class TraceJsonReader : JsonReader, IJsonLineInfo
+    internal partial class TraceJsonReader : JsonReader, IJsonLineInfo
     {
         private readonly JsonReader _innerReader;
         private readonly JsonTextWriter _textWriter;
@@ -20,7 +20,7 @@ namespace Newtonsoft.Json.Serialization
             // prefix the message in the stringwriter to avoid concat with a potentially large JSON string
             _sw.Write("Deserialized JSON: " + Environment.NewLine);
 
-            _textWriter = new JsonTextWriter(_sw);
+            _textWriter = new JsonTextWriterImpl(_sw);
             _textWriter.Formatting = Formatting.Indented;
         }
 

--- a/Src/Newtonsoft.Json/Serialization/TraceJsonWriter.Async.cs
+++ b/Src/Newtonsoft.Json/Serialization/TraceJsonWriter.Async.cs
@@ -1,0 +1,651 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+#if !PORTABLE || NETSTANDARD1_1
+using System.Numerics;
+#endif
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Serialization
+{
+    internal partial class TraceJsonWriter
+    {
+        public override Task WriteValueAsync(bool value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(bool? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+            return t;
+        }
+
+        public override Task WriteValueAsync(byte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(byte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(byte[] value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value != null)
+            {
+                base.WriteValue(value);
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(char value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(char? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(DateTime value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(DateTime? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(DateTimeOffset value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(DateTimeOffset? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(decimal value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(decimal? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(double value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(double? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(float value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(float? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(Guid value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(Guid? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(int value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(int? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(long value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(long? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(object value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+#if !PORTABLE || NETSTANDARD1_1
+            if (value is BigInteger)
+            {
+                InternalWriteValue(JsonToken.Integer);
+            }
+            else
+#endif
+            {
+                if (value != null)
+                {
+                    base.WriteValue(value);
+                }
+                else
+                {
+                    base.WriteNull();
+                }
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(sbyte value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(sbyte? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+            return t;
+        }
+
+        public override Task WriteValueAsync(short value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(short? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(string value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value != null)
+            {
+                base.WriteValue(value);
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(TimeSpan value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(TimeSpan? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(uint value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(uint? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(ulong value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(ulong? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(Uri value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value != null)
+            {
+                base.WriteValue(value);
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteValueAsync(ushort value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            base.WriteValue(value);
+            return t;
+        }
+
+        public override Task WriteValueAsync(ushort? value, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteValueAsync(value, cancellationToken);
+            _textWriter.WriteValue(value);
+            if (value.HasValue)
+            {
+                base.WriteValue(value.GetValueOrDefault());
+            }
+            else
+            {
+                base.WriteNull();
+            }
+
+            return t;
+        }
+
+        public override Task WriteUndefinedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteUndefinedAsync(cancellationToken);
+            _textWriter.WriteUndefined();
+            base.WriteUndefined();
+            return t;
+        }
+
+        public override Task WriteWhitespaceAsync(string ws, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteWhitespaceAsync(ws, cancellationToken);
+            _textWriter.WriteWhitespace(ws);
+            base.WriteWhitespace(ws);
+            return t;
+        }
+
+        public override Task CloseAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.CloseAsync(cancellationToken);
+            _textWriter.Close();
+            base.Close();
+            return t;
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.FlushAsync(cancellationToken);
+            _textWriter.Flush();
+            return t;
+        }
+
+        public override Task WriteRawAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteRawAsync(json, cancellationToken);
+            _textWriter.WriteRaw(json);
+            base.WriteRaw(json);
+            return t;
+        }
+
+        public override Task WriteEndArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteEndArrayAsync(cancellationToken);
+            _textWriter.WriteEndArray();
+            base.WriteEndArray();
+            return t;
+        }
+
+        public override Task WriteEndConstructorAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteEndConstructorAsync(cancellationToken);
+            _textWriter.WriteEndConstructor();
+            base.WriteEndConstructor();
+            return t;
+        }
+
+        public override Task WriteEndObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteEndObjectAsync(cancellationToken);
+            _textWriter.WriteEndObject();
+            base.WriteEndObject();
+            return t;
+        }
+
+        public override Task WriteNullAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteNullAsync(cancellationToken);
+            _textWriter.WriteNull();
+            base.WriteUndefined();
+            return t;
+        }
+
+        public override Task WritePropertyNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WritePropertyNameAsync(name, cancellationToken);
+            _textWriter.WritePropertyName(name);
+            base.WritePropertyName(name);
+            return t;
+        }
+
+        public override Task WritePropertyNameAsync(string name, bool escape, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WritePropertyNameAsync(name, escape, cancellationToken);
+            _textWriter.WritePropertyName(name, escape);
+
+            // method with escape will error
+            base.WritePropertyName(name);
+            return t;
+        }
+
+        public override Task WriteStartArrayAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteStartArrayAsync(cancellationToken);
+            _textWriter.WriteStartArray();
+            base.WriteStartArray();
+            return t;
+        }
+
+        public override Task WriteCommentAsync(string text, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteCommentAsync(text, cancellationToken);
+            _textWriter.WriteComment(text);
+            base.WriteComment(text);
+            return t;
+        }
+
+        public override Task WriteRawValueAsync(string json, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteRawValueAsync(json, cancellationToken);
+            _textWriter.WriteRawValue(json);
+
+            // calling base method will write json twice
+            InternalWriteValue(JsonToken.Undefined);
+            return t;
+        }
+
+        public override Task WriteStartConstructorAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteStartConstructorAsync(name, cancellationToken);
+            _textWriter.WriteStartConstructor(name);
+            base.WriteStartConstructor(name);
+            return t;
+        }
+
+        public override Task WriteStartObjectAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Task t = _innerWriter.WriteStartObjectAsync(cancellationToken);
+            _textWriter.WriteStartObject();
+            base.WriteStartObject();
+            return t;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Serialization/TraceJsonWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/TraceJsonWriter.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal class TraceJsonWriter : JsonWriter
+    internal partial class TraceJsonWriter : JsonWriter
     {
         private readonly JsonWriter _innerWriter;
         private readonly JsonTextWriter _textWriter;
@@ -23,7 +23,7 @@ namespace Newtonsoft.Json.Serialization
             // prefix the message in the stringwriter to avoid concat with a potentially large JSON string
             _sw.Write("Serialized JSON: " + Environment.NewLine);
 
-            _textWriter = new JsonTextWriter(_sw);
+            _textWriter = new JsonTextWriterImpl(_sw);
             _textWriter.Formatting = Formatting.Indented;
             _textWriter.Culture = innerWriter.Culture;
             _textWriter.DateFormatHandling = innerWriter.DateFormatHandling;

--- a/Src/Newtonsoft.Json/Utilities/AsyncUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/AsyncUtils.cs
@@ -1,0 +1,119 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Utilities
+{
+    internal static class AsyncUtils
+    {
+        private static readonly Action _nop = () => { };
+        // Pre-allocate to avoid wasted allocations.
+        public static readonly Task<bool> False = Task.FromResult(false);
+        public static readonly Task<bool> True = Task.FromResult(true);
+        public static readonly Task<object> NullTask = Task.FromResult<object>(null);
+
+        internal static Task<bool> ToAsync(this bool value)
+        {
+            return value ? True : False;
+        }
+
+        public static Task CancelIfRequesedAsync(this CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ? CancelledAsync(cancellationToken) : null;
+        }
+
+        public static Task<T> CancelIfRequesedAsync<T>(this CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ? CancelledAsync<T>(cancellationToken) : null;
+        }
+
+        public static Task<object> CancelledOrNullAsync(this CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ? CancelledAsync<object>(cancellationToken) : NullTask;
+        }
+
+        public static Task CancelledAsync(this CancellationToken cancellationToken)
+        {
+            Debug.Assert(cancellationToken.IsCancellationRequested);
+            return new Task(_nop, cancellationToken);
+        }
+
+        public static Task<T> CancelledAsync<T>(this CancellationToken cancellationToken)
+        {
+            Debug.Assert(cancellationToken.IsCancellationRequested);
+            return new Task<T>(() => default(T), cancellationToken);
+        }
+
+        // Task.Delay(0) is optimised as a cached task within the framework, and indeed
+        // the same cached task that CompletedTask returns as of 4.6, but we'll add our
+        // own property for previous frameworks.
+        internal static Task CompletedTask
+        {
+            get { return Task.Delay(0); }
+        }
+
+        public static Task WriteAsync(this TextWriter writer, char value, CancellationToken cancellationToken)
+        {
+            Debug.Assert(writer != null);
+            return cancellationToken.IsCancellationRequested ? CancelledAsync(cancellationToken) : writer.WriteAsync(value);
+        }
+        public static Task WriteAsync(this TextWriter writer, string value, CancellationToken cancellationToken)
+        {
+            Debug.Assert(writer != null);
+            return cancellationToken.IsCancellationRequested ? CancelledAsync(cancellationToken) : writer.WriteAsync(value);
+        }
+        public static Task WriteAsync(this TextWriter writer, char[] value, CancellationToken cancellationToken)
+        {
+            Debug.Assert(writer != null);
+            return cancellationToken.IsCancellationRequested ? CancelledAsync(cancellationToken) : writer.WriteAsync(value);
+        }
+        public static Task WriteAsync(this TextWriter writer, char[] value, int start, int count, CancellationToken cancellationToken)
+        {
+            Debug.Assert(writer != null);
+            return cancellationToken.IsCancellationRequested
+                ? CancelledAsync(cancellationToken) : writer.WriteAsync(value, start, count);
+        }
+        public static Task WriteLineAsync(this TextWriter writer, CancellationToken cancellationToken)
+        {
+            Debug.Assert(writer != null);
+            return cancellationToken.IsCancellationRequested ? CancelledAsync(cancellationToken) : writer.WriteLineAsync();
+        }
+
+        public static Task<int> ReadAsync(this TextReader reader, char[] buffer, int index, int count, CancellationToken cancellationToken)
+        {
+            Debug.Assert(reader != null);
+            return cancellationToken.IsCancellationRequested ? CancelledAsync<int>(cancellationToken) : reader.ReadAsync(buffer, index, count);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Utilities/Base64Encoder.Async.cs
+++ b/Src/Newtonsoft.Json/Utilities/Base64Encoder.Async.cs
@@ -1,0 +1,129 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Utilities
+{
+    internal partial class Base64Encoder
+    {
+        public async Task EncodeAsync(byte[] buffer, int index, int count, CancellationToken cancellationToken)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (count > buffer.Length - index)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_leftOverBytesCount > 0)
+            {
+                int leftOverBytesCount = _leftOverBytesCount;
+                while (leftOverBytesCount < 3 && count > 0)
+                {
+                    _leftOverBytes[leftOverBytesCount++] = buffer[index++];
+                    count--;
+                }
+
+                if (count == 0 && leftOverBytesCount < 3)
+                {
+                    _leftOverBytesCount = leftOverBytesCount;
+                    return;
+                }
+
+                int num2 = Convert.ToBase64CharArray(_leftOverBytes, 0, 3, _charsLine, 0);
+                await WriteCharsAsync(_charsLine, 0, num2, cancellationToken).ConfigureAwait(false);
+            }
+
+            _leftOverBytesCount = count % 3;
+            if (_leftOverBytesCount > 0)
+            {
+                count -= _leftOverBytesCount;
+                if (_leftOverBytes == null)
+                {
+                    _leftOverBytes = new byte[3];
+                }
+                for (int i = 0; i < _leftOverBytesCount; i++)
+                {
+                    _leftOverBytes[i] = buffer[index + count + i];
+                }
+            }
+
+            int num4 = index + count;
+            int length = LineSizeInBytes;
+            while (index < num4)
+            {
+                if (index + length > num4)
+                {
+                    length = num4 - index;
+                }
+                int num6 = Convert.ToBase64CharArray(buffer, index, length, _charsLine, 0);
+                await WriteCharsAsync(_charsLine, 0, num6, cancellationToken).ConfigureAwait(false);
+                index += length;
+            }
+        }
+
+        private Task WriteCharsAsync(char[] chars, int index, int count, CancellationToken cancellationToken)
+        {
+            return _writer.WriteAsync(chars, index, count, cancellationToken);
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return cancellationToken.CancelledAsync();
+
+            if (_leftOverBytesCount > 0)
+            {
+                int count = Convert.ToBase64CharArray(_leftOverBytes, 0, _leftOverBytesCount, _charsLine, 0);
+                _leftOverBytesCount = 0;
+                return WriteCharsAsync(_charsLine, 0, count, cancellationToken);
+            }
+
+            return AsyncUtils.CompletedTask;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Utilities/Base64Encoder.cs
+++ b/Src/Newtonsoft.Json/Utilities/Base64Encoder.cs
@@ -28,7 +28,7 @@ using System.IO;
 
 namespace Newtonsoft.Json.Utilities
 {
-    internal class Base64Encoder
+    internal partial class Base64Encoder
     {
         private const int Base64LineSize = 76;
         private const int LineSizeInBytes = 57;

--- a/Src/Newtonsoft.Json/Utilities/DateTimeUtils.Async.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeUtils.Async.cs
@@ -1,0 +1,67 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Utilities
+{
+    internal static partial class DateTimeUtils
+    {
+        internal static Task WriteDateTimeStringAsync(TextWriter writer, DateTime value, DateFormatHandling format, string formatString, CultureInfo culture, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(formatString))
+            {
+                char[] chars = new char[64];
+                int pos = WriteDateTimeString(chars, 0, value, null, value.Kind, format);
+                return writer.WriteAsync(chars, 0, pos, cancellationToken);
+            }
+
+            return writer.WriteAsync(value.ToString(formatString, culture), cancellationToken);
+        }
+
+        internal static Task WriteDateTimeOffsetStringAsync(TextWriter writer, DateTimeOffset value, DateFormatHandling format, string formatString, CultureInfo culture, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(formatString))
+            {
+                char[] chars = new char[64];
+                int pos = WriteDateTimeString(chars, 0, (format == DateFormatHandling.IsoDateFormat) ? value.DateTime : value.UtcDateTime, value.Offset, DateTimeKind.Local, format);
+                return writer.WriteAsync(chars, 0, pos, cancellationToken);
+            }
+
+            return writer.WriteAsync(value.ToString(formatString, culture), cancellationToken);
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
@@ -30,7 +30,7 @@ using System.Globalization;
 
 namespace Newtonsoft.Json.Utilities
 {
-    internal static class DateTimeUtils
+    internal static partial class DateTimeUtils
     {
         internal static readonly long InitialJavaScriptDateTicks = 621355968000000000;
         private const string IsoDateFormat = "yyyy-MM-ddTHH:mm:ss.FFFFFFFK";

--- a/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.Async.cs
+++ b/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.Async.cs
@@ -1,0 +1,204 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40 || PORTABLE40)
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Newtonsoft.Json.Utilities
+{
+    internal static partial class JavaScriptUtils
+    {
+        public static async Task<char[]> WriteEscapedJavaScriptStringAsync(TextWriter writer, string s, char delimiter, bool appendDelimiters,
+            bool[] charEscapeFlags, StringEscapeHandling stringEscapeHandling, IArrayPool<char> bufferPool, char[] writeBuffer, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // leading delimiter
+            if (appendDelimiters)
+            {
+                await writer.WriteAsync(delimiter, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (s != null)
+            {
+                int lastWritePosition = 0;
+
+                for (int i = 0; i < s.Length; i++)
+                {
+                    char c = s[i];
+
+                    if (c < charEscapeFlags.Length && !charEscapeFlags[c])
+                    {
+                        continue;
+                    }
+
+                    string escapedValue;
+
+                    switch (c)
+                    {
+                        case '\t':
+                            escapedValue = @"\t";
+                            break;
+                        case '\n':
+                            escapedValue = @"\n";
+                            break;
+                        case '\r':
+                            escapedValue = @"\r";
+                            break;
+                        case '\f':
+                            escapedValue = @"\f";
+                            break;
+                        case '\b':
+                            escapedValue = @"\b";
+                            break;
+                        case '\\':
+                            escapedValue = @"\\";
+                            break;
+                        case '\u0085': // Next Line
+                            escapedValue = @"\u0085";
+                            break;
+                        case '\u2028': // Line Separator
+                            escapedValue = @"\u2028";
+                            break;
+                        case '\u2029': // Paragraph Separator
+                            escapedValue = @"\u2029";
+                            break;
+                        default:
+                            if (c < charEscapeFlags.Length || stringEscapeHandling == StringEscapeHandling.EscapeNonAscii)
+                            {
+                                if (c == '\'' && stringEscapeHandling != StringEscapeHandling.EscapeHtml)
+                                {
+                                    escapedValue = @"\'";
+                                }
+                                else if (c == '"' && stringEscapeHandling != StringEscapeHandling.EscapeHtml)
+                                {
+                                    escapedValue = @"\""";
+                                }
+                                else
+                                {
+                                    if (writeBuffer == null || writeBuffer.Length < UnicodeTextLength)
+                                    {
+                                        writeBuffer = BufferUtils.EnsureBufferSize(bufferPool, UnicodeTextLength, writeBuffer);
+                                    }
+
+                                    StringUtils.ToCharAsUnicode(c, writeBuffer);
+
+                                    // slightly hacky but it saves multiple conditions in if test
+                                    escapedValue = EscapedUnicodeText;
+                                }
+                            }
+                            else
+                            {
+                                escapedValue = null;
+                            }
+                            break;
+                    }
+
+                    if (escapedValue == null)
+                    {
+                        continue;
+                    }
+
+                    bool isEscapedUnicodeText = string.Equals(escapedValue, EscapedUnicodeText);
+
+                    if (i > lastWritePosition)
+                    {
+                        int length = i - lastWritePosition + ((isEscapedUnicodeText) ? UnicodeTextLength : 0);
+                        int start = (isEscapedUnicodeText) ? UnicodeTextLength : 0;
+
+                        if (writeBuffer == null || writeBuffer.Length < length)
+                        {
+                            char[] newBuffer = BufferUtils.RentBuffer(bufferPool, length);
+
+                            // the unicode text is already in the buffer
+                            // copy it over when creating new buffer
+                            if (isEscapedUnicodeText)
+                            {
+                                Array.Copy(writeBuffer, newBuffer, UnicodeTextLength);
+                            }
+
+                            BufferUtils.ReturnBuffer(bufferPool, writeBuffer);
+
+                            writeBuffer = newBuffer;
+                        }
+
+                        s.CopyTo(lastWritePosition, writeBuffer, start, length - start);
+
+                        cancellationToken.ThrowIfCancellationRequested();
+                        // write unchanged chars before writing escaped text
+                        await writer.WriteAsync(writeBuffer, start, length - start, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    lastWritePosition = i + 1;
+                    if (!isEscapedUnicodeText)
+                    {
+                        await writer.WriteAsync(escapedValue, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await writer.WriteAsync(writeBuffer, 0, UnicodeTextLength, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                if (lastWritePosition == 0)
+                {
+                    // no escaped text, write entire string
+                    await writer.WriteAsync(s, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    int length = s.Length - lastWritePosition;
+
+                    if (writeBuffer == null || writeBuffer.Length < length)
+                    {
+                        writeBuffer = BufferUtils.EnsureBufferSize(bufferPool, length, writeBuffer);
+                    }
+
+                    s.CopyTo(lastWritePosition, writeBuffer, 0, length);
+
+                    // write remaining text
+                    await writer.WriteAsync(writeBuffer, 0, length, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            // trailing delimiter
+            if (appendDelimiters)
+            {
+                await writer.WriteAsync(delimiter, cancellationToken).ConfigureAwait(false);
+            }
+
+            return writeBuffer;
+        }
+    }
+}
+
+#endif

--- a/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
@@ -78,7 +78,7 @@ namespace Newtonsoft.Json.Utilities
         }
     }
 
-    internal static class JavaScriptUtils
+    internal static partial class JavaScriptUtils
     {
         internal static readonly bool[] SingleQuoteCharEscapeFlags = new bool[128];
         internal static readonly bool[] DoubleQuoteCharEscapeFlags = new bool[128];


### PR DESCRIPTION
Closes #650 

Default base-class behaviour is to execute the associated synchronous method and return a completed task.

Similarly to `StreamReader` and `StreamWriter` in the case of classes derived from those offering asynchronous operations, the derived class itself must override the async method or it will operate synchronously, as it's not possible otherwise to match the overridden behaviour of virtual methods. An exception is `CustomCreationConverter` which explicitly checks if `ReadJson` was overridden as the common use would have `Create` (safely) overridden but not `ReadJson`.

Having separate files for all the async code was originally intended only to be a temporary method during development, but as it offers convenience in comparing methods I left them like that.

Possible future work:

Commonality between synch and asynch methods could be refactored into separate methods, but doing this immediately would lead to a more confusing PR with some of the refactoring being rather opaque if combined with this work.

Asynch support for BSON. Requires asynch support that the framework `BinaryReader` and `BinaryWriter` doesn't provide, which would impact considerably on the current implementation, so left out of this PR. (As the BSON-related classes do inherit the default synchronously-returning methods from the base, there are still tests added for those methods)