### PR TITLE
Fix for issue #1479 - support for distinct read & write converters

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/DistinctReadAndWriteConverterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/DistinctReadAndWriteConverterTest.cs
@@ -1,0 +1,65 @@
+using System;
+using Newtonsoft.Json;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Converters
+{
+    public class DistinctReadAndWriteConverterTests : TestFixtureBase
+    {
+        [Test]
+        public void SerializeString()
+        {
+            var settings = new JsonSerializerSettings()
+            {
+                Converters = { new ReadConverter(), new WriteConverter() }
+            };
+            var data = "testdata";
+            var serialized = JsonConvert.SerializeObject(data, settings);
+            Assert.AreEqual("\"C:testdata\"", serialized);
+            var result = JsonConvert.DeserializeObject<string>(serialized, settings);
+            Assert.AreEqual("testdata", result);
+        }
+    }
+
+    public class ReadConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+        public override bool CanRead => true;
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return reader.Value?.ToString()?.Substring(2);
+        }
+    }
+
+    public class WriteConverter : JsonConverter
+    {
+        public override bool CanWrite => true;
+        public override bool CanRead => false;
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(string);
+        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue("C:" + value);
+        }
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -1187,12 +1187,12 @@ namespace Newtonsoft.Json
             return _referenceResolver;
         }
 
-        internal JsonConverter GetMatchingConverter(Type type)
+        internal JsonConverter GetMatchingConverter(Type type, bool forWriting)
         {
-            return GetMatchingConverter(_converters, type);
+            return GetMatchingConverter(_converters, type, forWriting);
         }
 
-        internal static JsonConverter GetMatchingConverter(IList<JsonConverter> converters, Type objectType)
+        internal static JsonConverter GetMatchingConverter(IList<JsonConverter> converters, Type objectType, bool forWriting)
         {
 #if DEBUG
             ValidationUtils.ArgumentNotNull(objectType, nameof(objectType));
@@ -1200,15 +1200,19 @@ namespace Newtonsoft.Json
 
             if (converters != null)
             {
+                JsonConverter possibleConverter = null;
                 for (int i = 0; i < converters.Count; i++)
                 {
                     JsonConverter converter = converters[i];
 
                     if (converter.CanConvert(objectType))
                     {
-                        return converter;
+                        if (forWriting ? converter.CanWrite : converter.CanRead)
+                            return converter;
+                        possibleConverter = converter;
                     }
                 }
+                return possibleConverter;
             }
 
             return null;

--- a/Src/Newtonsoft.Json/Linq/JValue.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.Async.cs
@@ -49,7 +49,7 @@ namespace Newtonsoft.Json.Linq
         {
             if (converters != null && converters.Length > 0 && _value != null)
             {
-                JsonConverter matchingConverter = JsonSerializer.GetMatchingConverter(converters, _value.GetType());
+                JsonConverter matchingConverter = JsonSerializer.GetMatchingConverter(converters, _value.GetType(), true);
                 if (matchingConverter != null && matchingConverter.CanWrite)
                 {
                     // TODO: Call WriteJsonAsync when it exists.

--- a/Src/Newtonsoft.Json/Linq/JValue.cs
+++ b/Src/Newtonsoft.Json/Linq/JValue.cs
@@ -720,7 +720,7 @@ namespace Newtonsoft.Json.Linq
         {
             if (converters != null && converters.Length > 0 && _value != null)
             {
-                JsonConverter matchingConverter = JsonSerializer.GetMatchingConverter(converters, _value.GetType());
+                JsonConverter matchingConverter = JsonSerializer.GetMatchingConverter(converters, _value.GetType(), true);
                 if (matchingConverter != null && matchingConverter.CanWrite)
                 {
                     matchingConverter.WriteJson(writer, _value, JsonSerializer.CreateDefault());

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -758,7 +758,7 @@ namespace Newtonsoft.Json.Serialization
             contract.Converter = ResolveContractConverter(contract.NonNullableUnderlyingType);
 
             // then see whether object is compatible with any of the built in converters
-            contract.InternalConverter = JsonSerializer.GetMatchingConverter(BuiltInConverters, contract.NonNullableUnderlyingType);
+            contract.InternalConverter = JsonSerializer.GetMatchingConverter(BuiltInConverters, contract.NonNullableUnderlyingType, true);
 
             if (contract.IsInstantiable
                 && (ReflectionUtils.HasDefaultConstructor(contract.CreatedType, true) || contract.CreatedType.IsValueType()))

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -396,7 +396,7 @@ namespace Newtonsoft.Json.Serialization
                     // class attribute converter
                     converter = contract.Converter;
                 }
-                else if ((matchingConverter = Serializer.GetMatchingConverter(contract.UnderlyingType)) != null)
+                else if ((matchingConverter = Serializer.GetMatchingConverter(contract.UnderlyingType, false)) != null)
                 {
                     // passed in converters
                     converter = matchingConverter;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -158,7 +158,7 @@ namespace Newtonsoft.Json.Serialization
                 containerProperty?.ItemConverter ??
                 containerContract?.ItemConverter ??
                 valueContract.Converter ??
-                Serializer.GetMatchingConverter(valueContract.UnderlyingType) ??
+                Serializer.GetMatchingConverter(valueContract.UnderlyingType, true) ??
                 valueContract.InternalConverter;
 
             if (converter != null && converter.CanWrite)


### PR DESCRIPTION
Allows having distinct converters for writing & reading - when finding converters for writing, attempts to find one with CanWrite = true, when finding for reading, looks for one with CanRead = true, otherwise falls back to converter that can handle type.