### PR TITLE
Identity operator support added

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Documentation/LinqToJsonTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Documentation/LinqToJsonTests.cs
@@ -518,6 +518,40 @@ namespace Newtonsoft.Json.Tests.Documentation
             Assert.AreEqual(50m, productPrice);
             Assert.AreEqual("Elbow Grease", productName);
         }
+        [Test]
+        public void SelectTokenSupportsIdentityOperator()
+        {
+            #region SelectTokenSupportsIdentityOperator
+            JObject o = JObject.Parse(@"{
+	            'Values': [{
+
+                    'Coercible': 1,
+                    'Name': 'Number'
+
+                }, {
+		            'Coercible': '1',
+		            'Name': 'String'
+	            }]
+            }");
+
+            // just to verify expected behavior hasn't changed
+            IEnumerable<string> sanity1 = o.SelectTokens("Values[?(@.Coercible == '1')].Name").Select(x => (string)x);
+            IEnumerable<string> sanity2 = o.SelectTokens("Values[?(@.Coercible != '1')].Name").Select(x => (string)x);
+            // new behavior
+            IEnumerable<string> mustBeNumber1 = o.SelectTokens("Values[?(@.Coercible === 1)].Name").Select(x => (string)x);
+            IEnumerable<string> mustBeString1 = o.SelectTokens("Values[?(@.Coercible !== 1)].Name").Select(x => (string)x);
+            IEnumerable<string> mustBeString2 = o.SelectTokens("Values[?(@.Coercible === '1')].Name").Select(x => (string)x);
+            IEnumerable<string> mustBeNumber2 = o.SelectTokens("Values[?(@.Coercible !== '1')].Name").Select(x => (string)x);
+            #endregion
+            // FAILS-- JPath returns { "String" }
+            //CollectionAssert.AreEquivalent(new[] { "Number", "String" }, sanity1);
+            // FAILS-- JPath returns { "Number" }
+            //Assert.IsTrue(!sanity2.Any());
+            Assert.AreEqual("Number", mustBeNumber1.Single());
+            Assert.AreEqual("String", mustBeString1.Single());
+            Assert.AreEqual("Number", mustBeNumber2.Single());
+            Assert.AreEqual("String", mustBeString2.Single());
+        }
 
         [Test]
         public void SelectTokenLinq()

--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -786,6 +786,11 @@ namespace Newtonsoft.Json.Linq.JsonPath
                 throw new JsonException("Path ended with open query.");
             }
 
+            if(Match("==="))
+            {
+                return QueryOperator.Identity;
+            }
+
             if (Match("=="))
             {
                 return QueryOperator.Equals;
@@ -794,6 +799,11 @@ namespace Newtonsoft.Json.Linq.JsonPath
             if (Match("=~"))
             {
                 return QueryOperator.RegexEquals;
+            }
+
+            if(Match("!=="))
+            {
+                return QueryOperator.NotIdentity;
             }
 
             if (Match("!=") || Match("<>"))

--- a/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/QueryExpression.cs
@@ -24,7 +24,9 @@ namespace Newtonsoft.Json.Linq.JsonPath
         GreaterThanOrEquals = 7,
         And = 8,
         Or = 9,
-        RegexEquals = 10
+        RegexEquals = 10,
+        Identity = 11,
+        NotIdentity = 12
     }
 
     internal abstract class QueryExpression
@@ -135,13 +137,25 @@ namespace Newtonsoft.Json.Linq.JsonPath
                         }
                         break;
                     case QueryOperator.Equals:
-                        if (EqualsWithStringCoercion(leftValue, rightValue))
+                        if(EqualsWithStringCoercion(leftValue, rightValue))
+                        {
+                            return true;
+                        }
+                        break;
+                    case QueryOperator.Identity:
+                        if(EqualsWithoutStringCoercion(leftValue, rightValue))
                         {
                             return true;
                         }
                         break;
                     case QueryOperator.NotEquals:
-                        if (!EqualsWithStringCoercion(leftValue, rightValue))
+                        if(!EqualsWithStringCoercion(leftValue, rightValue))
+                        {
+                            return true;
+                        }
+                        break;
+                    case QueryOperator.NotIdentity:
+                        if(!EqualsWithoutStringCoercion(leftValue, rightValue))
                         {
                             return true;
                         }
@@ -256,6 +270,11 @@ namespace Newtonsoft.Json.Linq.JsonPath
             }
 
             return string.Equals(currentValueString, queryValueString, StringComparison.Ordinal);
+        }
+        private bool EqualsWithoutStringCoercion(JValue value, JValue queryValue)
+        {
+            // Looking at the impl I believe it considers type and value and may be euqivalent to javascript's identity op. I think. :/
+            return value.Equals(queryValue);
         }
     }
 }


### PR DESCRIPTION
Added support for the identity and negated identity operators ===, !==. Behavior of the JPath parser matches the behavior exhibited by these ops on jsonpath.com.  Added tests for the new behavior and includes a couple sanity tests that show current behavior doesn't match expected JSONPath results.

Related to issue #1835 