### PR TITLE
Optimise DynamicProxyMetaObject

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -800,7 +800,7 @@ namespace Newtonsoft.Json.Linq
         /// </returns>
         protected override DynamicMetaObject GetMetaObject(Expression parameter)
         {
-            return new DynamicProxyMetaObject<JObject>(parameter, this, new JObjectDynamicProxy(), true);
+            return new DynamicProxyMetaObject<JObject>(parameter, this, new JObjectDynamicProxy());
         }
 
         private class JObjectDynamicProxy : DynamicProxy<JObject>

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2365,7 +2365,7 @@ namespace Newtonsoft.Json.Linq
         /// </returns>
         protected virtual DynamicMetaObject GetMetaObject(Expression parameter)
         {
-            return new DynamicProxyMetaObject<JToken>(parameter, this, new DynamicProxy<JToken>(), true);
+            return new DynamicProxyMetaObject<JToken>(parameter, this, new DynamicProxy<JToken>());
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -977,7 +977,7 @@ namespace Newtonsoft.Json.Linq
         /// </returns>
         protected override DynamicMetaObject GetMetaObject(Expression parameter)
         {
-            return new DynamicProxyMetaObject<JValue>(parameter, this, new JValueDynamicProxy(), true);
+            return new DynamicProxyMetaObject<JValue>(parameter, this, new JValueDynamicProxy());
         }
 
         private class JValueDynamicProxy : DynamicProxy<JValue>

--- a/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
@@ -45,11 +45,6 @@ namespace Newtonsoft.Json.Utilities
             _dontFallbackFirst = dontFallbackFirst;
         }
 
-        private new T Value
-        {
-            get { return (T)base.Value; }
-        }
-
         private bool IsOverridden(string method)
         {
             return ReflectionUtils.IsMethodOverridden(_proxy.GetType(), typeof(DynamicProxy<T>), method);
@@ -402,7 +397,7 @@ namespace Newtonsoft.Json.Utilities
 
         public override IEnumerable<string> GetDynamicMemberNames()
         {
-            return _proxy.GetDynamicMemberNames(Value);
+            return _proxy.GetDynamicMemberNames((T)Value);
         }
 
         // It is okay to throw NotSupported from this binder. This object

--- a/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
@@ -178,9 +178,9 @@ namespace Newtonsoft.Json.Utilities
 
         private static readonly Expression[] NoArgs = new Expression[0];
 
-        private static Expression[] GetArgs(params DynamicMetaObject[] args)
+        private static IEnumerable<Expression> GetArgs(params DynamicMetaObject[] args)
         {
-            return args.Select(arg => Expression.Convert(arg.Expression, typeof(object))).ToArray();
+            return args.Select(arg => Expression.Convert(arg.Expression, typeof(object)));
         }
 
         private static Expression[] GetArgArray(DynamicMetaObject[] args)
@@ -211,7 +211,7 @@ namespace Newtonsoft.Json.Utilities
         /// Helper method for generating a MetaObject which calls a
         /// specific method on Dynamic that returns a result
         /// </summary>
-        private DynamicMetaObject CallMethodWithResult(string methodName, DynamicMetaObjectBinder binder, Expression[] args, Fallback fallback, Fallback fallbackInvoke = null)
+        private DynamicMetaObject CallMethodWithResult(string methodName, DynamicMetaObjectBinder binder, IEnumerable<Expression> args, Fallback fallback, Fallback fallbackInvoke = null)
         {
             //
             // First, call fallback to do default binding
@@ -233,7 +233,7 @@ namespace Newtonsoft.Json.Utilities
             return _dontFallbackFirst ? callDynamic : fallback(callDynamic);
         }
 
-        private DynamicMetaObject BuildCallMethodWithResult(string methodName, DynamicMetaObjectBinder binder, Expression[] args, DynamicMetaObject fallbackResult, Fallback fallbackInvoke)
+        private DynamicMetaObject BuildCallMethodWithResult(string methodName, DynamicMetaObjectBinder binder, IEnumerable<Expression> args, DynamicMetaObject fallbackResult, Fallback fallbackInvoke)
         {
             //
             // Build a new expression like:
@@ -291,7 +291,7 @@ namespace Newtonsoft.Json.Utilities
         /// specific method on Dynamic, but uses one of the arguments for
         /// the result.
         /// </summary>
-        private DynamicMetaObject CallMethodReturnLast(string methodName, DynamicMetaObjectBinder binder, Expression[] args, Fallback fallback)
+        private DynamicMetaObject CallMethodReturnLast(string methodName, DynamicMetaObjectBinder binder, IEnumerable<Expression> args, Fallback fallback)
         {
             //
             // First, call fallback to do default binding
@@ -312,7 +312,7 @@ namespace Newtonsoft.Json.Utilities
             callArgs.Add(Expression.Convert(Expression, typeof(T)));
             callArgs.Add(Constant(binder));
             callArgs.AddRange(args);
-            callArgs[args.Length + 1] = Expression.Assign(result, callArgs[args.Length + 1]);
+            callArgs[callArgs.Count - 1] = Expression.Assign(result, callArgs[callArgs.Count - 1]);
 
             DynamicMetaObject callDynamic = new DynamicMetaObject(
                 Expression.Block(

--- a/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
+++ b/Src/Newtonsoft.Json/Utilities/DynamicProxyMetaObject.cs
@@ -170,7 +170,11 @@ namespace Newtonsoft.Json.Utilities
 
         private static IEnumerable<Expression> GetArgs(params DynamicMetaObject[] args)
         {
-            return args.Select(arg => Expression.Convert(arg.Expression, typeof(object)));
+            return args.Select(arg =>
+            {
+                Expression exp = arg.Expression;
+                return exp.Type.IsValueType() ? Expression.Convert(exp, typeof(object)) : exp;
+            });
         }
 
         private static Expression[] GetArgArray(DynamicMetaObject[] args)
@@ -180,10 +184,11 @@ namespace Newtonsoft.Json.Utilities
 
         private static Expression[] GetArgArray(DynamicMetaObject[] args, DynamicMetaObject value)
         {
-            return new Expression[]
+            var exp = value.Expression;
+            return new[]
             {
                 Expression.NewArrayInit(typeof(object), GetArgs(args)),
-                Expression.Convert(value.Expression, typeof(object))
+                exp.Type.IsValueType() ? Expression.Convert(exp, typeof(object)) : exp
             };
         }
 


### PR DESCRIPTION
Remove unnecessary `ToArray` call.

Remove `Value` property.

- One use compares with null, so cast to T is a waste, base property serves better.

- This leaves just one other use, so it can be inlined.

Remove `_dontFallbackFirst`

- Is always `true`. Remove it and branches for it being `false`.

Don't use `Expression.Convert` to cast reference types to object.

- The end-result is a no-op, so don't waste the allocation unless the type is a value type.