### PR TITLE
Ensure that RepositoryUrl follows documentation

### DIFF
--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -21,7 +21,7 @@
     <PackageIconUrl>https://www.newtonsoft.com/content/images/nugeticon.png</PackageIconUrl>
     <PackageProjectUrl>https://www.newtonsoft.com/json</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/JamesNK/Newtonsoft.Json</RepositoryUrl>
+    <RepositoryUrl>https://github.com/JamesNK/Newtonsoft.Json.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Newtonsoft.Json</RootNamespace>
     <AssemblyName>Newtonsoft.Json</AssemblyName>


### PR DESCRIPTION
In the documentation for the [MSBuild Pack Target](https://github.com/emgarten/docs.microsoft.com-nuget/blob/patch-1/docs/reference/msbuild-targets.md#pack-target) it should be `Repository URL used to clone or retrieve source code` and that the example is `https://github.com/NuGet/NuGet.Client.git`.

This change makes the Nuget packaging follow that example.