### PR TITLE
Reduce enumeration of rightResults in BooleanQueryExpression.IsMatch

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -2,6 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+#if NET20
+using Newtonsoft.Json.Utilities.LinqBridge;
+#else
+using System.Linq;
+#endif
 using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
@@ -88,24 +93,29 @@ namespace Newtonsoft.Json.Linq.JsonPath
 
         public override bool IsMatch(JToken root, JToken t)
         {
-            IEnumerable<JToken> rightResults = GetResult(root, t, Right);
-            IEnumerable<JToken> leftResults = GetResult(root, t, Left);
-
-            foreach (JToken leftResult in leftResults)
+            if (Operator == QueryOperator.Exists)
             {
-                if (Operator == QueryOperator.Exists)
+                return GetResult(root, t, Left).Any();
+            }
+
+            using (IEnumerator<JToken> leftResults = GetResult(root, t, Left).GetEnumerator())
+            {
+                if (leftResults.MoveNext())
                 {
-                    return true;
-                }
-                else
-                {
-                    foreach (JToken rightResult in rightResults)
+                    IEnumerable<JToken> rightResultsEn = GetResult(root, t, Right);
+                    ICollection<JToken> rightResults = rightResultsEn as ICollection<JToken> ?? rightResultsEn.ToList();
+
+                    do
                     {
-                        if (MatchTokens(leftResult, rightResult))
+                        JToken leftResult = leftResults.Current;
+                        foreach (JToken rightResult in rightResults)
                         {
-                            return true;
+                            if (MatchTokens(leftResult, rightResult))
+                            {
+                                return true;
+                            }
                         }
-                    }
+                    } while (leftResults.MoveNext());
                 }
             }
 


### PR DESCRIPTION
If `Operator` is `Exists` or `leftResults` is empty don't obtain `rightResults`, as not relevant.

Otherwise if `rightResults` is not an `ICollection<JToken>` load it into a `List` so it won't be recomputed on each enumeration of `leftResults`.