### PR TITLE
Coalesce nulls rather than null test where applicable.

### DIFF
--- a/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/EntityKeyMemberConverter.cs
@@ -59,13 +59,13 @@ namespace Newtonsoft.Json.Converters
             string keyName = (string)_reflectionObject.GetValue(value, KeyPropertyName);
             object keyValue = _reflectionObject.GetValue(value, ValuePropertyName);
 
-            Type keyValueType = (keyValue != null) ? keyValue.GetType() : null;
+            Type keyValueType = keyValue?.GetType();
 
             writer.WriteStartObject();
             writer.WritePropertyName((resolver != null) ? resolver.GetResolvedPropertyName(KeyPropertyName) : KeyPropertyName);
             writer.WriteValue(keyName);
             writer.WritePropertyName((resolver != null) ? resolver.GetResolvedPropertyName(TypePropertyName) : TypePropertyName);
-            writer.WriteValue((keyValueType != null) ? keyValueType.FullName : null);
+            writer.WriteValue(keyValueType?.FullName);
 
             writer.WritePropertyName((resolver != null) ? resolver.GetResolvedPropertyName(ValuePropertyName) : ValuePropertyName);
 

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1649,7 +1649,7 @@ namespace Newtonsoft.Json.Converters
         {
             if (reader.TokenType == JsonToken.String)
             {
-                return (reader.Value != null) ? reader.Value.ToString() : null;
+                return reader.Value?.ToString();
             }
             else if (reader.TokenType == JsonToken.Integer)
             {
@@ -1837,7 +1837,7 @@ namespace Newtonsoft.Json.Converters
                                                     throw JsonSerializationException.Create(reader, "Unexpected JsonToken: " + reader.TokenType);
                                                 }
 
-                                                attributeValue = (reader.Value != null) ? reader.Value.ToString() : null;
+                                                attributeValue = reader.Value?.ToString();
                                                 attributeNameValues.Add(jsonPrefix + ":" + attributeName, attributeValue);
                                                 break;
                                             default:

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -271,7 +271,7 @@ namespace Newtonsoft.Json
         /// </summary>
         public virtual Type ValueType
         {
-            get { return (_value != null) ? _value.GetType() : null; }
+            get { return _value?.GetType(); }
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -597,8 +597,7 @@ namespace Newtonsoft.Json
         public static JsonSerializer CreateDefault()
         {
             // copy static to local variable to avoid concurrency issues
-            Func<JsonSerializerSettings> defaultSettingsCreator = JsonConvert.DefaultSettings;
-            JsonSerializerSettings defaultSettings = (defaultSettingsCreator != null) ? defaultSettingsCreator() : null;
+            JsonSerializerSettings defaultSettings = JsonConvert.DefaultSettings?.Invoke();
 
             return Create(defaultSettings);
         }

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -528,7 +528,7 @@ namespace Newtonsoft.Json
                     WritePropertyName(value.ToString());
                     break;
                 case JsonToken.Comment:
-                    WriteComment((value != null) ? value.ToString() : null);
+                    WriteComment(value?.ToString());
                     break;
                 case JsonToken.Integer:
                     ValidationUtils.ArgumentNotNull(value, nameof(value));
@@ -599,7 +599,7 @@ namespace Newtonsoft.Json
                     }
                     break;
                 case JsonToken.Raw:
-                    WriteRawValue((value != null) ? value.ToString() : null);
+                    WriteRawValue(value?.ToString());
                     break;
                 case JsonToken.Bytes:
                     ValidationUtils.ArgumentNotNull(value, nameof(value));

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -322,7 +322,7 @@ namespace Newtonsoft.Json.Linq
 
                 JProperty property = Property(propertyName);
 
-                return (property != null) ? property.Value : null;
+                return property?.Value;
             }
             set
             {

--- a/Src/Newtonsoft.Json/Linq/JTokenReader.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenReader.cs
@@ -240,7 +240,7 @@ namespace Newtonsoft.Json.Linq
 
         private string SafeToString(object value)
         {
-            return (value != null) ? value.ToString() : null;
+            return value?.ToString();
         }
 
         bool IJsonLineInfo.HasLineInfo()

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -423,7 +423,7 @@ namespace Newtonsoft.Json.Linq
             {
                 if (operation == ExpressionType.Add || operation == ExpressionType.AddAssign)
                 {
-                    result = ((objA != null) ? objA.ToString() : null) + ((objB != null) ? objB.ToString() : null);
+                    result = objA?.ToString() + objB?.ToString();
                     return true;
                 }
             }
@@ -712,8 +712,8 @@ namespace Newtonsoft.Json.Linq
             get { return _value; }
             set
             {
-                Type currentType = (_value != null) ? _value.GetType() : null;
-                Type newType = (value != null) ? value.GetType() : null;
+                Type currentType = _value?.GetType();
+                Type newType = value?.GetType();
 
                 if (currentType != newType)
                 {
@@ -744,10 +744,10 @@ namespace Newtonsoft.Json.Linq
             switch (_valueType)
             {
                 case JTokenType.Comment:
-                    writer.WriteComment((_value != null) ? _value.ToString() : null);
+                    writer.WriteComment(_value?.ToString());
                     return;
                 case JTokenType.Raw:
-                    writer.WriteRawValue((_value != null) ? _value.ToString() : null);
+                    writer.WriteRawValue(_value?.ToString());
                     return;
                 case JTokenType.Null:
                     writer.WriteNull();
@@ -798,7 +798,7 @@ namespace Newtonsoft.Json.Linq
                     }
                     return;
                 case JTokenType.String:
-                    writer.WriteValue((_value != null) ? _value.ToString() : null);
+                    writer.WriteValue(_value?.ToString());
                     return;
                 case JTokenType.Boolean:
                     writer.WriteValue(Convert.ToBoolean(_value, CultureInfo.InvariantCulture));

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -99,7 +99,7 @@ namespace Newtonsoft.Json.Serialization
                     && string.Equals(reader.Value.ToString(), JsonTypeReflector.IdPropertyName, StringComparison.Ordinal))
                 {
                     reader.ReadAndAssert();
-                    id = (reader.Value != null) ? reader.Value.ToString() : null;
+                    id = reader.Value?.ToString();
                     reader.ReadAndAssert();
                 }
 
@@ -705,7 +705,7 @@ namespace Newtonsoft.Json.Serialization
                                 throw JsonSerializationException.Create(reader, "JSON reference {0} property must have a string or null value.".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.RefPropertyName));
                             }
 
-                            string reference = (reader.Value != null) ? reader.Value.ToString() : null;
+                            string reference = reader.Value?.ToString();
 
                             reader.ReadAndAssert();
 
@@ -745,7 +745,7 @@ namespace Newtonsoft.Json.Serialization
                         {
                             reader.ReadAndAssert();
 
-                            id = (reader.Value != null) ? reader.Value.ToString() : null;
+                            id = reader.Value?.ToString();
 
                             reader.ReadAndAssert();
                             metadataProperty = true;
@@ -771,9 +771,9 @@ namespace Newtonsoft.Json.Serialization
         private void ResolveTypeName(JsonReader reader, ref Type objectType, ref JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, string qualifiedTypeName)
         {
             TypeNameHandling resolvedTypeNameHandling =
-                ((member != null) ? member.TypeNameHandling : null)
-                ?? ((containerContract != null) ? containerContract.ItemTypeNameHandling : null)
-                ?? ((containerMember != null) ? containerMember.ItemTypeNameHandling : null)
+                member?.TypeNameHandling
+                ?? containerContract?.ItemTypeNameHandling
+                ?? containerMember?.ItemTypeNameHandling
                 ?? Serializer._typeNameHandling;
 
             if (resolvedTypeNameHandling != TypeNameHandling.None)

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -154,9 +154,9 @@ namespace Newtonsoft.Json.Serialization
             }
 
             JsonConverter converter =
-                ((member != null) ? member.Converter : null) ??
-                ((containerProperty != null) ? containerProperty.ItemConverter : null) ??
-                ((containerContract != null) ? containerContract.ItemConverter : null) ??
+                member?.Converter ??
+                containerProperty?.ItemConverter ??
+                containerContract?.ItemConverter ??
                 valueContract.Converter ??
                 Serializer.GetMatchingConverter(valueContract.UnderlyingType) ??
                 valueContract.InternalConverter;
@@ -554,7 +554,7 @@ namespace Newtonsoft.Json.Serialization
                     if (memberValue == null)
                     {
                         JsonObjectContract objectContract = contract as JsonObjectContract;
-                        Required resolvedRequired = property._required ?? ((objectContract != null) ? objectContract.ItemRequired : null) ?? Required.Default;
+                        Required resolvedRequired = property._required ?? objectContract?.ItemRequired ?? Required.Default;
                         if (resolvedRequired == Required.Always)
                         {
                             throw JsonSerializationException.Create(null, writer.ContainerPath, "Cannot write a null value for property '{0}'. Property requires a value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName), null);
@@ -1000,9 +1000,9 @@ namespace Newtonsoft.Json.Serialization
         private bool ShouldWriteType(TypeNameHandling typeNameHandlingFlag, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerProperty)
         {
             TypeNameHandling resolvedTypeNameHandling =
-                ((member != null) ? member.TypeNameHandling : null)
-                ?? ((containerProperty != null) ? containerProperty.ItemTypeNameHandling : null)
-                ?? ((containerContract != null) ? containerContract.ItemTypeNameHandling : null)
+                member?.TypeNameHandling
+                ?? containerProperty?.ItemTypeNameHandling
+                ?? containerContract?.ItemTypeNameHandling
                 ?? Serializer._typeNameHandling;
 
             if (HasFlag(resolvedTypeNameHandling, typeNameHandlingFlag))

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -649,7 +649,7 @@ namespace Newtonsoft.Json.Utilities
 
         private static object EnsureTypeAssignable(object value, Type initialType, Type targetType)
         {
-            Type valueType = (value != null) ? value.GetType() : null;
+            Type valueType = value?.GetType();
 
             if (value != null)
             {
@@ -672,7 +672,7 @@ namespace Newtonsoft.Json.Utilities
                 }
             }
 
-            throw new ArgumentException("Could not cast or convert from {0} to {1}.".FormatWith(CultureInfo.InvariantCulture, (initialType != null) ? initialType.ToString() : "{null}", targetType));
+            throw new ArgumentException("Could not cast or convert from {0} to {1}.".FormatWith(CultureInfo.InvariantCulture, initialType?.ToString() ?? "{null}", targetType));
         }
 
 #if !(DOTNET || PORTABLE40 || PORTABLE)

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -142,7 +142,7 @@ namespace Newtonsoft.Json.Utilities
 
         public static Type GetObjectType(object v)
         {
-            return (v != null) ? v.GetType() : null;
+            return v?.GetType();
         }
 
         public static string GetTypeName(Type t, TypeNameAssemblyFormatHandling assemblyFormat, ISerializationBinder binder)
@@ -735,7 +735,7 @@ namespace Newtonsoft.Json.Utilities
         {
             T[] attributes = GetAttributes<T>(attributeProvider, inherit);
 
-            return (attributes != null) ? attributes.FirstOrDefault() : null;
+            return attributes?.FirstOrDefault();
         }
 
 #if !(DOTNET || PORTABLE)


### PR DESCRIPTION
And I thought I'd found all of them in #1125.

Five reduce field accesses, and five reduce virtual calls.