### PR TITLE
Simplify Equals override in JValue

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -871,18 +871,7 @@ namespace Newtonsoft.Json.Linq
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            JValue otherValue = obj as JValue;
-            if (otherValue != null)
-            {
-                return Equals(otherValue);
-            }
-
-            return base.Equals(obj);
+            return Equals(obj as JValue);
         }
 
         /// <summary>


### PR DESCRIPTION
`otherValue == null`, including `obj == null`, both result in `false` and will also result in `false` if continued into the `Equals(JValue)` method in the first branch, so having separate branches is just extra work.