### PR TITLE
enable source linking

### DIFF
--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -87,4 +87,7 @@
     <NugetTargetMoniker>.NETPortable,Version=v0.0,Profile=Profile259</NugetTargetMoniker>
     <LanguageTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets</LanguageTargets>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.3" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Much has changed since 2013 #103. That was source indexing with Windows PDB files. Instead, this pull request enables source linking of the Portable PDB files and adds them to the main nupkg to be published to NuGet Gallery. SourceLink was added to the .NET Foundation. Several Microsoft projects are expected to ship packages this way in the VS 15.6 time-frame.

Adding the portable pdb files to the nupkg increased it by 847 KB, about 0.8 MB.
![image](https://user-images.githubusercontent.com/80104/34449126-ac5e8f7a-ecd3-11e7-866f-810940ad58c1.png)

The .symbols.nupkg size is not affected. However, it becomes obsolete with source linking. You can remove it by removing `/p:IncludeSource=true`.

One reason for producing this is we would like to troubleshoot some performance issues by including source linked portable pdb files with Ionide https://github.com/fsharp/FsAutoComplete/issues/264.