### PR TITLE
Fix RootFilter to proper return an IEnumerable containing the root

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathExecuteTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathExecuteTests.cs
@@ -1271,11 +1271,85 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
 
             JArray a = JArray.Parse(json);
 
-            List<JToken> result = a.SelectTokens("$.[?($.store.bicycle.price < 20)]").ToList();
+            List<JToken> result = a.SelectTokens("$.[?($.[0].store.bicycle.price < 20)]").ToList();
             Assert.AreEqual(1, result.Count);
 
-            result = a.SelectTokens("$.[?($.store.bicycle.price < 10)]").ToList();
+            result = a.SelectTokens("$.[?($.[0].store.bicycle.price < 10)]").ToList();
             Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public void RootInFilterWithRootObject()
+        {
+            string json = @"{
+                ""store"" : {
+                    ""book"" : [
+                        {
+                            ""category"" : ""reference"",
+                            ""author"" : ""Nigel Rees"",
+                            ""title"" : ""Sayings of the Century"",
+                            ""price"" : 8.95
+                        },
+                        {
+                            ""category"" : ""fiction"",
+                            ""author"" : ""Evelyn Waugh"",
+                            ""title"" : ""Sword of Honour"",
+                            ""price"" : 12.99
+                        },
+                        {
+                            ""category"" : ""fiction"",
+                            ""author"" : ""Herman Melville"",
+                            ""title"" : ""Moby Dick"",
+                            ""isbn"" : ""0-553-21311-3"",
+                            ""price"" : 8.99
+                        },
+                        {
+                            ""category"" : ""fiction"",
+                            ""author"" : ""J. R. R. Tolkien"",
+                            ""title"" : ""The Lord of the Rings"",
+                            ""isbn"" : ""0-395-19395-8"",
+                            ""price"" : 22.99
+                        }
+                    ],
+                    ""bicycle"" : [
+                        {
+                            ""color"" : ""red"",
+                            ""price"" : 19.95
+                        }
+                    ]
+                },
+                ""expensive"" : 10
+            }";
+
+            JObject a = JObject.Parse(json);
+
+            List<JToken> result = a.SelectTokens("$..book[?(@.price <= $['expensive'])]").ToList();
+            Assert.AreEqual(2, result.Count);
+
+            result = a.SelectTokens("$.store..[?(@.price > $.expensive)]").ToList();
+            Assert.AreEqual(3, result.Count);
+        }
+
+        [Test]
+        public void RootInFilterWithInitializers()
+        {
+            JObject rootObject = new JObject
+            {
+                { "referenceDate", new JValue(DateTime.MinValue) },
+                {
+                    "dateObjectsArray",
+                    new JArray()
+                    {
+                        new JObject { { "date", new JValue(DateTime.MinValue) } },
+                        new JObject { { "date", new JValue(DateTime.MaxValue) } },
+                        new JObject { { "date", new JValue(DateTime.Now) } },
+                        new JObject { { "date", new JValue(DateTime.MinValue) } },
+                    }
+                }
+            };
+
+            List<JToken> result = rootObject.SelectTokens("$.dateObjectsArray[?(@.date == $.referenceDate)]").ToList();
+            Assert.AreEqual(2, result.Count);
         }
     }
 }

--- a/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
@@ -12,7 +12,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
 
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
-            return root;
+            yield return root;
         }
     }
 }


### PR DESCRIPTION
This PR is related to #998 and its resolution with https://github.com/JamesNK/Newtonsoft.Json/commit/ac2d61947428a34eb6e48d26bfd22f7141c757ce

I was trying to achieve what is described by the unit test `RootInFilterWithInitializers` in my project using the latest version of Newtonsoft.Json (10.0.2), but `SelectTokens` always returned an empty Enumerable.

Suspecting the problem came from DateTime JValue, I tried what is described by the unit test `RootInFilterWithRootObject`, which came from an example in https://github.com/json-path/JsonPath and that you can test in [Jayway JsonPath Evaluator](http://jsonpath.herokuapp.com/?path=$..book[?(@.price%20%3C=%20$[%27expensive%27])]).

Then I tried to understand the use case described by @saiphcbk in #998, but I couldn't... I honestly do not know what he is trying to achieve with those data and this JsonPath.
BTW, if you look carefully at his [Jayway JsonPath Evaluator example](http://jsonpath.herokuapp.com/?path=$.%5B?%28$.store.bicycle.price%20%3C%2020%29%5D), you would see that in Jayway implementation the result is wrapped in an array (couldn't figure why) and that in Goessner it just return all objects, wrapped in an array too.
I guess you couldn't understand this use case too, and that's why in your unit test `RootInFilter` you wrapped his root object in an array. But then the unit test itself seems to be bad because the JsonPath `$.store.bicycle.price` does not match anymore...

Anyway, it seems obvious to me that the `RootFilter` should return an IEnumerable containing the root JToken rather than the root JToken itself. If not, you cannot access top level properties, and the unit tests I added would fail.

I changed your unit test `RootInFilter` the less intrusive way I found, but I'm not sure if it is necessary to keep it.

I tried to be the most exhaustive I could about this issue, just let me know what do you think about it 😃 