### PR TITLE
Use null-propogation where applicable and useful.

### DIFF
--- a/Src/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonReader.cs
@@ -230,12 +230,12 @@ namespace Newtonsoft.Json.Bson
         {
             base.Close();
 
-            if (CloseInput && _reader != null)
+            if (CloseInput)
             {
 #if !(DOTNET || PORTABLE40 || PORTABLE)
-                _reader.Close();
+                _reader?.Close();
 #else
-                _reader.Dispose();
+                _reader?.Dispose();
 #endif
             }
         }

--- a/Src/Newtonsoft.Json/Bson/BsonWriter.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonWriter.cs
@@ -177,9 +177,9 @@ namespace Newtonsoft.Json.Bson
         {
             base.Close();
 
-            if (CloseOutput && _writer != null)
+            if (CloseOutput)
             {
-                _writer.Close();
+                _writer?.Close();
             }
         }
 

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -1182,11 +1182,7 @@ namespace Newtonsoft.Json
 
         internal void OnError(ErrorEventArgs e)
         {
-            EventHandler<ErrorEventArgs> error = Error;
-            if (error != null)
-            {
-                error(this, e);
-            }
+            Error?.Invoke(this, e);
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -231,12 +231,7 @@ namespace Newtonsoft.Json
         {
             get
             {
-                if (ReferenceResolverProvider == null)
-                {
-                    return null;
-                }
-
-                return ReferenceResolverProvider();
+                return ReferenceResolverProvider?.Invoke();
             }
             set
             {

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -2414,12 +2414,12 @@ namespace Newtonsoft.Json
                 _chars = null;
             }
 
-            if (CloseInput && _reader != null)
+            if (CloseInput)
             {
 #if !(DOTNET || PORTABLE40 || PORTABLE)
-                _reader.Close();
+                _reader?.Close();
 #else
-                _reader.Dispose();
+                _reader?.Dispose();
 #endif
             }
 

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -184,12 +184,12 @@ namespace Newtonsoft.Json
                 _writeBuffer = null;
             }
 
-            if (CloseOutput && _writer != null)
+            if (CloseOutput)
             {
 #if !(DOTNET || PORTABLE40 || PORTABLE)
-                _writer.Close();
+                _writer?.Close();
 #else
-                _writer.Dispose();
+                _writer?.Dispose();
 #endif
             }
         }

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -97,7 +97,7 @@ namespace Newtonsoft.Json
 
             private IEnumerable<string> GetRequiredProperties(JsonSchemaModel schema)
             {
-                if (schema == null || schema.Properties == null)
+                if (schema?.Properties == null)
                 {
                     return Enumerable.Empty<string>();
                 }
@@ -358,9 +358,9 @@ namespace Newtonsoft.Json
         public override void Close()
         {
             base.Close();
-            if (CloseInput && _reader != null)
+            if (CloseInput)
             {
-                _reader.Close();
+                _reader?.Close();
             }
         }
 

--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -139,11 +139,7 @@ namespace Newtonsoft.Json.Linq
         /// <param name="e">The <see cref="AddingNewEventArgs"/> instance containing the event data.</param>
         protected virtual void OnAddingNew(AddingNewEventArgs e)
         {
-            AddingNewEventHandler handler = _addingNew;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            _addingNew?.Invoke(this, e);
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Linq/JProperty.cs
+++ b/Src/Newtonsoft.Json/Linq/JProperty.cs
@@ -212,17 +212,11 @@ namespace Newtonsoft.Json.Linq
                 return;
             }
 
-            if (Parent != null)
-            {
-                ((JObject)Parent).InternalPropertyChanging(this);
-            }
+            ((JObject)Parent)?.InternalPropertyChanging(this);
 
             base.SetItem(0, item);
 
-            if (Parent != null)
-            {
-                ((JObject)Parent).InternalPropertyChanged(this);
-            }
+            ((JObject)Parent)?.InternalPropertyChanged(this);
         }
 
         internal override bool RemoveItem(JToken item)
@@ -263,15 +257,11 @@ namespace Newtonsoft.Json.Linq
 
         internal override void MergeItem(object content, JsonMergeSettings settings)
         {
-            JProperty p = content as JProperty;
-            if (p == null)
-            {
-                return;
-            }
+            JToken value = (content as JProperty)?.Value;
 
-            if (p.Value != null && p.Value.Type != JTokenType.Null)
+            if (value != null && value.Type != JTokenType.Null)
             {
-                Value = p.Value;
+                Value = value;
             }
         }
 

--- a/Src/Newtonsoft.Json/Linq/JPropertyKeyedCollection.cs
+++ b/Src/Newtonsoft.Json/Linq/JPropertyKeyedCollection.cs
@@ -72,10 +72,7 @@ namespace Newtonsoft.Json.Linq
         {
             base.ClearItems();
 
-            if (_dictionary != null)
-            {
-                _dictionary.Clear();
-            }
+            _dictionary?.Clear();
         }
 
         public bool Contains(string key)
@@ -148,10 +145,7 @@ namespace Newtonsoft.Json.Linq
 
         private void RemoveKey(string key)
         {
-            if (_dictionary != null)
-            {
-                _dictionary.Remove(key);
-            }
+            _dictionary?.Remove(key);
         }
 
         protected override void SetItem(int index, JToken item)

--- a/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -177,13 +177,9 @@ namespace Newtonsoft.Json.Linq
         /// <param name="name">The name of the property.</param>
         public override void WritePropertyName(string name)
         {
-            JObject o = _parent as JObject;
-            if (o != null)
-            {
-                // avoid duplicate property name exception
-                // last property name wins
-                o.Remove(name);
-            }
+            // avoid duplicate property name exception
+            // last property name wins
+            (_parent as JObject)?.Remove(name);
 
             AddParent(new JProperty(name));
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -532,10 +532,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
                     {
                         CompositeExpression andExpression = new CompositeExpression { Operator = QueryOperator.And };
 
-                        if (parentExpression != null)
-                        {
-                            parentExpression.Expressions.Add(andExpression);
-                        }
+                        parentExpression?.Expressions.Add(andExpression);
 
                         parentExpression = andExpression;
 
@@ -558,10 +555,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
                     {
                         CompositeExpression orExpression = new CompositeExpression { Operator = QueryOperator.Or };
 
-                        if (parentExpression != null)
-                        {
-                            parentExpression.Expressions.Add(orExpression);
-                        }
+                        parentExpression?.Expressions.Add(orExpression);
 
                         parentExpression = orExpression;
 

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaGenerator.cs
@@ -176,7 +176,7 @@ namespace Newtonsoft.Json.Schema
         {
             JsonContainerAttribute containerAttribute = JsonTypeReflector.GetCachedAttribute<JsonContainerAttribute>(type);
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Title))
+            if (!string.IsNullOrEmpty(containerAttribute?.Title))
             {
                 return containerAttribute.Title;
             }
@@ -188,27 +188,24 @@ namespace Newtonsoft.Json.Schema
         {
             JsonContainerAttribute containerAttribute = JsonTypeReflector.GetCachedAttribute<JsonContainerAttribute>(type);
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Description))
+            if (!string.IsNullOrEmpty(containerAttribute?.Description))
             {
                 return containerAttribute.Description;
             }
 
 #if !(DOTNET || PORTABLE40 || PORTABLE)
             DescriptionAttribute descriptionAttribute = ReflectionUtils.GetAttribute<DescriptionAttribute>(type);
-            if (descriptionAttribute != null)
-            {
-                return descriptionAttribute.Description;
-            }
-#endif
-
+            return descriptionAttribute?.Description;
+#else
             return null;
+#endif
         }
 
         private string GetTypeId(Type type, bool explicitOnly)
         {
             JsonContainerAttribute containerAttribute = JsonTypeReflector.GetCachedAttribute<JsonContainerAttribute>(type);
 
-            if (containerAttribute != null && !string.IsNullOrEmpty(containerAttribute.Id))
+            if (!string.IsNullOrEmpty(containerAttribute?.Id))
             {
                 return containerAttribute.Id;
             }

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1427,13 +1427,13 @@ namespace Newtonsoft.Json.Serialization
 
             string mappedName;
             bool hasSpecifiedName;
-            if (propertyAttribute != null && propertyAttribute.PropertyName != null)
+            if (propertyAttribute?.PropertyName != null)
             {
                 mappedName = propertyAttribute.PropertyName;
                 hasSpecifiedName = true;
             }
 #if !NET20
-            else if (dataMemberAttribute != null && dataMemberAttribute.Name != null)
+            else if (dataMemberAttribute?.Name != null)
             {
                 mappedName = dataMemberAttribute.Name;
                 hasSpecifiedName = true;
@@ -1542,7 +1542,7 @@ namespace Newtonsoft.Json.Serialization
 
             property.ItemIsReference = (propertyAttribute != null) ? propertyAttribute._itemIsReference : null;
             property.ItemConverter =
-                (propertyAttribute != null && propertyAttribute.ItemConverterType != null)
+                (propertyAttribute?.ItemConverterType != null)
                     ? JsonTypeReflector.CreateJsonConverterInstance(propertyAttribute.ItemConverterType, propertyAttribute.ItemConverterParameters)
                     : null;
             property.ItemReferenceLoopHandling = (propertyAttribute != null) ? propertyAttribute._itemReferenceLoopHandling : null;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -377,11 +377,11 @@ namespace Newtonsoft.Json.Serialization
                 // member attribute converter
                 converter = memberConverter;
             }
-            else if (containerProperty != null && containerProperty.ItemConverter != null)
+            else if (containerProperty?.ItemConverter != null)
             {
                 converter = containerProperty.ItemConverter;
             }
-            else if (containerContract != null && containerContract.ItemConverter != null)
+            else if (containerContract?.ItemConverter != null)
             {
                 converter = containerContract.ItemConverter;
             }

--- a/Src/Newtonsoft.Json/Utilities/DictionaryWrapper.cs
+++ b/Src/Newtonsoft.Json/Utilities/DictionaryWrapper.cs
@@ -253,9 +253,9 @@ namespace Newtonsoft.Json.Utilities
                 throw new NotSupportedException();
             }
 #endif
-            else if (_genericDictionary != null)
+            else
             {
-                _genericDictionary.Add(item);
+                _genericDictionary?.Add(item);
             }
         }
 

--- a/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/JavaScriptUtils.cs
@@ -54,12 +54,7 @@ namespace Newtonsoft.Json.Utilities
 
         public static void ReturnBuffer(IArrayPool<char> bufferPool, char[] buffer)
         {
-            if (bufferPool == null)
-            {
-                return;
-            }
-
-            bufferPool.Return(buffer);
+            bufferPool?.Return(buffer);
         }
 
         public static char[] EnsureBufferSize(IArrayPool<char> bufferPool, int size, char[] buffer)

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -123,13 +123,7 @@ namespace Newtonsoft.Json.Utilities
                 return m.GetBaseDefinition();
             }
 
-            m = propertyInfo.GetSetMethod(true);
-            if (m != null)
-            {
-                return m.GetBaseDefinition();
-            }
-
-            return null;
+            return propertyInfo.GetSetMethod(true)?.GetBaseDefinition();
         }
 
         public static bool IsPublic(PropertyInfo property)


### PR DESCRIPTION
Primarily where it means one fewer field-access or simplifies event delegate invocation, though one or two cases have just the lesser advantage of allowing an IL stack `dup` rather than local access.

(Cases that involve introducing a nullable, e.g. where `obj != null ? obj.Value : 0` can be turned into `(obj?.Value) ?? 0` are less clearly wins, and so not done).