### PR TITLE
Fixing JToken line info set

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2229,7 +2229,7 @@ namespace Newtonsoft.Json.Linq
 
         internal void SetLineInfo(IJsonLineInfo lineInfo, JsonLoadSettings settings)
         {
-            if (settings != null && settings.LineInfoHandling == LineInfoHandling.Load)
+            if (settings != null && settings.LineInfoHandling != LineInfoHandling.Load)
             {
                 return;
             }


### PR DESCRIPTION
The `SetLineInfo` method of JToken was doing nothing on `LineInfoHandling.Load`, which in turn caused problems in JToken as well as JObject parsing methods.

This explains and closes #1249 

Edit: After the CI build failed, I discovered unit tests that depended on this behavior, but without explicitly using the property. Since it seems to be consolidated behavior, this PR would constitute a breaking change. For now, I'll just leave it for consideration.