### PR TITLE
Performance optimization for integer value serialization.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Benchmarks/JsonTextWriterBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/JsonTextWriterBenchmarks.cs
@@ -45,6 +45,20 @@ namespace Newtonsoft.Json.Tests.Benchmarks
 
             return sw.ToString();
         }
+
+        [Benchmark]
+        public string SerializeIntegers()
+        {
+            StringWriter sw = new StringWriter();
+            JsonTextWriter jsonTextWriter = new JsonTextWriter(sw);
+            for (int i = 0; i < 10000; i++)
+            {
+                jsonTextWriter.WriteValue(i);
+            }
+            jsonTextWriter.Flush();
+
+            return sw.ToString();
+        }
     }
 }
 

--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -902,6 +902,9 @@ namespace Newtonsoft.Json.Tests
                 jsonWriter.WriteValue(long.MinValue);
                 jsonWriter.WriteValue(ulong.MaxValue);
                 jsonWriter.WriteValue(ulong.MinValue);
+                jsonWriter.WriteValue((ulong)uint.MaxValue - 1);
+                jsonWriter.WriteValue((ulong)uint.MaxValue);
+                jsonWriter.WriteValue((ulong)uint.MaxValue + 1);
 
                 jsonWriter.WriteEndArray();
             }
@@ -918,7 +921,10 @@ namespace Newtonsoft.Json.Tests
   9223372036854775807,
   -9223372036854775808,
   18446744073709551615,
-  0
+  0,
+  4294967294,
+  4294967295,
+  4294967296
 ]", sb.ToString());
         }
 

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -854,5 +854,56 @@ namespace Newtonsoft.Json
 
             return totalLength;
         }
+
+        private void WriteIntegerValue(int value)
+        {
+            if (value >= 0 && value <= 9)
+            {
+                _writer.Write((char)('0' + value));
+            }
+            else
+            {
+                bool negative = value < 0;
+                WriteIntegerValue(negative ? (uint)-value : (uint)value, negative);
+            }
+        }
+
+        private void WriteIntegerValue(uint uvalue, bool negative)
+        {
+            if (!negative & uvalue <= 9)
+            {
+                _writer.Write((char)('0' + uvalue));
+            }
+            else
+            {
+                int length = WriteNumberToBuffer(uvalue, negative);
+                _writer.Write(_writeBuffer, 0, length);
+            }
+        }
+
+        private int WriteNumberToBuffer(uint value, bool negative)
+        {
+            EnsureWriteBuffer();
+
+            int totalLength = MathUtils.IntLength(value);
+
+            if (negative)
+            {
+                totalLength++;
+                _writeBuffer[0] = '-';
+            }
+
+            int index = totalLength;
+
+            do
+            {
+                uint quotient = value / 10;
+                uint digit = value - (quotient * 10);
+                _writeBuffer[--index] = (char)('0' + digit);
+                value = quotient;
+            } while (value != 0);
+
+            return totalLength;
+        }
     }
 }

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -846,8 +846,10 @@ namespace Newtonsoft.Json
 
             do
             {
-                _writeBuffer[--index] = (char)('0' + value % 10);
-                value /= 10;
+                ulong quotient = value / 10;
+                ulong digit = value - (quotient * 10);
+                _writeBuffer[--index] = (char)('0' + digit);
+                value = quotient;
             } while (value != 0);
 
             return totalLength;

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -832,6 +832,12 @@ namespace Newtonsoft.Json
 
         private int WriteNumberToBuffer(ulong value, bool negative)
         {
+            if(value < uint.MaxValue)
+            {
+                // avoid the 64 bit division if possible
+                return WriteNumberToBuffer((uint)value, negative);                
+            }
+
             EnsureWriteBuffer();
 
             int totalLength = MathUtils.IntLength(value);

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -817,15 +817,15 @@ namespace Newtonsoft.Json
             }
         }
 
-        private void WriteIntegerValue(ulong uvalue, bool negative)
+        private void WriteIntegerValue(ulong value, bool negative)
         {
-            if (!negative & uvalue <= 9)
+            if (!negative & value <= 9)
             {
-                _writer.Write((char)('0' + uvalue));
+                _writer.Write((char)('0' + value));
             }
             else
             {
-                int length = WriteNumberToBuffer(uvalue, negative);
+                int length = WriteNumberToBuffer(value, negative);
                 _writer.Write(_writeBuffer, 0, length);
             }
         }
@@ -868,15 +868,15 @@ namespace Newtonsoft.Json
             }
         }
 
-        private void WriteIntegerValue(uint uvalue, bool negative)
+        private void WriteIntegerValue(uint value, bool negative)
         {
-            if (!negative & uvalue <= 9)
+            if (!negative & value <= 9)
             {
-                _writer.Write((char)('0' + uvalue));
+                _writer.Write((char)('0' + value));
             }
             else
             {
-                int length = WriteNumberToBuffer(uvalue, negative);
+                int length = WriteNumberToBuffer(value, negative);
                 _writer.Write(_writeBuffer, 0, length);
             }
         }

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -832,7 +832,7 @@ namespace Newtonsoft.Json
 
         private int WriteNumberToBuffer(ulong value, bool negative)
         {
-            if (value < uint.MaxValue)
+            if (value <= uint.MaxValue)
             {
                 // avoid the 64 bit division if possible
                 return WriteNumberToBuffer((uint)value, negative);

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -832,10 +832,10 @@ namespace Newtonsoft.Json
 
         private int WriteNumberToBuffer(ulong value, bool negative)
         {
-            if(value < uint.MaxValue)
+            if (value < uint.MaxValue)
             {
                 // avoid the 64 bit division if possible
-                return WriteNumberToBuffer((uint)value, negative);                
+                return WriteNumberToBuffer((uint)value, negative);
             }
 
             EnsureWriteBuffer();


### PR DESCRIPTION
Replaces a modulus operation with a multiply and subtract, which is measurably faster. Added a benchmark to target the change.

Running the benchmark in this configuration:
.NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2558.0

Before:
 SerializeIntegers | 895.3 us | 1.851 us | 1.546 us |

After:
 SerializeIntegers | 726.8 us | 3.092 us | 2.892 us |
