### PR TITLE
Fixe for issue #1284

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue1284.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue1284.cs
@@ -1,0 +1,137 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    [TestFixture]
+    public class Issue1284
+    {
+        [Test]
+        public void Test()
+        {
+            var ser = new JsonSerializerSettings()
+            {
+                PreserveReferencesHandling = PreserveReferencesHandling.Objects,
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+            };
+            var b = new B(1, "Hello");
+
+            var a = new A(1.234) { B = b };
+            b.As = new List<A> { a };
+
+            var aChild = new AChild(1.45f) { A = a };
+
+            a.Child = aChild;
+
+            string json = JsonConvert.SerializeObject(b, ser);
+
+            Debug.WriteLine(json);
+
+            var deserializedObject = JsonConvert.DeserializeObject<B>(json, ser);
+
+            Assert.IsNotNull(deserializedObject);
+            Assert.IsNotNull(deserializedObject.As);
+            Assert.AreEqual(1, deserializedObject.As.Count);
+            Assert.IsNotNull(deserializedObject.As[0]);
+            Assert.IsNotNull(deserializedObject.As[0].B);
+            Assert.IsNotNull(deserializedObject.As[0].Child);
+            Assert.IsNotNull(deserializedObject.As[0].Child.A);
+            Assert.IsNotNull(deserializedObject.As[0]);
+        }
+
+        public class B
+        {
+            public int Id { get; set; }
+            private string Message;
+
+            public List<A> As;
+
+            public B(int id, string message)
+            {
+                Id = id;
+                Message = message;
+            }
+
+            //public B() // Must be present to deserialize A -> B
+            //{
+
+            //}
+        }
+
+        public class A
+        {
+            public double D { get; set; }
+
+            public B B
+            {
+                get;
+                set;
+            }
+
+            public AChild Child { get; set; }
+
+            public A(double d)
+            {
+                D = d;
+            }
+
+            //public A() // Must be present to deserialize AChild -> A
+            //{
+
+            //}
+        }
+
+        public class AChild
+        {
+            public A A { get; set; }
+            public float F { get; set; }
+
+            //public AChild() // Can be removed
+            //{
+
+            //}
+
+            public AChild(float f)
+            {
+                F = f;
+            }
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1888,7 +1888,7 @@ namespace Newtonsoft.Json.Serialization
                 TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Deserializing {0} using creator with parameters: {1}.".FormatWith(CultureInfo.InvariantCulture, contract.UnderlyingType, parameters)), null);
             }
 
-            List<CreatorPropertyContext> propertyContexts = ResolvePropertyAndCreatorValues(contract, containerProperty, reader, objectType);
+            List<CreatorPropertyContext> propertyContexts = ResolvePropertyAndCreatorValues(contract, containerProperty, reader, objectType, id, out var deferredExecution);
             if (trackPresence)
             {
                 foreach (JsonProperty property in contract.Properties)
@@ -1979,6 +1979,8 @@ namespace Newtonsoft.Json.Serialization
             {
                 AddReference(reader, id, createdObject);
             }
+
+            deferredExecution?.Invoke();
 
             OnDeserializing(reader, contract, createdObject);
 
@@ -2111,8 +2113,9 @@ namespace Newtonsoft.Json.Serialization
             return value;
         }
 
-        private List<CreatorPropertyContext> ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType)
+        private List<CreatorPropertyContext> ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, Type objectType, string id, out Action deferredExecution)
         {
+            deferredExecution = null;
             List<CreatorPropertyContext> propertyValues = new List<CreatorPropertyContext>();
             bool exit = false;
             do
@@ -2130,28 +2133,33 @@ namespace Newtonsoft.Json.Serialization
                         };
                         propertyValues.Add(creatorPropertyContext);
 
-                        JsonProperty property = creatorPropertyContext.ConstructorProperty ?? creatorPropertyContext.Property;
-                        if (property != null && !property.Ignored)
+                        JsonProperty property = creatorPropertyContext.ConstructorProperty;
+
+                        if ((property != null || id == null && (property = creatorPropertyContext.Property) != null) && !property.Ignored)
                         {
-                            if (property.PropertyContract == null)
-                            {
-                                property.PropertyContract = GetContractSafe(property.PropertyType);
-                            }
+                            ReadPropertyValue(contract, containerProperty, reader, memberName, creatorPropertyContext, property);
 
-                            JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.Converter, contract, containerProperty);
+                            continue;
+                        }
+                        else if (id != null && (property = creatorPropertyContext.Property) != null && !property.Ignored)
+                        {
+                            // Defer the deserialization till the object is created and the reference is stored in the reference resolver.
 
-                            if (!reader.ReadForType(property.PropertyContract, propertyConverter != null))
-                            {
-                                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
-                            }
+                            var deferredReader = new DeferredJsonReader(reader);
 
-                            if (propertyConverter != null && propertyConverter.CanRead)
+                            Action deferred = () =>
                             {
-                                creatorPropertyContext.Value = DeserializeConvertable(propertyConverter, reader, property.PropertyType, null);
+                                deferredReader.Read();
+                                ReadPropertyValue(contract, containerProperty, deferredReader, memberName, creatorPropertyContext, property);
+                            };
+
+                            if (deferredExecution == null)
+                            {
+                                deferredExecution = deferred;
                             }
                             else
                             {
-                                creatorPropertyContext.Value = CreateValueInternal(reader, property.PropertyType, property.PropertyContract, property, contract, containerProperty, null);
+                                deferredExecution += deferred;
                             }
 
                             continue;
@@ -2199,6 +2207,93 @@ namespace Newtonsoft.Json.Serialization
             }
 
             return propertyValues;
+        }
+
+        private void ReadPropertyValue(JsonObjectContract contract, JsonProperty containerProperty, JsonReader reader, string memberName, CreatorPropertyContext creatorPropertyContext, JsonProperty property)
+        {
+            if (property.PropertyContract == null)
+            {
+                property.PropertyContract = GetContractSafe(property.PropertyType);
+            }
+
+            JsonConverter propertyConverter = GetConverter(property.PropertyContract, property.Converter, contract, containerProperty);
+
+            if (!reader.ReadForType(property.PropertyContract, propertyConverter != null))
+            {
+                throw JsonSerializationException.Create(reader, "Unexpected end when setting {0}'s value.".FormatWith(CultureInfo.InvariantCulture, memberName));
+            }
+
+            if (propertyConverter != null && propertyConverter.CanRead)
+            {
+                creatorPropertyContext.Value = DeserializeConvertable(propertyConverter, reader, property.PropertyType, null);
+            }
+            else
+            {
+                var value = CreateValueInternal(reader, property.PropertyType, property.PropertyContract, property, contract, containerProperty, null);
+
+                if (value == null)
+                {
+
+                }
+
+                creatorPropertyContext.Value = value;
+            }
+        }
+
+        // Reads the child nodes of the current node of reader and stores them for deferred reading.
+        private sealed class DeferredJsonReader : JsonReader
+        {
+            private readonly Queue<StoredToken> _tokens = new Queue<StoredToken>();
+
+            public DeferredJsonReader(JsonReader reader)
+            {
+                if (reader == null)
+                    throw new ArgumentNullException(nameof(reader));
+
+                QuoteChar = reader.QuoteChar;
+                DateTimeZoneHandling = reader.DateTimeZoneHandling;
+                DateParseHandling = reader.DateParseHandling;
+                FloatParseHandling = reader.FloatParseHandling;
+                DateFormatString = reader.DateFormatString;
+                Culture = reader.Culture;
+
+                _tokens.Enqueue(new StoredToken { Token = reader.TokenType, Value = reader.Value });
+
+                if (reader.TokenType == JsonToken.PropertyName)
+                {
+                    reader.Read();
+                    _tokens.Enqueue(new StoredToken { Token = reader.TokenType, Value = reader.Value });
+                }
+
+                if (JsonTokenUtils.IsStartToken(reader.TokenType))
+                {
+                    var depth = reader.Depth;
+
+                    while (reader.Read() && (depth < reader.Depth))
+                    {
+                        _tokens.Enqueue(new StoredToken { Token = reader.TokenType, Value = reader.Value });
+                    }
+
+                    _tokens.Enqueue(new StoredToken { Token = reader.TokenType, Value = reader.Value });
+                }
+            }
+
+            public override bool Read()
+            {
+                if (_tokens.Count == 0)
+                    return false;
+
+                var storedToken = _tokens.Dequeue();
+
+                SetToken(storedToken.Token, storedToken.Value);
+                return true;
+            }
+
+            private struct StoredToken
+            {
+                public JsonToken Token;
+                public object Value;
+            }
         }
 
         public object CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, string id, out bool createdFromNonDefaultCreator)


### PR DESCRIPTION
# Issue
The problem when deserializing a cyclic object graph and not using default constructors is, that the object is put in the reference resolver after the child-objects are deserialized. They try to load the parent reference from the reference resolver that is not inserted yet.
# Proposed Solution
The proposed and implemented solution is to deffer the deserialization of child objects till the parent object is constructed and put to the reference resolver. For this to work, a new JsonReader type is implemented that queues the tokens of the child objects. When the parent object is registered in the reference resolver, the desesialization of the queued tokens is started.
# Drawbacks
When deserializing large json files, many tokens have to be stored, that is both, time and memory intensive to copy.
If the constructor of the parent type has a property for the referenced child type, the reference cannot be resolved, because the constructor is invoked before the child object is available.

```
public class Parent
{
    public int Id { get; set; }
    private string Message;
    private readonly Child _child;

    public Parent(Child child, int id, string message)
    {
        Id = id;
        Message = message;

        // child will be null
    }
}

public class Child
{
    public double D { get; set; }
    public Parent Parent { get; }

    public Child(Parent parent, double d)
    {
        Parent = parent; // This contains the parent just fine
        D = d;
    }
}
```

In the example above, the child parameter of the parents constructor will be null, while the child contructor receives the correct parent object.

If the child object is not injected into the parents constructor but a field or property, everything works as expected.

# Other possible solutions
Another possible solution is [instantiating the object without calling a constructor](https://msdn.microsoft.com/de-de/library/system.runtime.serialization.formatterservices.getuninitializedobject(v=vs.110).aspx), registering it in the reference-resolver and then [call the constructor](https://stackoverflow.com/questions/27380307/calling-constructor-in-c-sharp-for-a-second-time#answer-27380691).

This is the best option in my opinion but is impractical to implement here. It is a braking change. The ObjectConstructor<T> type had to be modified.

