### PR TITLE
Optimise XmlNodeConverter

### DIFF
--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1177,6 +1177,11 @@ namespace Newtonsoft.Json.Converters
 
         private void SerializeGroupedNodes(JsonWriter writer, IXmlNode node, XmlNamespaceManager manager, bool writePropertyName)
         {
+            if (node.ChildNodes.Count == 0)
+            {
+                return;
+            }
+
             // group nodes together by name
             Dictionary<string, List<IXmlNode>> nodesGroupedByName = new Dictionary<string, List<IXmlNode>>();
 

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1768,11 +1768,10 @@ namespace Newtonsoft.Json.Converters
             }
 
             Dictionary<string, string> attributeNameValues = null;
-            bool finishedAttributes = false;
-            bool finishedElement = false;
+            bool finished = false;
 
             // read properties until first non-attribute is encountered
-            while (!finishedAttributes && !finishedElement && reader.Read())
+            while (!finished && reader.Read())
             {
                 switch (reader.TokenType)
                 {
@@ -1836,7 +1835,7 @@ namespace Newtonsoft.Json.Converters
                                             // special case $values, it will have a non-primitive value
                                             if (attributeName == JsonTypeReflector.ArrayValuesPropertyName)
                                             {
-                                                finishedAttributes = true;
+                                                finished = true;
                                                 break;
                                             }
 
@@ -1857,24 +1856,24 @@ namespace Newtonsoft.Json.Converters
                                             attributeNameValues.Add(jsonPrefix + ":" + attributeName, attributeValue);
                                             break;
                                         default:
-                                            finishedAttributes = true;
+                                            finished = true;
                                             break;
                                     }
                                     break;
                                 default:
-                                    finishedAttributes = true;
+                                    finished = true;
                                     break;
                             }
                         }
                         else
                         {
-                            finishedAttributes = true;
+                            finished = true;
                         }
 
                         break;
                     case JsonToken.EndObject:
                     case JsonToken.Comment:
-                        finishedElement = true;
+                        finished = true;
                         break;
                     default:
                         throw JsonSerializationException.Create(reader, "Unexpected JsonToken: " + reader.TokenType);

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1425,9 +1425,14 @@ namespace Newtonsoft.Json.Converters
         /// <returns>The object value.</returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            if (reader.TokenType == JsonToken.Null)
+            switch (reader.TokenType)
             {
-                return null;
+                case JsonToken.Null:
+                    return null;
+                case JsonToken.StartObject:
+                    break;
+                default:
+                    throw new JsonSerializationException("XmlNodeConverter can only convert JSON that begins with an object.");
             }
 
             XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
@@ -1467,11 +1472,6 @@ namespace Newtonsoft.Json.Converters
             if (document == null || rootNode == null)
             {
                 throw new JsonSerializationException("Unexpected type when converting XML: " + objectType);
-            }
-
-            if (reader.TokenType != JsonToken.StartObject)
-            {
-                throw new JsonSerializationException("XmlNodeConverter can only convert JSON that begins with an object.");
             }
 
             if (!string.IsNullOrEmpty(DeserializeRootElementName))


### PR DESCRIPTION
Short-circuit `SerializeGroupedNodes` on no child nodes: Avoids creating unused `Dictionary`.

Don't create `Dictionary` in `ReadAttributeElements` if it'll be empty.

Reduce calls to `JsonReader.TokenType` virtual property.