### PR TITLE
Avoid packing test projects

### DIFF
--- a/Src/Newtonsoft.Json.TestConsole/Newtonsoft.Json.TestConsole.csproj
+++ b/Src/Newtonsoft.Json.TestConsole/Newtonsoft.Json.TestConsole.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Newtonsoft.Json.TestConsole</RootNamespace>
     <AssemblyName>Newtonsoft.Json.TestConsole</AssemblyName>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="BenchmarkDotNet.Artifacts\**" />

--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -16,6 +16,7 @@
     <Copyright>Copyright © James Newton-King 2008</Copyright>
     <AssemblyName>Newtonsoft.Json.Tests</AssemblyName>
     <RootNamespace>Newtonsoft.Json.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
     <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0' AND '$(TargetFramework)' != 'netcoreapp1.1'">Full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
This makes it so when I use `msbuild /t:pack` at the command line, it only packs the product assembly and not the test projects.