### PR TITLE
Support for regex match operator for jsonpath queries

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
@@ -317,7 +317,7 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
         [Test]
         public void SinglePropertyAndFilterWithRegex()
         {
-            JPath path = new JPath("Blah[ ?( @.name=~'/hi/i' ) ]");
+            JPath path = new JPath("Blah[ ?( @.name=~/hi/i ) ]");
             Assert.AreEqual(2, path.Filters.Count);
             Assert.AreEqual("Blah", ((FieldFilter)path.Filters[0]).Name);
             BooleanQueryExpression expressions = (BooleanQueryExpression)((QueryFilter)path.Filters[1]).Expression;

--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/JPathParseTests.cs
@@ -315,6 +315,17 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
         }
 
         [Test]
+        public void SinglePropertyAndFilterWithRegex()
+        {
+            JPath path = new JPath("Blah[ ?( @.name=~'/hi/i' ) ]");
+            Assert.AreEqual(2, path.Filters.Count);
+            Assert.AreEqual("Blah", ((FieldFilter)path.Filters[0]).Name);
+            BooleanQueryExpression expressions = (BooleanQueryExpression)((QueryFilter)path.Filters[1]).Expression;
+            Assert.AreEqual(QueryOperator.RegExEquals, expressions.Operator);
+            Assert.AreEqual("/hi/i", (string)(JToken)expressions.Right);
+        }
+
+        [Test]
         public void SinglePropertyAndFilterWithUnknownEscape()
         {
             ExceptionAssert.Throws<JsonException>(() => { new JPath(@"Blah[ ?( @.name=='h\i' ) ]"); }, @"Unknown escape character: \i");

--- a/Src/Newtonsoft.Json.Tests/Linq/JsonPath/QueryExpressionTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JsonPath/QueryExpressionTests.cs
@@ -157,6 +157,70 @@ namespace Newtonsoft.Json.Tests.Linq.JsonPath
 
             Assert.IsFalse(compositeExpression.IsMatch(o3, o3));
         }
+        
+        [Test]
+        public void BooleanExpressionTest_RegExEqualsOperator()
+        {
+            BooleanQueryExpression e1 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/foo.*d/"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e1.IsMatch(null, new JArray("food")));
+            Assert.IsTrue(e1.IsMatch(null, new JArray("fooood and drink")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("FOOD")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("foo", "foog", "good")));
+
+            BooleanQueryExpression e2 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/Foo.*d/i"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e2.IsMatch(null, new JArray("food")));
+            Assert.IsTrue(e2.IsMatch(null, new JArray("fooood and drink")));
+            Assert.IsTrue(e2.IsMatch(null, new JArray("FOOD")));
+            Assert.IsFalse(e2.IsMatch(null, new JArray("foo", "foog", "good")));
+        }
+
+        [Test]
+        public void BooleanExpressionTest_RegExEqualsOperator_CornerCase()
+        {
+            BooleanQueryExpression e1 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/// comment/"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e1.IsMatch(null, new JArray("// comment")));
+            Assert.IsFalse(e1.IsMatch(null, new JArray("//comment", "/ comment")));
+
+            BooleanQueryExpression e2 = new BooleanQueryExpression
+            {
+                Operator = QueryOperator.RegExEquals,
+                Right = new JValue("/<tag>.*</tag>/i"),
+                Left = new List<PathFilter>
+                {
+                    new ArrayIndexFilter()
+                }
+            };
+
+            Assert.IsTrue(e2.IsMatch(null, new JArray("<Tag>Test</Tag>", "")));
+            Assert.IsFalse(e2.IsMatch(null, new JArray("<tag>Test<tag>")));
+        }
 
         [Test]
         public void BooleanExpressionTest()

--- a/Src/Newtonsoft.Json/Converters/RegexConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/RegexConverter.cs
@@ -29,6 +29,7 @@ using Newtonsoft.Json.Bson;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Converters
 {
@@ -149,25 +150,7 @@ namespace Newtonsoft.Json.Converters
             string patternText = regexText.Substring(1, patternOptionDelimiterIndex - 1);
             string optionsText = regexText.Substring(patternOptionDelimiterIndex + 1);
 
-            RegexOptions options = RegexOptions.None;
-            foreach (char c in optionsText)
-            {
-                switch (c)
-                {
-                    case 'i':
-                        options |= RegexOptions.IgnoreCase;
-                        break;
-                    case 'm':
-                        options |= RegexOptions.Multiline;
-                        break;
-                    case 's':
-                        options |= RegexOptions.Singleline;
-                        break;
-                    case 'x':
-                        options |= RegexOptions.ExplicitCapture;
-                        break;
-                }
-            }
+            RegexOptions options = MiscellaneousUtils.GetRegexOptions(optionsText);
 
             return new Regex(patternText, options);
         }

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -649,6 +649,11 @@ namespace Newtonsoft.Json.Linq.JsonPath
                     return true;
                 }
             }
+            else if (currentChar == '/')
+            {
+                value = ReadRegexString();
+                return true;
+            }
 
             value = null;
             return false;
@@ -696,6 +701,83 @@ namespace Newtonsoft.Json.Linq.JsonPath
             }
 
             throw new JsonException("Path ended with an open string.");
+        }
+
+        private string ReadRegexString()
+        {
+            var sb = new StringBuilder("/");
+
+            _currentIndex++;
+            while (_currentIndex < _expression.Length)
+            {
+                char currentChar = _expression[_currentIndex];
+                if (currentChar == '\\' && _currentIndex + 1 < _expression.Length)
+                {
+                    _currentIndex++;
+
+                    if (_expression[_currentIndex] == '\'')
+                    {
+                        sb.Append('\'');
+                    }
+                    else if (_expression[_currentIndex] == '\\')
+                    {
+                        sb.Append('\\');
+                    }
+                    else if (_expression[_currentIndex] == '/')
+                    {
+                        sb.Append('/');
+                    }
+                    else
+                    {
+                        throw new JsonException(@"Unknown escape character: \" + _expression[_currentIndex]);
+                    }
+
+                    _currentIndex++;
+                }
+                else if (currentChar == '/')
+                {
+                    sb.Append(currentChar);
+                    _currentIndex++;
+
+                    string options = ParseRegexOptions();
+                    sb.Append(options);
+
+                    return sb.ToString();
+                }
+                else
+                {
+                    _currentIndex++;
+                    sb.Append(currentChar);
+                }
+            }
+
+            throw new JsonException("Path ended with an open string.");
+        }
+
+        private string ParseRegexOptions()
+        {
+            var optionsSb = new StringBuilder();
+
+            while (_currentIndex < _expression.Length)
+            {
+                char currentChar = _expression[_currentIndex];
+
+                if (currentChar == 'i'
+                    || currentChar == 'm'
+                    || currentChar == 's'
+                    || currentChar == 'u'
+                    || currentChar == 'x')
+                {
+                    _currentIndex++;
+                    optionsSb.Append(currentChar);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return optionsSb.ToString();
         }
 
         private bool Match(string s)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -728,6 +728,12 @@ namespace Newtonsoft.Json.Linq.JsonPath
             {
                 return QueryOperator.Equals;
             }
+
+            if (Match("=~"))
+            {
+                return QueryOperator.RegExEquals;
+            }
+
             if (Match("!=") || Match("<>"))
             {
                 return QueryOperator.NotEquals;

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -194,33 +194,20 @@ namespace Newtonsoft.Json.Linq.JsonPath
             return false;
         }
 
-        private bool RegExEquals(JValue value, JValue queryValue)
+        private static bool RegExEquals(JValue input, JValue pattern)
         {
-            if (queryValue.Type != JTokenType.String || value.Type != JTokenType.String)
+            if (input.Type != JTokenType.String || pattern.Type != JTokenType.String)
             {
                 return false;
             }
 
-            var regExArray = ((string)queryValue.Value).Split('/');
-            if (regExArray.Length < 3)
-            {
-                throw new Exception("Syntax error when using regex compare");
-            }
+            var regexText = (string)pattern.Value;
+            int patternOptionDelimiterIndex = regexText.LastIndexOf('/');
 
-            var trimFirstAndLastMember = regExArray.Skip(1).Take(regExArray.Length - 2).ToArray();
-            var regExQuery = string.Join("/", trimFirstAndLastMember);
+            string patternText = regexText.Substring(1, patternOptionDelimiterIndex - 1);
+            string optionsText = regexText.Substring(patternOptionDelimiterIndex + 1);
 
-            if (regExArray.Last() == string.Empty)
-            {
-                return Regex.IsMatch((string)value.Value, regExQuery);
-            }
-
-            if (regExArray.Last() == "i")
-            {
-                return Regex.IsMatch((string)value.Value, regExQuery, RegexOptions.IgnoreCase);
-            }
-
-            throw new Exception("Syntax error when using regex compare");
+            return Regex.IsMatch((string)input.Value, patternText, MiscellaneousUtils.GetRegexOptions(optionsText));
         }
 
         private bool EqualsWithStringCoercion(JValue value, JValue queryValue)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -134,7 +134,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
                 switch (Operator)
                 {
                     case QueryOperator.RegExEquals:
-                        if (RegExEquals(leftValue, rightValue))
+                        if (RegexEquals(leftValue, rightValue))
                         {
                             return true;
                         }
@@ -194,7 +194,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
             return false;
         }
 
-        private static bool RegExEquals(JValue input, JValue pattern)
+        private static bool RegexEquals(JValue input, JValue pattern)
         {
             if (input.Type != JTokenType.String || pattern.Type != JTokenType.String)
             {

--- a/Src/Newtonsoft.Json/Utilities/MiscellaneousUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/MiscellaneousUtils.cs
@@ -30,6 +30,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Text;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Newtonsoft.Json.Utilities
 {
@@ -154,5 +155,31 @@ namespace Newtonsoft.Json.Utilities
 
             return value.ToString();
         }
+
+        internal static RegexOptions GetRegexOptions(string optionsText)
+        {
+            var options = RegexOptions.None;
+            foreach (char c in optionsText)
+            {
+                switch (c)
+                {
+                    case 'i':
+                        options |= RegexOptions.IgnoreCase;
+                        break;
+                    case 'm':
+                        options |= RegexOptions.Multiline;
+                        break;
+                    case 's':
+                        options |= RegexOptions.Singleline;
+                        break;
+                    case 'x':
+                        options |= RegexOptions.ExplicitCapture;
+                        break;
+                }
+            }
+
+            return options;
+        }
+
     }
 }


### PR DESCRIPTION
Added implementation for feature request #858. It is based on previous request #1382.
Implementation is using .NET regex syntax, and it is compatible with Jayway implementation.