### PR TITLE
Make json path filter and expressions public

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
@@ -4,10 +4,22 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters an array by index
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class ArrayIndexFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the index.
+        /// </summary>
+        /// <value>
+        /// The index.
+        /// </value>
         public int? Index { get; set; }
 
+        /// <inheritdoc />
+        /// <exception cref="JsonException">Index * not valid on the given token type</exception>
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArrayIndexFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class ArrayIndexFilter : PathFilter
+    public class ArrayIndexFilter : PathFilter
     {
         public int? Index { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArrayMultipleIndexFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArrayMultipleIndexFilter.cs
@@ -2,10 +2,21 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters an array by multiple indexes
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class ArrayMultipleIndexFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the indexes to filter by.
+        /// </summary>
+        /// <value>
+        /// The indexes.
+        /// </value>
         public List<int> Indexes { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArrayMultipleIndexFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArrayMultipleIndexFilter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class ArrayMultipleIndexFilter : PathFilter
+    public class ArrayMultipleIndexFilter : PathFilter
     {
         public List<int> Indexes { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
@@ -5,12 +5,37 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters an array by slicing it
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class ArraySliceFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the start.
+        /// </summary>
+        /// <value>
+        /// The start.
+        /// </value>
         public int? Start { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end.
+        /// </summary>
+        /// <value>
+        /// The end.
+        /// </value>
         public int? End { get; set; }
+
+        /// <summary>
+        /// Gets or sets the step.
+        /// </summary>
+        /// <value>
+        /// The step.
+        /// </value>
         public int? Step { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             if (Step == 0)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ArraySliceFilter.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class ArraySliceFilter : PathFilter
+    public class ArraySliceFilter : PathFilter
     {
         public int? Start { get; set; }
         public int? End { get; set; }

--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
@@ -4,10 +4,21 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters a document by a field
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class FieldFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the name of the filtering property.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class FieldFilter : PathFilter
+    public class FieldFilter : PathFilter
     {
         public string Name { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldMultipleFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldMultipleFilter.cs
@@ -9,10 +9,21 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters a document by multiple fields
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class FieldMultipleFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the field names.
+        /// </summary>
+        /// <value>
+        /// The names.
+        /// </value>
         public List<string> Names { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/FieldMultipleFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/FieldMultipleFilter.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class FieldMultipleFilter : PathFilter
+    public class FieldMultipleFilter : PathFilter
     {
         public List<string> Names { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -31,9 +31,9 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class JPath
+    public class JPath
     {
-        private static readonly char[] FloatCharacters = new[] {'.', 'E', 'e'};
+        private static readonly char[] FloatCharacters = new[] { '.', 'E', 'e' };
 
         private readonly string _expression;
         public List<PathFilter> Filters { get; }
@@ -198,7 +198,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
 
         private static PathFilter CreatePathFilter(string member, bool scan)
         {
-            PathFilter filter = (scan) ? (PathFilter)new ScanFilter {Name = member} : new FieldFilter {Name = member};
+            PathFilter filter = (scan) ? (PathFilter)new ScanFilter { Name = member } : new FieldFilter { Name = member };
             return filter;
         }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -31,15 +31,29 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Represents a json path
+    /// </summary>
     public class JPath
     {
         private static readonly char[] FloatCharacters = new[] { '.', 'E', 'e' };
 
         private readonly string _expression;
+
+        /// <summary>
+        /// Gets the filters for the path.
+        /// </summary>
+        /// <value>
+        /// The filters.
+        /// </value>
         public List<PathFilter> Filters { get; }
 
         private int _currentIndex;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JPath"/> class.
+        /// </summary>
+        /// <param name="expression">The json expression.</param>
         public JPath(string expression)
         {
             ValidationUtils.ArgumentNotNull(expression, nameof(expression));

--- a/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
@@ -4,10 +4,34 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Represents a path filter for json paths
+    /// </summary>
     public abstract class PathFilter
     {
+        /// <summary>
+        /// Executes the filter.
+        /// </summary>
+        /// <param name="root">The root token.</param>
+        /// <param name="current">The current tokens.</param>
+        /// <param name="errorWhenNoMatch">if set to <c>true</c> an error will be thrown when the match fails.</param>
+        /// <returns>A list of all matching tokens</returns>
         public abstract IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch);
 
+        /// <summary>
+        /// Gets the index of the token.
+        /// </summary>
+        /// <param name="t">The token.</param>
+        /// <param name="errorWhenNoMatch">if set to <c>true</c> an error will be thrown when the match fails.</param>
+        /// <param name="index">The index.</param>
+        /// <returns>The found token</returns>
+        /// <exception cref="JsonException">
+        /// Index is outside the bounds of JArray
+        /// or
+        /// Index is outside the bounds of JConstructor
+        /// or
+        /// Index is not valid on the given token type
+        /// </exception>
         protected static JToken GetTokenIndex(JToken t, bool errorWhenNoMatch, int index)
         {
 
@@ -50,6 +74,13 @@ namespace Newtonsoft.Json.Linq.JsonPath
             }
         }
 
+        /// <summary>
+        /// Gets the next scan value.
+        /// </summary>
+        /// <param name="originalParent">The original parent.</param>
+        /// <param name="container">The container.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The next token</returns>
         protected static JToken GetNextScanValue(JToken originalParent, JToken container, JToken value)
         {
             // step into container's values

--- a/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal abstract class PathFilter
+    public abstract class PathFilter
     {
         public abstract IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch);
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal enum QueryOperator
+    public enum QueryOperator
     {
         None = 0,
         Equals = 1,
@@ -27,14 +27,14 @@ namespace Newtonsoft.Json.Linq.JsonPath
         RegexEquals = 10
     }
 
-    internal abstract class QueryExpression
+    public abstract class QueryExpression
     {
         public QueryOperator Operator { get; set; }
 
         public abstract bool IsMatch(JToken root, JToken t);
     }
 
-    internal class CompositeExpression : QueryExpression
+    public class CompositeExpression : QueryExpression
     {
         public List<QueryExpression> Expressions { get; set; }
 
@@ -71,7 +71,7 @@ namespace Newtonsoft.Json.Linq.JsonPath
         }
     }
 
-    internal class BooleanQueryExpression : QueryExpression
+    public class BooleanQueryExpression : QueryExpression
     {
         public object Left { get; set; }
         public object Right { get; set; }

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -12,8 +12,12 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Represents a query operator
+    /// </summary>
     public enum QueryOperator
     {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         None = 0,
         Equals = 1,
         NotEquals = 2,
@@ -25,24 +29,64 @@ namespace Newtonsoft.Json.Linq.JsonPath
         And = 8,
         Or = 9,
         RegexEquals = 10
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 
+    /// <summary>
+    /// Represents a query expression
+    /// </summary>
     public abstract class QueryExpression
     {
+        /// <summary>
+        /// Gets or sets the operator.
+        /// </summary>
+        /// <value>
+        /// The operator.
+        /// </value>
         public QueryOperator Operator { get; set; }
 
+        /// <summary>
+        /// Determines whether the specified expression is matching against the given token.
+        /// </summary>
+        /// <param name="root">The root token.</param>
+        /// <param name="t">The token.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified token is matching; otherwise, <c>false</c>.
+        /// </returns>
         public abstract bool IsMatch(JToken root, JToken t);
     }
 
+    /// <summary>
+    /// Represents a combined expression that holds multiple expressions together
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.QueryExpression" />
     public class CompositeExpression : QueryExpression
     {
+        /// <summary>
+        /// Gets or sets the expressions.
+        /// </summary>
+        /// <value>
+        /// The expressions.
+        /// </value>
         public List<QueryExpression> Expressions { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeExpression"/> class.
+        /// </summary>
         public CompositeExpression()
         {
             Expressions = new List<QueryExpression>();
         }
 
+        /// <summary>
+        /// Determines whether the specified expressions are matching against the given token.
+        /// </summary>
+        /// <param name="root">The root token.</param>
+        /// <param name="t">The token.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified token is matching; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public override bool IsMatch(JToken root, JToken t)
         {
             switch (Operator)
@@ -71,9 +115,26 @@ namespace Newtonsoft.Json.Linq.JsonPath
         }
     }
 
+    /// <summary>
+    /// Represents a boolean query expression
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.QueryExpression" />
     public class BooleanQueryExpression : QueryExpression
     {
+        /// <summary>
+        /// Gets or sets the left value.
+        /// </summary>
+        /// <value>
+        /// The left value.
+        /// </value>
         public object Left { get; set; }
+
+        /// <summary>
+        /// Gets or sets the right value.
+        /// </summary>
+        /// <value>
+        /// The right value.
+        /// </value>
         public object Right { get; set; }
 
         private IEnumerable<JToken> GetResult(JToken root, JToken t, object o)
@@ -91,6 +152,14 @@ namespace Newtonsoft.Json.Linq.JsonPath
             return CollectionUtils.ArrayEmpty<JToken>();
         }
 
+        /// <summary>
+        /// Determines whether the specified expression is matching against the given token.
+        /// </summary>
+        /// <param name="root">The root token.</param>
+        /// <param name="t">The token.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified token is matching; otherwise, <c>false</c>.
+        /// </returns>
         public override bool IsMatch(JToken root, JToken t)
         {
             if (Operator == QueryOperator.Exists)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryFilter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class QueryFilter : PathFilter
+    public class QueryFilter : PathFilter
     {
         public QueryExpression Expression { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryFilter.cs
@@ -3,10 +3,21 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters a document by a query expression
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class QueryFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the query expression.
+        /// </summary>
+        /// <value>
+        /// The query expression.
+        /// </value>
         public QueryExpression Expression { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryScanFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryScanFilter.cs
@@ -3,10 +3,21 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters a document by an expression and traverses all descendant containers
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class QueryScanFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the filter expression.
+        /// </summary>
+        /// <value>
+        /// The filter expression.
+        /// </value>
         public QueryExpression Expression { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken t in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryScanFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryScanFilter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class QueryScanFilter : PathFilter
+    public class QueryScanFilter : PathFilter
     {
         public QueryExpression Expression { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class RootFilter : PathFilter
+    public class RootFilter : PathFilter
     {
         public static readonly RootFilter Instance = new RootFilter();
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/RootFilter.cs
@@ -2,14 +2,22 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Filters a document by it's root
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class RootFilter : PathFilter
     {
+        /// <summary>
+        /// Gets the instance
+        /// </summary>
         public static readonly RootFilter Instance = new RootFilter();
 
         private RootFilter()
         {
         }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             return new[] { root };

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class ScanFilter : PathFilter
+    public class ScanFilter : PathFilter
     {
         public string Name { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ScanFilter.cs
@@ -2,10 +2,21 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Scans a document and filters it by a property name
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class ScanFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken c in current)

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ScanMultipleFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ScanMultipleFilter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class ScanMultipleFilter : PathFilter
+    public class ScanMultipleFilter : PathFilter
     {
         public List<string> Names { get; set; }
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/ScanMultipleFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/ScanMultipleFilter.cs
@@ -2,10 +2,21 @@ using System.Collections.Generic;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
+    /// <summary>
+    /// Scans a document and filters it by multiple property names
+    /// </summary>
+    /// <seealso cref="Newtonsoft.Json.Linq.JsonPath.PathFilter" />
     public class ScanMultipleFilter : PathFilter
     {
+        /// <summary>
+        /// Gets or sets the names.
+        /// </summary>
+        /// <value>
+        /// The names.
+        /// </value>
         public List<string> Names { get; set; }
 
+        /// <inheritdoc />
         public override IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, bool errorWhenNoMatch)
         {
             foreach (JToken c in current)


### PR DESCRIPTION
**When merged this pull request will**
- Make all Linq Json Path Filter and Expressions public

Internally we are using a self written json path validation logic for custom expressions and filtering. To rely on tested parts we are using the filters of Newtonsoft.Json however they are internally by default. Our current workaround is to make a custom build where all those classes are made public. However this is difficult in workflow and often conflicts with frameworks referencing the official Newtonsoft.Json NuGet package.

We think this filters and expressions could also be helpful to others so we would like to make them public.
Plus, this opens the possibility to write custom filters and expressions as the base class is made public too.