### PR TITLE
Skip null converters during serialisation to prevent null reference exceptions

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -3698,6 +3698,39 @@ Path '', line 1, position 1.");
         }
 
         [Test]
+        public void SerializeWithNullJsonConverter()
+        {
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(null);
+            settings.Converters.Add(new StringEnumConverter());
+
+            Foo foo = new Foo();
+            string json = JsonConvert.SerializeObject(foo, settings);
+            Assert.IsTrue(json != null);
+
+            foo = new Foo();
+            json = JsonConvert.SerializeObject(foo, Formatting.None, null, new StringEnumConverter());
+            Assert.IsTrue(json != null);
+        }
+
+        [Test]
+        public void DeserializeWithNullJsonConverter()
+        {
+            Foo foo = new Foo();
+            string json = JsonConvert.SerializeObject(foo);
+
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(null);
+            settings.Converters.Add(new StringEnumConverter());
+
+            Foo newFoo = JsonConvert.DeserializeObject<Foo>(json, settings);
+            Assert.IsTrue(newFoo != null);
+
+            newFoo = JsonConvert.DeserializeObject<Foo>(json, null, new StringEnumConverter());
+            Assert.IsTrue(newFoo != null);
+        }
+
+        [Test]
         public void SerializeGuidKeyedDictionary()
         {
             Dictionary<Guid, int> dictionary = new Dictionary<Guid, int>();

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -1204,7 +1204,7 @@ namespace Newtonsoft.Json
                 {
                     JsonConverter converter = converters[i];
 
-                    if (converter.CanConvert(objectType))
+                    if (converter != null && converter.CanConvert(objectType))
                     {
                         return converter;
                     }


### PR DESCRIPTION
The converters list in the serialisation settings may contain nulls due to the list being exposed without validation.

Serialisation/deserialisation currently fails with a null reference exception when there is null converter in the list due to the absence of a null guard in converter processing code.

This pull request introduces a check that skips null objects in the converters list during serialisation.

This fixes the following unhelpful exception:

``
System.NullReferenceException : Object reference not set to an instance of an object.
   at Newtonsoft.Json.JsonSerializer.GetMatchingConverter(IList`1 converters, Type objectType)
   at Newtonsoft.Json.JsonSerializer.GetMatchingConverter(Type type)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.GetConverter(JsonContract contract, JsonConverter memberConverter, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Newtonsoft.Json.Tests.Serialization.JsonSerializerTest.DeserializeWithNullJsonConverter() in D:\tmp\ExternalSources\Newtonsoft.Json\Src\Newtonsoft.Json.Tests\Serialization\JsonSerializerTest.cs:line 3726
``