### PR TITLE
Fix typos

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
@@ -505,7 +505,7 @@ namespace Newtonsoft.Json.Tests.Converters
 }";
             ExceptionAssert.Throws<JsonSerializationException>(
                 () => { JsonConvert.DeserializeXmlNode(json); },
-                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName. Path 'Email', line 3, position 13.");
+                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifying a DeserializeRootElementName. Path 'Email', line 3, position 13.");
         }
 
         [Test]
@@ -1053,7 +1053,7 @@ namespace Newtonsoft.Json.Tests.Converters
         {
             ExceptionAssert.Throws<JsonSerializationException>(
                 () => { XmlDocument newDoc = (XmlDocument)JsonConvert.DeserializeXmlNode(@"{Prop1:1,Prop2:2}"); },
-                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName. Path 'Prop2', line 1, position 15.");
+                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifying a DeserializeRootElementName. Path 'Prop2', line 1, position 15.");
         }
 
         [Test]
@@ -1171,7 +1171,7 @@ namespace Newtonsoft.Json.Tests.Converters
 
             ExceptionAssert.Throws<JsonSerializationException>(
                 () => { JsonConvert.DeserializeXmlNode(json); },
-                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName. Path 'photos', line 1, position 26.");
+                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifying a DeserializeRootElementName. Path 'photos', line 1, position 26.");
         }
 #endif
 
@@ -1183,7 +1183,7 @@ namespace Newtonsoft.Json.Tests.Converters
 
             ExceptionAssert.Throws<JsonSerializationException>(
                 () => { JsonConvert.DeserializeXNode(json); },
-                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName. Path 'photos', line 1, position 26.");
+                "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifying a DeserializeRootElementName. Path 'photos', line 1, position 26.");
         }
 #endif
 
@@ -2727,7 +2727,7 @@ namespace Newtonsoft.Json.Tests.Converters
 
             ExceptionAssert.Throws<JsonSerializationException>(
                 () => JsonConvert.DeserializeXmlNode(json),
-                "JSON root object has property '$id' that will be converted to an attribute. A root object cannot have any attribute properties. Consider specifing a DeserializeRootElementName. Path '$id', line 2, position 12.");
+                "JSON root object has property '$id' that will be converted to an attribute. A root object cannot have any attribute properties. Consider specifying a DeserializeRootElementName. Path '$id', line 2, position 12.");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ExceptionHandlingTests.cs
@@ -87,7 +87,7 @@ namespace Newtonsoft.Json.Tests.JsonTextReaderTests
         {
             JsonReader reader = new JsonTextReader(new StringReader(@"'h\u123"));
 
-            ExceptionAssert.Throws<JsonReaderException>(() => { reader.Read(); }, "Unexpected end while parsing unicode character. Path '', line 1, position 4.");
+            ExceptionAssert.Throws<JsonReaderException>(() => { reader.Read(); }, "Unexpected end while parsing Unicode character. Path '', line 1, position 4.");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
@@ -294,7 +294,7 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
         [Test]
         public void SinglePropertyAndFilterWithUnknownEscape()
         {
-            ExceptionAssert.Throws<JsonException>(() => { new JPath(@"Blah[ ?( @.name=='h\i' ) ]"); }, @"Unknown escape chracter: \i");
+            ExceptionAssert.Throws<JsonException>(() => { new JPath(@"Blah[ ?( @.name=='h\i' ) ]"); }, @"Unknown escape character: \i");
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -995,7 +995,7 @@ namespace Newtonsoft.Json.Converters
         /// Gets or sets a flag to indicate whether to write the Json.NET array attribute.
         /// This attribute helps preserve arrays when converting the written XML back to JSON.
         /// </summary>
-        /// <value><c>true</c> if the array attibute is written to the XML; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if the array attribute is written to the XML; otherwise, <c>false</c>.</value>
         public bool WriteArrayAttribute { get; set; }
 
         /// <summary>
@@ -1618,7 +1618,7 @@ namespace Newtonsoft.Json.Converters
         {
             if (currentNode.NodeType == XmlNodeType.Document)
             {
-                throw JsonSerializationException.Create(reader, "JSON root object has property '{0}' that will be converted to an attribute. A root object cannot have any attribute properties. Consider specifing a DeserializeRootElementName.".FormatWith(CultureInfo.InvariantCulture, propertyName));
+                throw JsonSerializationException.Create(reader, "JSON root object has property '{0}' that will be converted to an attribute. A root object cannot have any attribute properties. Consider specifying a DeserializeRootElementName.".FormatWith(CultureInfo.InvariantCulture, propertyName));
             }
 
             string encodedName = XmlConvert.EncodeName(attributeName);
@@ -1949,7 +1949,7 @@ namespace Newtonsoft.Json.Converters
                     case JsonToken.PropertyName:
                         if (currentNode.NodeType == XmlNodeType.Document && document.DocumentElement != null)
                         {
-                            throw JsonSerializationException.Create(reader, "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifing a DeserializeRootElementName.");
+                            throw JsonSerializationException.Create(reader, "JSON root object has multiple properties. The root object must have a single property in order to create a valid XML document. Consider specifying a DeserializeRootElementName.");
                         }
 
                         string propertyName = reader.Value.ToString();

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -597,7 +597,7 @@ namespace Newtonsoft.Json
         /// <param name="type">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="JsonSerializer.TypeNameHandling"/> is <see cref="TypeNameHandling.Auto"/> to write out the type name if the type of the value does not match.
-        /// Specifing the type is optional.
+        /// Specifying the type is optional.
         /// </param>
         /// <returns>
         /// A JSON string representation of the object.
@@ -634,7 +634,7 @@ namespace Newtonsoft.Json
         /// <param name="type">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="JsonSerializer.TypeNameHandling"/> is <see cref="TypeNameHandling.Auto"/> to write out the type name if the type of the value does not match.
-        /// Specifing the type is optional.
+        /// Specifying the type is optional.
         /// </param>
         /// <returns>
         /// A JSON string representation of the object.

--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -175,7 +175,7 @@ namespace Newtonsoft.Json
         public string PropertyName { get; set; }
 
         /// <summary>
-        /// Gets or sets the the reference loop handling used when serializing the property's collection items.
+        /// Gets or sets the reference loop handling used when serializing the property's collection items.
         /// </summary>
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling ItemReferenceLoopHandling
@@ -185,7 +185,7 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
-        /// Gets or sets the the type name handling used when serializing the property's collection items.
+        /// Gets or sets the type name handling used when serializing the property's collection items.
         /// </summary>
         /// <value>The collection's items type name handling.</value>
         public TypeNameHandling ItemTypeNameHandling

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -1012,7 +1012,7 @@ namespace Newtonsoft.Json
         /// <param name="objectType">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="JsonSerializer.TypeNameHandling"/> is <see cref="TypeNameHandling.Auto"/> to write out the type name if the type of the value does not match.
-        /// Specifing the type is optional.
+        /// Specifying the type is optional.
         /// </param>
         public void Serialize(JsonWriter jsonWriter, object value, Type objectType)
         {
@@ -1028,7 +1028,7 @@ namespace Newtonsoft.Json
         /// <param name="objectType">
         /// The type of the value being serialized.
         /// This parameter is used when <see cref="TypeNameHandling"/> is Auto to write out the type name if the type of the value does not match.
-        /// Specifing the type is optional.
+        /// Specifying the type is optional.
         /// </param>
         public void Serialize(TextWriter textWriter, object value, Type objectType)
         {

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -221,7 +221,7 @@ namespace Newtonsoft.Json
         private void ShiftBufferIfNeeded()
         {
             // once in the last 10% of the buffer shift the remaining content to the start to avoid
-            // unnessesarly increasing the buffer size when reading numbers/strings
+            // unnecessarily increasing the buffer size when reading numbers/strings
             int length = _chars.Length;
             if (length - _charPos <= length * 0.1)
             {
@@ -1235,7 +1235,7 @@ namespace Newtonsoft.Json
             }
             else
             {
-                throw JsonReaderException.Create(this, "Unexpected end while parsing unicode character.");
+                throw JsonReaderException.Create(this, "Unexpected end while parsing Unicode character.");
             }
             return writeChar;
         }

--- a/Src/Newtonsoft.Json/JsonValidatingReader.cs
+++ b/Src/Newtonsoft.Json/JsonValidatingReader.cs
@@ -890,7 +890,7 @@ namespace Newtonsoft.Json
 
                 foreach (JsonSchemaModel currentSchema in CurrentSchemas)
                 {
-                    // if there is positional validation and the array index is past the number of item validation schemas and there is no additonal items then error
+                    // if there is positional validation and the array index is past the number of item validation schemas and there are no additional items then error
                     if (currentSchema != null
                         && currentSchema.PositionalItemsValidation
                         && !currentSchema.AllowAdditionalItems

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -1584,7 +1584,7 @@ namespace Newtonsoft.Json
 
                         TypeInformation typeInformation = ConvertUtils.GetTypeInformation(convertable);
 
-                        // if convertable has an underlying typecode of Object then attempt to convert it to a string
+                        // if convertible has an underlying typecode of Object then attempt to convert it to a string
                         PrimitiveTypeCode resolvedTypeCode = (typeInformation.TypeCode == PrimitiveTypeCode.Object) ? PrimitiveTypeCode.String : typeInformation.TypeCode;
                         Type resolvedType = (typeInformation.TypeCode == PrimitiveTypeCode.Object) ? typeof(string) : typeInformation.Type;
 

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -561,7 +561,7 @@ namespace Newtonsoft.Json.Linq
 
         ICollection<string> IDictionary<string, JToken>.Keys
         {
-            // todo: make order the collection returned match JObject order
+            // todo: make order of the collection returned match JObject order
             get { return _properties.Keys; }
         }
 

--- a/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -493,7 +493,7 @@ namespace Newtonsoft.Json.Linq
         {
             JTokenReader tokenReader = reader as JTokenReader;
 
-            // closing the token wrather than reading then writing it doesn't lose some type information, e.g. Guid, byte[], etc
+            // cloning the token rather than reading then writing it doesn't lose some type information, e.g. Guid, byte[], etc
             if (tokenReader != null && writeChildren && writeDateConstructorAsDate && writeComments)
             {
                 if (tokenReader.TokenType == JsonToken.None)

--- a/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
@@ -29,7 +29,7 @@ namespace Newtonsoft.Json.Linq
         }
 
         /// <summary>
-        /// Gets or sets how how null value properties are merged.
+        /// Gets or sets how null value properties are merged.
         /// </summary>
         /// <value>How null value properties are merged.</value>
         public MergeNullValueHandling MergeNullValueHandling

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
@@ -28,13 +28,13 @@ namespace Newtonsoft.Json.Linq.JsonPath
                     int startIndex = Start ?? ((stepCount > 0) ? 0 : a.Count - 1);
                     int stopIndex = End ?? ((stepCount > 0) ? a.Count : -1);
 
-                    // start from the end of the list if start is negitive
+                    // start from the end of the list if start is negative
                     if (Start < 0)
                     {
                         startIndex = a.Count + startIndex;
                     }
 
-                    // end from the start of the list if stop is negitive
+                    // end from the start of the list if stop is negative
                     if (End < 0)
                     {
                         stopIndex = a.Count + stopIndex;

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -672,7 +672,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
                     }
                     else
                     {
-                        throw new JsonException(@"Unknown escape chracter: \" + _expression[_currentIndex]);
+                        throw new JsonException(@"Unknown escape character: \" + _expression[_currentIndex]);
                     }
 
                     _currentIndex++;

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -166,7 +166,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
                 switch (Operator)
                 {
                     case QueryOperator.Exists:
-                    // you can only specify primative types in a comparison
+                    // you can only specify primitive types in a comparison
                     // notequals will always be true
                     case QueryOperator.NotEquals:
                         return true;

--- a/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs
+++ b/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs
@@ -76,7 +76,7 @@ using System.Security;
 
 #if !(PORTABLE40 || PORTABLE)
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components. If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
@@ -462,7 +462,7 @@ namespace Newtonsoft.Json.Schema
                     {
                         if (typeToken.Type != JTokenType.String)
                         {
-                            throw JsonException.Create(typeToken, typeToken.Path, "Exception JSON schema type string token, got {0}.".FormatWith(CultureInfo.InvariantCulture, token.Type));
+                            throw JsonException.Create(typeToken, typeToken.Path, "Expected JSON schema type string token, got {0}.".FormatWith(CultureInfo.InvariantCulture, token.Type));
                         }
 
                         type = type | MapType((string)typeToken);

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -778,7 +778,7 @@ namespace Newtonsoft.Json.Serialization
 
             contract.Converter = ResolveContractConverter(contract.NonNullableUnderlyingType);
 
-            // then see whether object is compadible with any of the built in converters
+            // then see whether object is compatible with any of the built in converters
             contract.InternalConverter = JsonSerializer.GetMatchingConverter(BuiltInConverters, contract.NonNullableUnderlyingType);
 
             if (contract.IsInstantiable
@@ -1300,7 +1300,7 @@ namespace Newtonsoft.Json.Serialization
                 return type.FullName;
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", new object[] { type.Namespace, type.Name });
+            return "{0}.{1}".FormatWith(CultureInfo.InvariantCulture, type.Namespace, type.Name);
         }
 
         /// <summary>
@@ -1314,7 +1314,7 @@ namespace Newtonsoft.Json.Serialization
             List<MemberInfo> members = GetSerializableMembers(type);
             if (members == null)
             {
-                throw new JsonSerializationException("Null collection of seralizable members returned.");
+                throw new JsonSerializationException("Null collection of serializable members returned.");
             }
 
             JsonPropertyCollection properties = new JsonPropertyCollection(type);

--- a/Src/Newtonsoft.Json/Serialization/IReferenceResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/IReferenceResolver.cs
@@ -39,7 +39,7 @@ namespace Newtonsoft.Json.Serialization
         object ResolveReference(object context, string reference);
 
         /// <summary>
-        /// Gets the reference for the sepecified object.
+        /// Gets the reference for the specified object.
         /// </summary>
         /// <param name="context">The serialization context.</param>
         /// <param name="value">The object to get a reference for.</param>

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -282,13 +282,13 @@ namespace Newtonsoft.Json.Serialization
         public bool? ItemIsReference { get; set; }
 
         /// <summary>
-        /// Gets or sets the the type name handling used when serializing the property's collection items.
+        /// Gets or sets the type name handling used when serializing the property's collection items.
         /// </summary>
         /// <value>The collection's items type name handling.</value>
         public TypeNameHandling? ItemTypeNameHandling { get; set; }
 
         /// <summary>
-        /// Gets or sets the the reference loop handling used when serializing the property's collection items.
+        /// Gets or sets the reference loop handling used when serializing the property's collection items.
         /// </summary>
         /// <value>The collection's items reference loop handling.</value>
         public ReferenceLoopHandling? ItemReferenceLoopHandling { get; set; }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1083,13 +1083,13 @@ namespace Newtonsoft.Json.Serialization
                 return true;
             }
 
-            // test tokentype here because null might not be convertable to some types, e.g. ignoring null when applied to DateTime
+            // test tokenType here because null might not be convertible to some types, e.g. ignoring null when applied to DateTime
             if (property.NullValueHandling.GetValueOrDefault(Serializer._nullValueHandling) == NullValueHandling.Ignore && tokenType == JsonToken.Null)
             {
                 return true;
             }
 
-            // test tokentype here because default value might not be convertable to actual type, e.g. default of "" for DateTime
+            // test tokenType here because default value might not be convertible to actual type, e.g. default of "" for DateTime
             if (HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Ignore)
                 && !HasFlag(property.DefaultValueHandling.GetValueOrDefault(Serializer._defaultValueHandling), DefaultValueHandling.Populate)
                 && JsonTokenUtils.IsPrimitiveToken(tokenType)
@@ -1891,7 +1891,7 @@ namespace Newtonsoft.Json.Serialization
         {
             ValidationUtils.ArgumentNotNull(creator, nameof(creator));
 
-            // only need to keep a track of properies presence if they are required or a value should be defaulted if missing
+            // only need to keep a track of properties' presence if they are required or a value should be defaulted if missing
             bool trackPresence = (contract.HasRequiredOrDefaultValueProperties || HasFlag(Serializer._defaultValueHandling, DefaultValueHandling.Populate));
 
             Type objectType = contract.UnderlyingType;
@@ -2304,7 +2304,7 @@ namespace Newtonsoft.Json.Serialization
         {
             OnDeserializing(reader, contract, newObject);
 
-            // only need to keep a track of properies presence if they are required or a value should be defaulted if missing
+            // only need to keep a track of properties' presence if they are required or a value should be defaulted if missing
             Dictionary<JsonProperty, PropertyPresence> propertiesPresence = (contract.HasRequiredOrDefaultValueProperties || HasFlag(Serializer._defaultValueHandling, DefaultValueHandling.Populate))
                 ? contract.Properties.ToDictionary(m => m, m => PropertyPresence.None)
                 : null;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -98,7 +98,7 @@ namespace Newtonsoft.Json.Serialization
             finally
             {
                 // clear root contract to ensure that if level was > 1 then it won't
-                // accidently be used for non root values
+                // accidentally be used for non root values
                 _rootType = null;
             }
         }

--- a/Src/Newtonsoft.Json/Utilities/CollectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/CollectionUtils.cs
@@ -139,7 +139,7 @@ namespace Newtonsoft.Json.Utilities
                         break;
                     }
 
-                    // incase we can't find an exact match, use first inexact
+                    // in case we can't find an exact match, use first inexact
                     if (match == null)
                     {
                         if (parameterType.IsAssignableFrom(constructorArgumentType))

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -1150,7 +1150,7 @@ namespace Newtonsoft.Json.Utilities
                 }
                 else
                 {
-                    // normal postive exponent case
+                    // normal positive exponent case
                     val = ((ulong)exp << 52) | ((val >> 11) & 0x000FFFFFFFFFFFFF);
                 }
 

--- a/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/EnumUtils.cs
@@ -126,7 +126,7 @@ namespace Newtonsoft.Json.Utilities
 
             if (!enumType.IsEnum())
             {
-                throw new ArgumentException("Type {0} is not an Enum.".FormatWith(CultureInfo.InvariantCulture, enumType), nameof(enumType));
+                throw new ArgumentException("Type {0} is not an enum.".FormatWith(CultureInfo.InvariantCulture, enumType.Name), nameof(enumType));
             }
 
             IList<object> enumValues = GetValues(enumType);
@@ -143,7 +143,7 @@ namespace Newtonsoft.Json.Utilities
                 catch (OverflowException e)
                 {
                     throw new InvalidOperationException(
-                        string.Format(CultureInfo.InvariantCulture, "Value from enum with the underlying type of {0} cannot be added to dictionary with a value type of {1}. Value was too large: {2}",
+                        "Value from enum with the underlying type of {0} cannot be added to dictionary with a value type of {1}. Value was too large: {2}".FormatWith(CultureInfo.InvariantCulture,
                             Enum.GetUnderlyingType(enumType), typeof(TUnderlyingType), Convert.ToUInt64(enumValues[i], CultureInfo.InvariantCulture)), e);
                 }
             }
@@ -155,7 +155,7 @@ namespace Newtonsoft.Json.Utilities
         {
             if (!enumType.IsEnum())
             {
-                throw new ArgumentException("Type '" + enumType.Name + "' is not an enum.");
+                throw new ArgumentException("Type {0} is not an enum.".FormatWith(CultureInfo.InvariantCulture, enumType.Name), nameof(enumType));
             }
 
             List<object> values = new List<object>();
@@ -173,7 +173,7 @@ namespace Newtonsoft.Json.Utilities
         {
             if (!enumType.IsEnum())
             {
-                throw new ArgumentException("Type '" + enumType.Name + "' is not an enum.");
+                throw new ArgumentException("Type {0} is not an enum.".FormatWith(CultureInfo.InvariantCulture, enumType.Name), nameof(enumType));
             }
 
             List<string> values = new List<string>();

--- a/Src/Newtonsoft.Json/Utilities/LinqBridge.cs
+++ b/Src/Newtonsoft.Json/Utilities/LinqBridge.cs
@@ -1281,7 +1281,7 @@ namespace Newtonsoft.Json.Utilities.LinqBridge
       IEnumerable<TSource> second,
       IEqualityComparer<TSource> comparer)
     {
-      CheckNotNull(first, "frist");
+      CheckNotNull(first, "first");
       CheckNotNull(second, "second");
 
       comparer = comparer ?? EqualityComparer<TSource>.Default;
@@ -1653,7 +1653,7 @@ namespace Newtonsoft.Json.Utilities.LinqBridge
         // ToDictionary is meant to throw ArgumentNullException if
         // keySelector produces a key that is null and 
         // Argument exception if keySelector produces duplicate keys 
-        // for two elements. Incidentally, the doucmentation for
+        // for two elements. Incidentally, the documentation for
         // IDictionary<TKey, TValue>.Add says that the Add method
         // throws the same exceptions under the same circumstances
         // so we don't need to do any additional checking or work

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -530,7 +530,7 @@ namespace Newtonsoft.Json.Utilities
                         throw new ArgumentException("MemberInfo '{0}' has index parameters".FormatWith(CultureInfo.InvariantCulture, member.Name), e);
                     }
                 default:
-                    throw new ArgumentException("MemberInfo '{0}' is not of type FieldInfo or PropertyInfo".FormatWith(CultureInfo.InvariantCulture, CultureInfo.InvariantCulture, member.Name), nameof(member));
+                    throw new ArgumentException("MemberInfo '{0}' is not of type FieldInfo or PropertyInfo".FormatWith(CultureInfo.InvariantCulture, member.Name), nameof(member));
             }
         }
 
@@ -983,7 +983,7 @@ namespace Newtonsoft.Json.Utilities
 
             GetChildPrivateProperties(propertyInfos, targetType, bindingAttr);
 
-            // a base class private getter/setter will be inaccessable unless the property was gotten from the base class
+            // a base class private getter/setter will be inaccessible unless the property was gotten from the base class
             for (int i = 0; i < propertyInfos.Count; i++)
             {
                 PropertyInfo member = propertyInfos[i];


### PR DESCRIPTION
This should fix most, if not all, of the remaining typos in the main project. Internal `//` line comments are largely left alone, as are typos in unit tests (except those that must be fixed to reflect changes in the main library).

There are a few other changes smuggled in that deal mostly with `string.Format` and `str.FormatWith`.