### PR TITLE
Don't assign _largeByteBuffer until clear it will be used.

### DIFF
--- a/Src/Newtonsoft.Json/Bson/BsonBinaryWriter.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonBinaryWriter.cs
@@ -210,12 +210,13 @@ namespace Newtonsoft.Json.Bson
         {
             if (s != null)
             {
-                if (_largeByteBuffer == null)
-                {
-                    _largeByteBuffer = new byte[256];
-                }
                 if (byteCount <= 256)
                 {
+                    if (_largeByteBuffer == null)
+                    {
+                        _largeByteBuffer = new byte[256];
+                    }
+
                     Encoding.GetBytes(s, 0, s.Length, _largeByteBuffer, 0);
                     _writer.Write(_largeByteBuffer, 0, byteCount);
                 }


### PR DESCRIPTION
`BsonBinaryWriter._largeByteBuffer` is lazily-allocated, but a path following the allocation doesn't use it. Move the allocation into the path that makes use of it, to avoid the null-check and potentially the allocation.