### PR TITLE
First draft of adding ability to skip serialization read errors.

### DIFF
--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -123,6 +123,7 @@ namespace Newtonsoft.Json
         private bool _hasExceededMaxDepth;
         internal DateParseHandling _dateParseHandling;
         internal FloatParseHandling _floatParseHandling;
+        internal TypeCastErrorHandling _typeCastErrorHandling;
         private string _dateFormatString;
         private List<JsonPosition> _stack;
 
@@ -1072,6 +1073,23 @@ namespace Newtonsoft.Json
                     break;
                 default:
                     throw JsonReaderException.Create(this, "While setting the reader state back to current object an unexpected JsonType was encountered: {0}".FormatWith(CultureInfo.InvariantCulture, currentObject));
+            }
+        }
+
+        /// <summary>
+        /// Indicates the method that will be used during deserialization handing errors in conversion.
+        /// </summary>
+        public TypeCastErrorHandling TypeCastErrorHandling
+        {
+            get => _typeCastErrorHandling;
+            set
+            {
+                if (value < TypeCastErrorHandling.Throw || value > TypeCastErrorHandling.Ignore)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _typeCastErrorHandling = value;
             }
         }
 

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -66,6 +66,7 @@ namespace Newtonsoft.Json
         private DateFormatHandling? _dateFormatHandling;
         private DateTimeZoneHandling? _dateTimeZoneHandling;
         private DateParseHandling? _dateParseHandling;
+        private TypeCastErrorHandling? _typeCastErrorHandling;
         private FloatFormatHandling? _floatFormatHandling;
         private FloatParseHandling? _floatParseHandling;
         private StringEscapeHandling? _stringEscapeHandling;
@@ -458,6 +459,16 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Gets or sets how type cast errors are handled by the serializer.
+        /// The default value is <see cref="Json.TypeCastErrorHandling.Throw" />.
+        /// </summary>
+        public virtual TypeCastErrorHandling TypeCastErrorHandling
+        {
+            get => _typeCastErrorHandling ?? JsonSerializerSettings.DefaultTypeCastErrorHandling;
+            set => _typeCastErrorHandling = value;
+        }
+
+        /// <summary>
         /// Gets or sets how floating point numbers, e.g. 1.0 and 9.9, are parsed when reading JSON text.
         /// The default value is <see cref="Json.FloatParseHandling.Double" />.
         /// </summary>
@@ -676,6 +687,10 @@ namespace Newtonsoft.Json
             {
                 serializer.TypeNameAssemblyFormatHandling = settings.TypeNameAssemblyFormatHandling;
             }
+            if (settings._typeCastErrorHandling != null)
+            {
+                serializer.TypeCastErrorHandling = settings.TypeCastErrorHandling;
+            }
             if (settings._preserveReferencesHandling != null)
             {
                 serializer.PreserveReferencesHandling = settings.PreserveReferencesHandling;
@@ -815,9 +830,10 @@ namespace Newtonsoft.Json
             DateTimeZoneHandling? previousDateTimeZoneHandling;
             DateParseHandling? previousDateParseHandling;
             FloatParseHandling? previousFloatParseHandling;
+            TypeCastErrorHandling? previousTypeCastErrorHandling;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousTypeCastErrorHandling, out previousMaxDepth, out previousDateFormatString);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? CreateTraceJsonReader(reader)
@@ -831,7 +847,7 @@ namespace Newtonsoft.Json
                 TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
             }
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousTypeCastErrorHandling, previousMaxDepth, previousDateFormatString);
         }
 
         /// <summary>
@@ -889,9 +905,10 @@ namespace Newtonsoft.Json
             DateTimeZoneHandling? previousDateTimeZoneHandling;
             DateParseHandling? previousDateParseHandling;
             FloatParseHandling? previousFloatParseHandling;
+            TypeCastErrorHandling? previousTypeCastErrorHandling;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousTypeCastErrorHandling, out previousMaxDepth, out previousDateFormatString);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? CreateTraceJsonReader(reader)
@@ -905,12 +922,12 @@ namespace Newtonsoft.Json
                 TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
             }
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousTypeCastErrorHandling, previousMaxDepth, previousDateFormatString);
 
             return value;
         }
 
-        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out int? previousMaxDepth, out string previousDateFormatString)
+        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out TypeCastErrorHandling? previousTypeCastErrorHandling, out int? previousMaxDepth, out string previousDateFormatString)
         {
             if (_culture != null && !_culture.Equals(reader.Culture))
             {
@@ -962,6 +979,16 @@ namespace Newtonsoft.Json
                 previousMaxDepth = null;
             }
 
+            if (_typeCastErrorHandling != null && reader.TypeCastErrorHandling != _typeCastErrorHandling)
+            {
+                previousTypeCastErrorHandling = reader.TypeCastErrorHandling;
+                reader.TypeCastErrorHandling = _typeCastErrorHandling.GetValueOrDefault();
+            }
+            else
+            {
+                previousTypeCastErrorHandling = null;
+            }
+
             if (_dateFormatStringSet && reader.DateFormatString != _dateFormatString)
             {
                 previousDateFormatString = reader.DateFormatString;
@@ -981,7 +1008,7 @@ namespace Newtonsoft.Json
             }
         }
 
-        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, int? previousMaxDepth, string previousDateFormatString)
+        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, TypeCastErrorHandling? previousTypeCastErrorHandling, int? previousMaxDepth, string previousDateFormatString)
         {
             // reset reader back to previous options
             if (previousCulture != null)
@@ -999,6 +1026,10 @@ namespace Newtonsoft.Json
             if (previousFloatParseHandling != null)
             {
                 reader.FloatParseHandling = previousFloatParseHandling.GetValueOrDefault();
+            }
+            if (previousTypeCastErrorHandling != null)
+            {
+                reader.TypeCastErrorHandling = previousTypeCastErrorHandling.GetValueOrDefault();
             }
             if (_maxDepthSet)
             {

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -46,6 +46,7 @@ namespace Newtonsoft.Json
         internal const PreserveReferencesHandling DefaultPreserveReferencesHandling = PreserveReferencesHandling.None;
         internal const ConstructorHandling DefaultConstructorHandling = ConstructorHandling.Default;
         internal const TypeNameHandling DefaultTypeNameHandling = TypeNameHandling.None;
+        internal const TypeCastErrorHandling DefaultTypeCastErrorHandling = TypeCastErrorHandling.Throw;
         internal const MetadataPropertyHandling DefaultMetadataPropertyHandling = MetadataPropertyHandling.Default;
         internal static readonly StreamingContext DefaultContext;
 
@@ -85,6 +86,7 @@ namespace Newtonsoft.Json
         internal ConstructorHandling? _constructorHandling;
         internal TypeNameHandling? _typeNameHandling;
         internal MetadataPropertyHandling? _metadataPropertyHandling;
+        internal TypeCastErrorHandling? _typeCastErrorHandling;
 
         /// <summary>
         /// Gets or sets how reference loops (e.g. a class referencing itself) are handled.
@@ -174,6 +176,16 @@ namespace Newtonsoft.Json
             set => _typeNameHandling = value;
         }
 
+        /// <summary>
+        /// Gets or sets how type cast errors are handled by the serializer.
+        /// The default value is <see cref="Json.TypeCastErrorHandling.Throw" />.
+        /// </summary>
+        /// <value>The type cast error handling.</value>
+        public TypeCastErrorHandling TypeCastErrorHandling
+        {
+            get => _typeCastErrorHandling ?? DefaultTypeCastErrorHandling;
+            set => _typeCastErrorHandling = value;
+        }
         /// <summary>
         /// Gets or sets how metadata properties are used during deserialization.
         /// The default value is <see cref="Json.MetadataPropertyHandling.Default" />.

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -978,7 +978,22 @@ namespace Newtonsoft.Json.Serialization
                 }
                 catch (Exception ex)
                 {
-                    throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}'.".FormatWith(CultureInfo.InvariantCulture, MiscellaneousUtils.FormatValueForPrint(value), targetType), ex);
+                    // don't throw if we've configured the reader to ignore the errors (TypeCastErrorHandling.Ignore)
+                    if (reader._typeCastErrorHandling == TypeCastErrorHandling.Throw)
+                    {
+                        throw JsonSerializationException.Create(reader, "Error converting value {0} to type '{1}'.".FormatWith(CultureInfo.InvariantCulture, MiscellaneousUtils.FormatValueForPrint(value), targetType), ex);
+                    }
+                    else
+                    {
+                        if (contract.IsNullable)
+                        {
+                            return null;
+                        }
+                        else
+                        {
+                            return Activator.CreateInstance(contract.NonNullableUnderlyingType);
+                        }
+                    }
                 }
             }
 

--- a/Src/Newtonsoft.Json/TypeCastErrorHandling.cs
+++ b/Src/Newtonsoft.Json/TypeCastErrorHandling.cs
@@ -1,0 +1,43 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json
+{
+    /// <summary>
+    /// Indicates the method that will be used during deserialization handing errors in conversion.
+    /// </summary>
+    public enum TypeCastErrorHandling
+    {
+        /// <summary>
+        /// In throw mode, any errors casting json to the appropriate property types are passed to the executing program.
+        /// </summary>
+        Throw = 0,
+
+        /// <summary>
+        /// In ignore mode, any errors casting json to the appropriate property types are ignored, and deserialization is resumed.
+        /// </summary>
+        Ignore = 1,
+    }
+}


### PR DESCRIPTION
Needs interface/architecture review + tests

@JamesNK can I get your input on this before I put too much more work into it however.

Basically, I want to be able to skip read-errors if I'm reading potentially out-dated or corrupted JSON, and still preserve as much of the original JSON as possible.

The idea is, if you set TypeCastErrorHandling.Ignore on your JsonSerializerSettings, then any type-cast errors encountered during reading are ignored, allowing you to read as much of the original JSON as possible, then correct any corrupted nodes later.

This applies to JToken.ToObject, JsonConvert.Deserialize, and anywhere else that can utilize JsonSerializerSettings.