### PR TITLE
JsonTextReader.cs and work with big files.

### DIFF
--- a/Src/Newtonsoft.Json.TestConsole/App.config
+++ b/Src/Newtonsoft.Json.TestConsole/App.config
@@ -4,4 +4,7 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
+  <runtime>
+    <gcAllowVeryLargeObjects enabled="true"/>
+  </runtime>
 </configuration>

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadTests.cs
@@ -274,6 +274,46 @@ namespace Newtonsoft.Json.Tests.JsonTextReaderTests
         }
 
         [Test]
+        public void ReadLargeObjects()
+        {
+            const int nrItems = 2;
+            const int length = int.MaxValue / 3;
+
+            byte apostrophe = Encoding.ASCII.GetBytes(@"""").First();
+            byte openingBracket = Encoding.ASCII.GetBytes(@"[").First();
+            byte comma = Encoding.ASCII.GetBytes(@",").First();
+            byte closingBracket = Encoding.ASCII.GetBytes(@"]").First();
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.WriteByte(openingBracket);
+                for (int i = 0; i < nrItems; i++)
+                {
+                    ms.WriteByte(apostrophe);
+
+                    for (int j = 0; j <= length; j++)
+                        ms.WriteByte(7);
+
+                    ms.WriteByte(apostrophe);
+                    if (i < nrItems - 1)
+                        ms.WriteByte(comma);
+                }
+                ms.WriteByte(closingBracket);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                var reader = new JsonTextReader(new StreamReader(ms));
+
+                Assert.IsTrue(reader.Read());
+
+                for (int i = 0; i < nrItems; i++)
+                    Assert.IsTrue(reader.Read());
+
+                Assert.IsTrue(reader.Read());
+                Assert.IsFalse(reader.Read());
+            }
+        }
+
+        [Test]
         public void ReadSingleBytes()
         {
             StringReader s = new StringReader(@"""SGVsbG8gd29ybGQu""");

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -240,7 +240,7 @@ namespace Newtonsoft.Json
             // once in the last 10% of the buffer shift the remaining content to the start to avoid
             // unnecessarily increasing the buffer size when reading numbers/strings
             int length = _chars.Length;
-            if (length - _charPos <= length * 0.1)
+            if (length - _charPos <= length * 0.1 || length > int.MaxValue / 2 - 1)
             {
                 int count = _charsUsed - _charPos;
                 if (count > 0)

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -239,6 +239,7 @@ namespace Newtonsoft.Json
         {
             // once in the last 10% of the buffer shift the remaining content to the start to avoid
             // unnecessarily increasing the buffer size when reading numbers/strings
+            //romasz: do it also if we are reading large objects that can cause the buffer's new length to exceed int.MaxValue
             int length = _chars.Length;
             if (length - _charPos <= length * 0.1 || length > int.MaxValue / 2 - 1)
             {


### PR DESCRIPTION
We are doubling the _chars.Length when calculation newArrayLength, thus it's worth to check if we are not out of int.MaxValue.
This fix allows to work on bigger files.