### PR TITLE
Fix Issue 1340. Bring back default behavior for JsonSerializer.Binder…

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -1341,14 +1341,6 @@ namespace Newtonsoft.Json.Tests.Serialization
             serializer.SerializationBinder = customBinder;
             Assert.AreEqual(customBinder, serializer.SerializationBinder);
 
-            ExceptionAssert.Throws<InvalidOperationException>(() =>
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var serializationBinder = serializer.Binder;
-#pragma warning restore CS0618 // Type or member is obsolete
-                serializationBinder.ToString();
-            }, "Cannot get SerializationBinder because an ISerializationBinder was previously set.");
-
             serializer.CheckAdditionalContent = true;
             Assert.AreEqual(true, serializer.CheckAdditionalContent);
 
@@ -1577,14 +1569,6 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             serializerProxy.SerializationBinder = customBinder;
             Assert.AreEqual(customBinder, serializerProxy.SerializationBinder);
-
-            ExceptionAssert.Throws<InvalidOperationException>(() =>
-            {
-#pragma warning disable CS0618 // Type or member is obsolete
-                var serializationBinder = serializerProxy.Binder;
-#pragma warning restore CS0618 // Type or member is obsolete
-                serializationBinder.ToString();
-            }, "Cannot get SerializationBinder because an ISerializationBinder was previously set.");
 
             serializerProxy.CheckAdditionalContent = true;
             Assert.AreEqual(true, serializerProxy.CheckAdditionalContent);

--- a/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
@@ -55,6 +55,7 @@ using Newtonsoft.Json.Utilities;
 using System.Net;
 using System.Runtime.Serialization;
 using System.IO;
+using System.Reflection;
 
 namespace Newtonsoft.Json.Tests.Serialization
 {
@@ -883,7 +884,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             }
         }
 #endif
-
+        
         [Test]
         public void NewSerializeUsingCustomBinder()
         {
@@ -1317,6 +1318,7 @@ namespace Newtonsoft.Json.Tests.Serialization
 #endif
 
 #if !(NET20 || NET35)
+
         [Test]
         public void SerializationBinderWithFullName()
         {
@@ -2122,6 +2124,48 @@ namespace Newtonsoft.Json.Tests.Serialization
             StringAssert.AreEqual("Hello!", objWithMessage.Message.Value.Value);
         }
 #endif
+
+
+#if !(NET20 || NET35)
+
+        [Test]
+        public void SerializerWithDefaultBinder()
+        {
+            var serializer = JsonSerializer.Create();
+#pragma warning disable CS0618
+            Assert.NotNull(serializer.Binder);
+            StringAssert.Equals(typeof(DefaultSerializationBinder).FullName, serializer.Binder.GetType().FullName);
+#pragma warning restore CS0618 // Type or member is obsolete
+            StringAssert.Equals(typeof(DefaultSerializationBinder).FullName, serializer.SerializationBinder.GetType().FullName);
+        }
+        
+        [Test]
+        public void ObsoleteBinderThrowsIfISerializationBinderSet()
+        {   
+            var serializer = JsonSerializer.Create(new JsonSerializerSettings() { SerializationBinder = new FancyBinder() });
+#pragma warning disable CS0618
+            Assert.Throws<InvalidOperationException>(() => { var foo = serializer.Binder; });
+#pragma warning restore CS0618 // Type or member is obsolete
+            StringAssert.Equals(typeof(FancyBinder).Name, serializer.SerializationBinder.GetType().Name);
+        }
+
+
+        public class FancyBinder : ISerializationBinder
+        {
+            string annotate = new string(':', 3);
+            public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+            {
+                assemblyName = string.Format("FancyAssemblyName=>{0}", Assembly.GetAssembly(serializedType)?.GetName().Name);
+                typeName = string.Format("{0}{1}{0}", annotate, serializedType.Name);
+            }
+
+            public Type BindToType(string assemblyName, string typeName)
+            {
+                return null;
+            }
+        }
+#endif
+
     }
 
     public struct Message2

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -117,6 +117,17 @@ namespace Newtonsoft.Json
                     return adapter.SerializationBinder;
                 }
 
+                //Check if Default Binder was set
+                if (_serializationBinder.GetType().IsAssignableFrom(typeof(DefaultSerializationBinder)))
+                {
+                    adapter = new SerializationBinderAdapter(_serializationBinder as DefaultSerializationBinder);
+                }
+
+                if (adapter != null)
+                {
+                    return adapter.SerializationBinder;
+                }
+
                 throw new InvalidOperationException("Cannot get SerializationBinder because an ISerializationBinder was previously set.");
             }
             set


### PR DESCRIPTION
Fix for #1340
Bring Back default behavior of JsonSerializer.Binder. If not set it will return DefaultSerializationBinder.
This is especially important when shallow copying Serializer objects via reflection and Binder not set during JsonSerializer construction.
