### PR TITLE
Add ItemNullValueHandling to JsonObjectAttribute

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/NullValueHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/NullValueHandlingTests.cs
@@ -40,6 +40,20 @@ namespace Newtonsoft.Json.Tests.Serialization
     [TestFixture]
     public class NullValueHandlingTests : TestFixtureBase
     {
+        private const string MovieNullValueHandlingIncludeExpectedResult = @"{
+  ""Name"": ""Bad Boys III"",
+  ""Description"": ""It's no Bad Boys"",
+  ""Classification"": null,
+  ""Studio"": null,
+  ""ReleaseDate"": null,
+  ""ReleaseCountries"": null
+}";
+
+        private const string MovieNullValueHandlingIgnoreExpectedResult = @"{
+  ""Name"": ""Bad Boys III"",
+  ""Description"": ""It's no Bad Boys""
+}";
+
 #if !NET20
         [Test]
         public void DeserializeNullIntoDateTime()
@@ -110,19 +124,55 @@ namespace Newtonsoft.Json.Tests.Serialization
             //   "Description": "It's no Bad Boys"
             // }
 
-            StringAssert.AreEqual(@"{
-  ""Name"": ""Bad Boys III"",
-  ""Description"": ""It's no Bad Boys"",
-  ""Classification"": null,
-  ""Studio"": null,
-  ""ReleaseDate"": null,
-  ""ReleaseCountries"": null
-}", included);
+            StringAssert.AreEqual(MovieNullValueHandlingIncludeExpectedResult, included);
 
-            StringAssert.AreEqual(@"{
-  ""Name"": ""Bad Boys III"",
-  ""Description"": ""It's no Bad Boys""
-}", ignored);
+            StringAssert.AreEqual(MovieNullValueHandlingIgnoreExpectedResult, ignored);
+        }
+
+        [Test]
+        public void JsonObjectNullValueHandlingIgnore()
+        {
+            var movie = new MovieWithJsonObjectNullValueHandlingIgnore
+            {
+                Name = "Bad Boys III",
+                Description = "It's no Bad Boys"
+            };
+            
+            string ignored = JsonConvert.SerializeObject(movie,
+                Formatting.Indented,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Include });
+
+            // {
+            //   "Name": "Bad Boys III",
+            //   "Description": "It's no Bad Boys"
+            // }
+
+            StringAssert.AreEqual(MovieNullValueHandlingIgnoreExpectedResult, ignored);
+        }
+
+        [Test]
+        public void JsonObjectNullValueHandlingInclude()
+        {
+            var movie = new MovieWithJsonObjectNullValueHandlingInclude
+            {
+                Name = "Bad Boys III",
+                Description = "It's no Bad Boys"
+            };
+
+            string included = JsonConvert.SerializeObject(movie,
+                Formatting.Indented,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+            // {
+            //   "Name": "Bad Boys III",
+            //   "Description": "It's no Bad Boys",
+            //   "Classification": null,
+            //   "Studio": null,
+            //   "ReleaseDate": null,
+            //   "ReleaseCountries": null
+            // }
+
+            StringAssert.AreEqual(MovieNullValueHandlingIncludeExpectedResult, included);
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingIgnore.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingIgnore.cs
@@ -28,7 +28,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Tests.TestObjects
 {
-    [JsonObject(NullValueHandling = NullValueHandling.Ignore)]
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class MovieWithJsonObjectNullValueHandlingIgnore
     {
         public string Name { get; set; }

--- a/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingIgnore.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingIgnore.cs
@@ -1,0 +1,41 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    [JsonObject(NullValueHandling = NullValueHandling.Ignore)]
+    public class MovieWithJsonObjectNullValueHandlingIgnore
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Classification { get; set; }
+        public string Studio { get; set; }
+        public DateTime? ReleaseDate { get; set; }
+        public List<string> ReleaseCountries { get; set; }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingInclude.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingInclude.cs
@@ -28,7 +28,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Tests.TestObjects
 {
-    [JsonObject(NullValueHandling = NullValueHandling.Include)]
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Include)]
     public class MovieWithJsonObjectNullValueHandlingInclude
     {
         public string Name { get; set; }

--- a/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingInclude.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/MovieWithJsonObjectNullValueHandlingInclude.cs
@@ -1,0 +1,41 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    [JsonObject(NullValueHandling = NullValueHandling.Include)]
+    public class MovieWithJsonObjectNullValueHandlingInclude
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Classification { get; set; }
+        public string Studio { get; set; }
+        public DateTime? ReleaseDate { get; set; }
+        public List<string> ReleaseCountries { get; set; }
+    }
+}

--- a/Src/Newtonsoft.Json/JsonObjectAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonObjectAttribute.cs
@@ -34,11 +34,11 @@ namespace Newtonsoft.Json
     public sealed class JsonObjectAttribute : JsonContainerAttribute
     {
         private MemberSerialization _memberSerialization = MemberSerialization.OptOut;
-        private NullValueHandling _nullValueHandling = NullValueHandling.Include;
-
+        
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state
         internal Required? _itemRequired;
+        internal NullValueHandling? _nullValueHandling;
 
         /// <summary>
         /// Gets or sets the member serialization.
@@ -56,7 +56,7 @@ namespace Newtonsoft.Json
         /// <value>The null value handling.</value>
         public NullValueHandling NullValueHandling
         {
-            get => _nullValueHandling;
+            get => _nullValueHandling ?? default(NullValueHandling);
             set => _nullValueHandling = value;
         }
 

--- a/Src/Newtonsoft.Json/JsonObjectAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonObjectAttribute.cs
@@ -38,7 +38,7 @@ namespace Newtonsoft.Json
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state
         internal Required? _itemRequired;
-        internal NullValueHandling? _nullValueHandling;
+        internal NullValueHandling? _itemNullValueHandling;
 
         /// <summary>
         /// Gets or sets the member serialization.
@@ -54,10 +54,10 @@ namespace Newtonsoft.Json
         /// Gets or sets the null value handling.
         /// </summary>
         /// <value>The null value handling.</value>
-        public NullValueHandling NullValueHandling
+        public NullValueHandling ItemNullValueHandling
         {
-            get => _nullValueHandling ?? default(NullValueHandling);
-            set => _nullValueHandling = value;
+            get => _itemNullValueHandling ?? default(NullValueHandling);
+            set => _itemNullValueHandling = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/JsonObjectAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonObjectAttribute.cs
@@ -34,6 +34,7 @@ namespace Newtonsoft.Json
     public sealed class JsonObjectAttribute : JsonContainerAttribute
     {
         private MemberSerialization _memberSerialization = MemberSerialization.OptOut;
+        private NullValueHandling _nullValueHandling = NullValueHandling.Include;
 
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state
@@ -47,6 +48,16 @@ namespace Newtonsoft.Json
         {
             get => _memberSerialization;
             set => _memberSerialization = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the null value handling.
+        /// </summary>
+        /// <value>The null value handling.</value>
+        public NullValueHandling NullValueHandling
+        {
+            get => _nullValueHandling;
+            set => _nullValueHandling = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1511,7 +1511,7 @@ namespace Newtonsoft.Json.Serialization
 
             if (property.NullValueHandling == null && containerAttribute is JsonObjectAttribute objectAttribute)
             {
-                property.NullValueHandling = objectAttribute.NullValueHandling;
+                property.NullValueHandling = objectAttribute._nullValueHandling;
             }
 
             if (requiredAttribute != null)

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1509,6 +1509,11 @@ namespace Newtonsoft.Json.Serialization
 #endif
             }
 
+            if (property.NullValueHandling == null && containerAttribute is JsonObjectAttribute objectAttribute)
+            {
+                property.NullValueHandling = objectAttribute.NullValueHandling;
+            }
+
             if (requiredAttribute != null)
             {
                 property._required = Required.Always;

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1511,7 +1511,7 @@ namespace Newtonsoft.Json.Serialization
 
             if (property.NullValueHandling == null && containerAttribute is JsonObjectAttribute objectAttribute)
             {
-                property.NullValueHandling = objectAttribute._nullValueHandling;
+                property.NullValueHandling = objectAttribute._itemNullValueHandling;
             }
 
             if (requiredAttribute != null)


### PR DESCRIPTION
Resolves the main issue in #1429 - I would recommend spinning off separate issues for the other things discussed in the thread. This PR adds an ItemNullValueHandling property to JsonObjectAttribute that controls null value handling for all properties of that object. This reduces the need for multiple redundant JsonPropertyAttributes. So the heirarchy is JsonPropertyAttribute overrides JsonObjectAttribute overrides JsonSerializerSettings.