### PR TITLE
Optimise Extensions.Values

### DIFF
--- a/Src/Newtonsoft.Json/Linq/Extensions.cs
+++ b/Src/Newtonsoft.Json/Linq/Extensions.cs
@@ -184,13 +184,14 @@ namespace Newtonsoft.Json.Linq
         {
             ValidationUtils.ArgumentNotNull(source, nameof(source));
 
-            foreach (JToken token in source)
+            if (key == null)
             {
-                if (key == null)
+                foreach (T token in source)
                 {
-                    if (token is JValue)
+                    JValue value = token as JValue;
+                    if (value != null)
                     {
-                        yield return Convert<JValue, U>((JValue)token);
+                        yield return Convert<JValue, U>(value);
                     }
                     else
                     {
@@ -200,7 +201,10 @@ namespace Newtonsoft.Json.Linq
                         }
                     }
                 }
-                else
+            }
+            else
+            {
+                foreach (T token in source)
                 {
                     JToken value = token[key];
                     if (value != null)
@@ -209,8 +213,6 @@ namespace Newtonsoft.Json.Linq
                     }
                 }
             }
-
-            yield break;
         }
 
         //TODO


### PR DESCRIPTION
Branch on key being null or not once, rather than once per loop.

Remove up-cast of token to `JToken` to allow jitter to either elide `JValue` path if impossible or turn into null-test when inevitable.

Replace is-and-cast with as-and-null-test for quicker cast in cases where cast is still done.