### PR TITLE
Use cancellationToken in two places it was missed.

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextWriter.Async.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.Async.cs
@@ -407,7 +407,7 @@ namespace Newtonsoft.Json
         {
             await task.ConfigureAwait(false);
 
-            await _writer.WriteAsync('[').ConfigureAwait(false);
+            await _writer.WriteAsync('[', cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -437,7 +437,7 @@ namespace Newtonsoft.Json
         {
             await task.ConfigureAwait(false);
 
-            await _writer.WriteAsync('{').ConfigureAwait(false);
+            await _writer.WriteAsync('{', cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
I'm not sure if this was a simple slip up, or if I was thinking of skipping the check for speed reasons when I did this, but as these two calls can both often happen at as the first actual write to stream, which can have the longest delay waiting for the underlying layer, they should both have the opportunity to cancel if requested.