### PR TITLE
Added DataTableColumnType to JsonSerializerSettings.

### DIFF
--- a/Src/Newtonsoft.Json/DataTableColumnType.cs
+++ b/Src/Newtonsoft.Json/DataTableColumnType.cs
@@ -1,0 +1,19 @@
+﻿
+namespace Newtonsoft.Json
+{
+    /// <summary>
+    /// Specifies how data type for columns are chosen for DataTable
+    /// </summary>
+    public enum DataTableColumnType
+    {
+        /// <summary>
+        /// Automatic, use the first example data's type as the column data type
+        /// </summary>
+        Automatic,
+
+        /// <summary>
+        /// Force as System.Object
+        /// </summary>
+        Object
+    }
+}

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -122,6 +122,8 @@ namespace Newtonsoft.Json
         private int? _maxDepth;
         private bool _hasExceededMaxDepth;
         internal DateParseHandling _dateParseHandling;
+        internal DataTableColumnType _dataTableColumnType;
+        
         internal FloatParseHandling _floatParseHandling;
         private string _dateFormatString;
         private List<JsonPosition> _stack;
@@ -173,6 +175,19 @@ namespace Newtonsoft.Json
                 }
 
                 _dateTimeZoneHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how column data types are defined in DataTables.
+        /// </summary>
+        public DataTableColumnType DataTableColumnType
+        {
+            get => _dataTableColumnType;
+            set
+            {
+
+                _dataTableColumnType = value;
             }
         }
 

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -38,6 +38,9 @@ using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;
 
 namespace Newtonsoft.Json
 {
+
+   
+
     /// <summary>
     /// Serializes and deserializes objects into and from the JSON format.
     /// The <see cref="JsonSerializer"/> enables you to control how objects are encoded into JSON.
@@ -66,6 +69,7 @@ namespace Newtonsoft.Json
         private DateFormatHandling? _dateFormatHandling;
         private DateTimeZoneHandling? _dateTimeZoneHandling;
         private DateParseHandling? _dateParseHandling;
+        private DataTableColumnType? _dataTableColumnType;
         private FloatFormatHandling? _floatFormatHandling;
         private FloatParseHandling? _floatParseHandling;
         private StringEscapeHandling? _stringEscapeHandling;
@@ -457,6 +461,16 @@ namespace Newtonsoft.Json
             set => _dateParseHandling = value;
         }
 
+
+        /// <summary>
+        /// Gets or sets how DataTable column types are set.        
+        /// </summary>
+        public virtual DataTableColumnType DataTableColumnType
+        {
+            get => _dataTableColumnType ?? JsonSerializerSettings.DefaultDataTableColumnType;
+            set => _dataTableColumnType = value;
+        }
+
         /// <summary>
         /// Gets or sets how floating point numbers, e.g. 1.0 and 9.9, are parsed when reading JSON text.
         /// The default value is <see cref="Json.FloatParseHandling.Double" />.
@@ -762,6 +776,10 @@ namespace Newtonsoft.Json
                 serializer._dateFormatString = settings._dateFormatString;
                 serializer._dateFormatStringSet = settings._dateFormatStringSet;
             }
+            if (settings._dataTableColumnType != null)
+            {
+                serializer._dataTableColumnType = settings._dataTableColumnType;
+            }
             if (settings._floatFormatHandling != null)
             {
                 serializer._floatFormatHandling = settings._floatFormatHandling;
@@ -815,9 +833,10 @@ namespace Newtonsoft.Json
             DateTimeZoneHandling? previousDateTimeZoneHandling;
             DateParseHandling? previousDateParseHandling;
             FloatParseHandling? previousFloatParseHandling;
+            DataTableColumnType? previousDataTableColumnType;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString, out previousDataTableColumnType);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? CreateTraceJsonReader(reader)
@@ -831,7 +850,7 @@ namespace Newtonsoft.Json
                 TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
             }
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString, previousDataTableColumnType);
         }
 
         /// <summary>
@@ -889,9 +908,10 @@ namespace Newtonsoft.Json
             DateTimeZoneHandling? previousDateTimeZoneHandling;
             DateParseHandling? previousDateParseHandling;
             FloatParseHandling? previousFloatParseHandling;
+            DataTableColumnType? previousDataTableColumnType;
             int? previousMaxDepth;
             string previousDateFormatString;
-            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString);
+            SetupReader(reader, out previousCulture, out previousDateTimeZoneHandling, out previousDateParseHandling, out previousFloatParseHandling, out previousMaxDepth, out previousDateFormatString, out previousDataTableColumnType);
 
             TraceJsonReader traceJsonReader = (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                 ? CreateTraceJsonReader(reader)
@@ -905,12 +925,12 @@ namespace Newtonsoft.Json
                 TraceWriter.Trace(TraceLevel.Verbose, traceJsonReader.GetDeserializedJsonMessage(), null);
             }
 
-            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString);
+            ResetReader(reader, previousCulture, previousDateTimeZoneHandling, previousDateParseHandling, previousFloatParseHandling, previousMaxDepth, previousDateFormatString, previousDataTableColumnType);
 
             return value;
         }
 
-        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out int? previousMaxDepth, out string previousDateFormatString)
+        private void SetupReader(JsonReader reader, out CultureInfo previousCulture, out DateTimeZoneHandling? previousDateTimeZoneHandling, out DateParseHandling? previousDateParseHandling, out FloatParseHandling? previousFloatParseHandling, out int? previousMaxDepth, out string previousDateFormatString, out DataTableColumnType? previousDataTableColumnType)
         {
             if (_culture != null && !_culture.Equals(reader.Culture))
             {
@@ -940,6 +960,17 @@ namespace Newtonsoft.Json
             else
             {
                 previousDateParseHandling = null;
+            }
+
+
+            if (_dataTableColumnType != null && reader.DataTableColumnType != _dataTableColumnType)
+            {
+                previousDataTableColumnType = reader.DataTableColumnType;
+                reader.DataTableColumnType = _dataTableColumnType.GetValueOrDefault();
+            }
+            else
+            {
+                previousDataTableColumnType = null;
             }
 
             if (_floatParseHandling != null && reader.FloatParseHandling != _floatParseHandling)
@@ -981,7 +1012,7 @@ namespace Newtonsoft.Json
             }
         }
 
-        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, int? previousMaxDepth, string previousDateFormatString)
+        private void ResetReader(JsonReader reader, CultureInfo previousCulture, DateTimeZoneHandling? previousDateTimeZoneHandling, DateParseHandling? previousDateParseHandling, FloatParseHandling? previousFloatParseHandling, int? previousMaxDepth, string previousDateFormatString, DataTableColumnType? previousDataTableColumnType)
         {
             // reset reader back to previous options
             if (previousCulture != null)
@@ -996,6 +1027,11 @@ namespace Newtonsoft.Json
             {
                 reader.DateParseHandling = previousDateParseHandling.GetValueOrDefault();
             }
+            if (previousDataTableColumnType != null)
+            {
+                reader.DataTableColumnType = previousDataTableColumnType.GetValueOrDefault();
+            }
+
             if (previousFloatParseHandling != null)
             {
                 reader.FloatParseHandling = previousFloatParseHandling.GetValueOrDefault();

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -60,11 +60,15 @@ namespace Newtonsoft.Json
         internal static readonly CultureInfo DefaultCulture;
         internal const bool DefaultCheckAdditionalContent = false;
         internal const string DefaultDateFormatString = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
+        internal const DataTableColumnType DefaultDataTableColumnType = DataTableColumnType.Automatic;
+
 
         internal Formatting? _formatting;
         internal DateFormatHandling? _dateFormatHandling;
         internal DateTimeZoneHandling? _dateTimeZoneHandling;
         internal DateParseHandling? _dateParseHandling;
+        internal DataTableColumnType? _dataTableColumnType;
+        
         internal FloatFormatHandling? _floatFormatHandling;
         internal FloatParseHandling? _floatParseHandling;
         internal StringEscapeHandling? _stringEscapeHandling;
@@ -379,6 +383,16 @@ namespace Newtonsoft.Json
         {
             get => _dateParseHandling ?? DefaultDateParseHandling;
             set => _dateParseHandling = value;
+        }
+
+        /// <summary>
+        /// Gets or sets how the data type for columns on DataTables is determined.
+        /// The default value is <see cref="Json.DataTableColumnType.Automatic" />.
+        /// </summary>
+        public DataTableColumnType DataTableColumnType
+        {
+            get => _dataTableColumnType ?? JsonSerializerSettings.DefaultDataTableColumnType;
+            set => _dataTableColumnType = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -433,6 +433,7 @@ namespace Newtonsoft.Json.Serialization
                     tokenReader.DateTimeZoneHandling = reader.DateTimeZoneHandling;
                     tokenReader.FloatParseHandling = reader.FloatParseHandling;
                     tokenReader.SupportMultipleContent = reader.SupportMultipleContent;
+                    tokenReader.DataTableColumnType = reader.DataTableColumnType;
 
                     // start
                     tokenReader.ReadAndAssert();


### PR DESCRIPTION
This update adds a new JsonSerializerSettings property called DataTableColumnType. DataTableColumnType has Automatic and Object. 


DataTableColumnType.Automatic is the default and the normal/historical behavior. DataTableColumnType.Object make the DataTable Columns type an object for all data. 

My issue was when a DataColumn is of type DateTime, DataTable will force all of DateTime.Kind to DateTimeKind.Unspecified (by default). So if you need to have both Utc and Local in the DataTable, you cannot. I have data which is of Local and Utc in the same column.

The effect is this round trip serialize/deserialize.

Input:
	var json = @"[
	  {    
		""DateCol"": ""2000-12-29T00:00:00""
	  },
	  {
		""DateCol"": ""2000-12-29T00:00:00Z""
	  }
	]";
	
Output (missing 'Z'):
	var json = @"[
	  {    
		""DateCol"": ""2000-12-29T00:00:00""
	  },
	  {
		""DateCol"": ""2000-12-29T00:00:00""
	  }
	]";
	
	
Using the new setting fixes this:
	
	DataTable deserializedDataTable = JsonConvert.DeserializeObject<DataTable>(json, new JsonSerializerSettings { 
		DataTableColumnType = DataTableColumnType.Object
	});
	
This update also addresses this item, https://github.com/JamesNK/Newtonsoft.Json/issues/1086, though it was not the goal. 

Even though my issue was really about DateTime, I make DataTableColumnType since this is very specific to DataTable and making it general addresses #1086.

