### PR TITLE
Don't throw on BsonWriter.WriteValue for null Uri or byte[]

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Bson/BsonWriterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Bson/BsonWriterTests.cs
@@ -832,6 +832,56 @@ namespace Newtonsoft.Json.Tests.Bson
 
             Assert.IsFalse(reader.Read());
         }
+
+        [Test]
+        public void WriteUri()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("uri0");
+            writer.WriteValue(new Uri("http://example.net/"));
+            writer.WritePropertyName("uri1");
+            writer.WriteValue(default(Uri));
+            writer.WriteEndObject();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual("http://example.net/", reader.ReadAsString());
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.IsNull(reader.ReadAsString());
+        }
+
+        [Test]
+        public void WriteByteArray()
+        {
+            MemoryStream ms = new MemoryStream();
+            BsonWriter writer = new BsonWriter(ms);
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("array0");
+            writer.WriteValue(new byte[] {0, 1, 2, 3, 4, 5, 6, 7});
+            writer.WritePropertyName("array1");
+            writer.WriteValue(default(byte[]));
+            writer.WriteEndObject();
+            ms.Seek(0, SeekOrigin.Begin);
+
+            BsonReader reader = new BsonReader(ms);
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.StartObject, reader.TokenType);
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.AreEqual(new byte[] {0, 1, 2, 3, 4, 5, 6, 7}, reader.ReadAsBytes());
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(JsonToken.PropertyName, reader.TokenType);
+            Assert.IsNull(reader.ReadAsBytes());
+        }
 #endif
     }
 }

--- a/Src/Newtonsoft.Json/Bson/BsonWriter.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonWriter.cs
@@ -461,6 +461,12 @@ namespace Newtonsoft.Json.Bson
         /// <param name="value">The <see cref="Byte"/>[] value to write.</param>
         public override void WriteValue(byte[] value)
         {
+            if (value == null)
+            {
+                WriteNull();
+                return;
+            }
+
             base.WriteValue(value);
             AddToken(new BsonBinary(value, BsonBinaryType.Binary));
         }
@@ -491,6 +497,12 @@ namespace Newtonsoft.Json.Bson
         /// <param name="value">The <see cref="Uri"/> value to write.</param>
         public override void WriteValue(Uri value)
         {
+            if (value == null)
+            {
+                WriteNull();
+                return;
+            }
+
             base.WriteValue(value);
             AddToken(new BsonString(value.ToString(), true));
         }


### PR DESCRIPTION
Fixes #1142