### PR TITLE
Update initialDepth for error handling

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
@@ -1026,6 +1026,21 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.AreEqual("Could not convert string to DateTime: 200NOTDATE. Path 'dateTime1', line 7, position 27.", errorMessages[2]);
         }
 
+        [Test]
+        public void HandleErrorInDictionaryObject()
+        {
+            var json = @"{
+                model1: { String1: 's1', Int1: 'x' },
+                model2: { String1: 's2', Int1: 2 }
+            }";
+            var dictionary = JsonConvert.DeserializeObject<TolerantDictionary<string, DataModel>>(json);
+
+            Assert.AreEqual(1, dictionary.Count);
+            Assert.IsTrue(dictionary.ContainsKey("model2"));
+            Assert.AreEqual("s2", dictionary["model2"].String1);
+            Assert.AreEqual(2, dictionary["model2"].Int1);
+        }
+
         private class DataModel
         {
             public string String1 { get; set; }
@@ -1131,6 +1146,18 @@ namespace Newtonsoft.Json.Tests.Serialization
         [OnError]
         internal void OnError(StreamingContext context, ErrorContext errorContext)
         {
+        }
+    }
+    
+    /// <summary>
+    /// A dictionary that ignores deserialization errors and excludes bad items
+    /// </summary>
+    public class TolerantDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+    {
+        [OnError]
+        public void OnDeserializationError(StreamingContext streamingContext, ErrorContext errorContext)
+        {
+            errorContext.Handled = true;
         }
     }
 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1472,7 +1472,7 @@ namespace Newtonsoft.Json.Serialization
 
                         if (IsErrorHandled(list, contract, errorPosition.Position, reader as IJsonLineInfo, reader.Path, ex))
                         {
-                            HandleError(reader, true, initialDepth);
+                            HandleError(reader, true, initialDepth + 1);
 
                             if (previousErrorIndex != null && previousErrorIndex == errorPosition.Position)
                             {
@@ -1624,7 +1624,7 @@ namespace Newtonsoft.Json.Serialization
 
                     if (IsErrorHandled(underlyingList, contract, errorPosition.Position, reader as IJsonLineInfo, reader.Path, ex))
                     {
-                        HandleError(reader, true, initialDepth);
+                        HandleError(reader, true, initialDepth + 1);
 
                         if (previousErrorIndex != null && previousErrorIndex == errorPosition.Position)
                         {
@@ -2334,7 +2334,7 @@ namespace Newtonsoft.Json.Serialization
                         {
                             if (IsErrorHandled(newObject, contract, memberName, reader as IJsonLineInfo, reader.Path, ex))
                             {
-                                HandleError(reader, true, initialDepth - 1);
+                                HandleError(reader, true, initialDepth);
                             }
                             else
                             {

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -2531,7 +2531,7 @@ namespace Newtonsoft.Json.Serialization
             {
                 reader.Skip();
 
-                while (reader.Depth > (initialDepth + 1))
+                while (reader.Depth > initialDepth)
                 {
                     if (!reader.Read())
                     {


### PR DESCRIPTION
When reading past the error in HandleError() method, the reader should keep reading until the depth is equal to the initial depth, rather then initialDepth + 1.
Only in case of a list or array (or multidimensional array), the initial depth should be advanced to +1, and that is because we don't want to skip list items in the same depth.

This change is also a fix to issue #1499 
A fix to the same issue was added earlier with commit f88ae288bc00836760ee8dfab526e4b944a191bb, however, that was a partial fix, as it only fixes the Object case but not the Dictionary case.
A unit test is added here to demonstrate the Dictionary error handling case, which was not covered by the previous fix.