### PR TITLE
Add construct public StringEnumConverter(bool camelCaseText, bool all…

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/StringEnumConverterTests.cs
@@ -139,6 +139,20 @@ namespace Newtonsoft.Json.Tests.Converters
             CamelCase
         }
 
+        [JsonConverter(typeof(StringEnumConverter), true, false)]
+        public enum NotAllowIntegerValuesEnum
+        {
+            Foo = 0,
+            Bar = 1
+        }
+
+        [JsonConverter(typeof(StringEnumConverter), true, true)]
+        public enum AllowIntegerValuesEnum
+        {
+            Foo = 0,
+            Bar = 1
+        }
+
         [Test]
         public void Serialize_CamelCaseFromAttribute()
         {
@@ -151,6 +165,22 @@ namespace Newtonsoft.Json.Tests.Converters
         {
             CamelCaseEnum e = JsonConvert.DeserializeObject<CamelCaseEnum>(@"""camelCase""");
             Assert.AreEqual(CamelCaseEnum.CamelCase, e);
+        }
+
+        [Test]
+        public void Deserialize_NotAllowIntegerValuesFromAttribute()
+        {
+            ExceptionAssert.Throws<JsonSerializationException>(() =>
+            {
+                NotAllowIntegerValuesEnum e = JsonConvert.DeserializeObject<NotAllowIntegerValuesEnum>(@"""9""");
+            });
+        }
+
+        [Test]
+        public void Deserialize_AllowIntegerValuesAttribute()
+        {
+            AllowIntegerValuesEnum e = JsonConvert.DeserializeObject<AllowIntegerValuesEnum>(@"""9""");
+            Assert.AreEqual(9, (int)e);
         }
 
 #if !NET20

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -78,6 +78,17 @@ namespace Newtonsoft.Json.Converters
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="StringEnumConverter"/> class.
+        /// </summary>
+        /// <param name="camelCaseText"><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</param>
+        /// <param name="allowIntegerValues"><c>true</c> if integers are allowed when deserializing; otherwise, <c>false</c>.</param>
+        public StringEnumConverter(bool camelCaseText, bool allowIntegerValues) : this(camelCaseText)
+        {
+            CamelCaseText = camelCaseText;
+            AllowIntegerValues = allowIntegerValues;
+        }
+
+        /// <summary>
         /// Writes the JSON representation of the object.
         /// </summary>
         /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>

--- a/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/StringEnumConverter.cs
@@ -84,7 +84,6 @@ namespace Newtonsoft.Json.Converters
         /// <param name="allowIntegerValues"><c>true</c> if integers are allowed when deserializing; otherwise, <c>false</c>.</param>
         public StringEnumConverter(bool camelCaseText, bool allowIntegerValues) : this(camelCaseText)
         {
-            CamelCaseText = camelCaseText;
             AllowIntegerValues = allowIntegerValues;
         }
 


### PR DESCRIPTION
```cs
        /// <summary>
        /// Initializes a new instance of the <see cref="StringEnumConverter"/> class.
        /// </summary>
        /// <param name="camelCaseText"><c>true</c> if the written enum text will be camel case; otherwise, <c>false</c>.</param>
        /// <param name="allowIntegerValues"><c>true</c> if integers are allowed when deserializing; otherwise, <c>false</c>.</param>
        public StringEnumConverter(bool camelCaseText, bool allowIntegerValues) : this(camelCaseText)
        {
            CamelCaseText = camelCaseText;
            AllowIntegerValues = allowIntegerValues;
        }
```