### PR TITLE
xml serialization with arrays when using JsonConvert.DeserializeXmlNode(String, String, Boolean)

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/XmlNodeConverterTest.cs
@@ -1162,6 +1162,32 @@ namespace Newtonsoft.Json.Tests.Converters
   }
 }";
             StringAssert.AreEqual(expected, arrayJsonText);
+
+            arrayXml = @"<root>
+			  <person id=""1"">
+				  <name>Alan</name>
+				  <url>http://www.google.com</url>
+				  <role json:Array=""true"" xmlns:json=""http://james.newtonking.com/projects/json"">Admin</role>
+			  </person>
+			</root>";
+
+            arrayDoc = new XmlDocument();
+            arrayDoc.LoadXml(arrayXml);
+
+            arrayJsonText = SerializeXmlNode(arrayDoc);
+            expected = @"{
+  ""root"": {
+    ""person"": {
+      ""@id"": ""1"",
+      ""name"": ""Alan"",
+      ""url"": ""http://www.google.com"",
+      ""role"": [
+        ""Admin""
+      ]
+    }
+  }
+}";
+            StringAssert.AreEqual(expected, arrayJsonText);
         }
 
         [Test]

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -2232,6 +2232,30 @@ namespace Newtonsoft.Json.Converters
         {
             foreach (IXmlNode xmlNode in c)
             {
+#if HAVE_XML_DOCUMENT
+                // ignores the attribute if it is the declaration of namespace "JsonNamespaceUri"
+                var xmlAttribute = xmlNode.WrappedNode as XmlAttribute;
+
+                if (xmlAttribute != null &&
+                    xmlAttribute.Prefix.Equals("xmlns", StringComparison.OrdinalIgnoreCase) && 
+                    xmlAttribute.Value == JsonNamespaceUri)
+                {
+                    continue;
+                }
+#endif
+
+#if HAVE_XLINQ
+                // ignores the attribute if it is the declaration of namespace "JsonNamespaceUri"
+                var xAttribute = xmlNode.WrappedNode as XAttribute;
+
+                if (xAttribute != null &&
+                    xAttribute.IsNamespaceDeclaration &&
+                    xAttribute.Value == JsonNamespaceUri)
+                {
+                    continue;
+                }
+#endif
+
                 if (xmlNode.NamespaceUri != JsonNamespaceUri)
                 {
                     return true;


### PR DESCRIPTION
Given this class
```csharp
public class TestInfo
{
    public TestInfo()
    {
        Key = "Key1";
        Name = "Name1";
        Values = new string[] { "Value1" };
        Properties = new Dictionary<string, string>() { { "Key", "Value" } };
    }

    public string Key { get; set; }
    public string Name { get; set; }
    public string[] Values { get; set; }
    public Dictionary<string, string> Properties { get; set; }
}
```
JsonConvert.DeserializeXmlNode generates the following xml when writeArrayAttribute is set to true:
```xml
<TestInfo>
  <Key>Key1</Key>
  <Name>Name1</Name>
  <Values json:Array="true" xmlns:json="http://james.newtonking.com/projects/json">Value1</Values>
  <Properties>
    <Key>Value</Key>
  </Properties>
</TestInfo>
```

If we save this xml to a file, load it back using XmlDocument.Load and then try to serialize it to json using JsonConvert.SerializeXmlNode, the resulting json looks like this:
```json
{
  "Key": "Key1",
  "Name": "Name1",
  "Values": [
    {
      "#text": "Value1"
    }
  ],
  "Properties": {
    "Key": "Value"
  }
}
```
As you can see the "Values" array is not correctly serialized, which means that if we try to pass this json to JsonConvert.DeserializeObject<TestInfo> an exception is thrown.