### PR TITLE
feature: implement new regex equals operator for JsonPath

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
@@ -315,6 +315,17 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
         }
 
         [Test]
+        public void SinglePropertyAndFilterWithRegex()
+        {
+            JPath path = new JPath("Blah[ ?( @.name=~'/hi/i' ) ]");
+            Assert.AreEqual(2, path.Filters.Count);
+            Assert.AreEqual("Blah", ((FieldFilter)path.Filters[0]).Name);
+            BooleanQueryExpression expressions = (BooleanQueryExpression)((QueryFilter)path.Filters[1]).Expression;
+            Assert.AreEqual(QueryOperator.RegExEquals, expressions.Operator);
+            Assert.AreEqual("/hi/i", (string)(JToken)expressions.Right);
+        }
+
+        [Test]
         public void SinglePropertyAndFilterWithUnknownEscape()
         {
             ExceptionAssert.Throws<JsonException>(() => { new JPath(@"Blah[ ?( @.name=='h\i' ) ]"); }, @"Unknown escape character: \i");

--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/QueryExpressionTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/QueryExpressionTests.cs
@@ -157,6 +157,70 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
 
             Assert.IsFalse(compositeExpression.IsMatch(o3, o3));
         }
+        
+        [Test]
+        public void BooleanExpressionTest_RegExEqualsOperator()
+        {
+            BooleanQueryExpression e1 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/foo.*d/"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e1.IsMatch(null, new JArray("food")));
+            Assert.IsTrue(e1.IsMatch(null, new JArray("fooood and drink")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("FOOD")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("foo", "foog", "good")));
+
+            BooleanQueryExpression e2 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/Foo.*d/i"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e2.IsMatch(null, new JArray("food")));
+            Assert.IsTrue(e2.IsMatch(null, new JArray("fooood and drink")));
+            Assert.IsTrue(e2.IsMatch(null, new JArray("FOOD")));
+            Assert.IsFalse(e2.IsMatch(null, new JArray("foo", "foog", "good")));
+        }
+
+        [Test]
+        public void BooleanExpressionTest_RegExEqualsOperator_CornerCase()
+        {
+            BooleanQueryExpression e1 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/// comment/"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e1.IsMatch(null, new JArray("// comment")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("//comment", "/ comment")));
+
+            BooleanQueryExpression e2 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/<tag>.*</tag>/i"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e2.IsMatch(null, new JArray("<Tag>Test</Tag>", "")));
+            Assert.IsFalse(e2.IsMatch(null, new JArray("<tag>Test<tag>")));
+        }
 
         [Test]
         public void BooleanExpressionTest()

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -728,6 +728,12 @@ namespace Newtonsoft.Json.Linq.JsonPath
             {
                 return QueryOperator.Equals;
             }
+
+            if (Match("=~"))
+            {
+                return QueryOperator.RegExEquals;
+            }
+
             if (Match("!=") || Match("<>"))
             {
                 return QueryOperator.NotEquals;


### PR DESCRIPTION
Example: Blah[?( @.name =~'/hi/i' )].
Feature request from #858