### PR TITLE
Add JObject.Property overload with a StringComparison and JsonMergeSettings.PropertyNameComparison

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
@@ -2063,5 +2063,27 @@ Parameter name: arrayIndex");
             Assert.AreEqual(1, (int)(JToken)value);
         }
 #endif
+
+        [Test]
+        public void Property()
+        {
+            JObject a = new JObject();
+            a["Name"] = "Name!";
+            a["name"] = "name!";
+            a["title"] = "Title!";
+
+            Assert.AreEqual(null, a.Property("NAME", StringComparison.Ordinal));
+            Assert.AreEqual(null, a.Property("NAME"));
+            Assert.AreEqual(null, a.Property("TITLE"));
+            Assert.AreEqual(null, a.Property(null, StringComparison.Ordinal));
+            Assert.AreEqual(null, a.Property(null));
+
+            // First match comparison match
+            Assert.AreEqual("Name", a.Property("NAME", StringComparison.OrdinalIgnoreCase).Name);
+            // Exact match before comparison
+            Assert.AreEqual("name", a.Property("name", StringComparison.OrdinalIgnoreCase).Name);
+            // Exact match without comparison
+            Assert.AreEqual("name", a.Property("name", StringComparison.Ordinal).Name);
+        }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
@@ -693,5 +693,13 @@ namespace Newtonsoft.Json.Tests.Linq
             Assert.AreEqual("User", (string)words[0]);
             Assert.AreEqual("Name", (string)words[1]);
         }
+
+        [Test]
+        public void MergeSettingsComparisonDefault()
+        {
+            JsonMergeSettings settings = new JsonMergeSettings();
+
+            Assert.AreEqual(StringComparison.OrdinalIgnoreCase, settings.PropertyNameComparison);
+        }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
@@ -666,5 +666,32 @@ namespace Newtonsoft.Json.Tests.Linq
 
             StringAssert.AreEqual(newJson, newFoo.ToString());
         }
+
+        [Test]
+        public void Merge_IgnorePropertyCase()
+        {
+            JObject o1 = JObject.Parse(@"{
+                                          'Id': '1',
+                                          'Words': [ 'User' ]
+                                        }");
+            JObject o2 = JObject.Parse(@"{
+                                            'Id': '1',
+                                            'words': [ 'Name' ]
+                                        }");
+
+            o1.Merge(o2, new JsonMergeSettings
+            {
+                MergeArrayHandling = MergeArrayHandling.Concat,
+                MergeNullValueHandling = MergeNullValueHandling.Merge,
+                PropertyNameComparison = StringComparison.OrdinalIgnoreCase
+            });
+
+            Assert.IsNull(o1["words"]);
+            Assert.IsNotNull(o1["Words"]);
+
+            JArray words = (JArray)o1["Words"];
+            Assert.AreEqual("User", (string)words[0]);
+            Assert.AreEqual("Name", (string)words[1]);
+        }
     }
 }

--- a/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
@@ -36,6 +36,11 @@ namespace Newtonsoft.Json.Linq
         private MergeNullValueHandling _mergeNullValueHandling;
         private StringComparison _propertyNameComparison;
 
+        public JsonMergeSettings()
+        {
+            _propertyNameComparison = StringComparison.Ordinal;
+        }
+
         /// <summary>
         /// Gets or sets the method used when merging JSON arrays.
         /// </summary>

--- a/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonMergeSettings.cs
@@ -1,3 +1,28 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
 using System;
 
 namespace Newtonsoft.Json.Linq
@@ -9,6 +34,7 @@ namespace Newtonsoft.Json.Linq
     {
         private MergeArrayHandling _mergeArrayHandling;
         private MergeNullValueHandling _mergeNullValueHandling;
+        private StringComparison _propertyNameComparison;
 
         /// <summary>
         /// Gets or sets the method used when merging JSON arrays.
@@ -43,6 +69,26 @@ namespace Newtonsoft.Json.Linq
                 }
 
                 _mergeNullValueHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the comparison used to match property names while merging.
+        /// The exact property name will be searched for first and if no matching property is found then
+        /// the <see cref="StringComparison"/> will be used to match a property.
+        /// </summary>
+        /// <value>The comparison used to match property names while merging.</value>
+        public StringComparison PropertyNameComparison
+        {
+            get => _propertyNameComparison;
+            set
+            {
+                if (value < StringComparison.CurrentCulture || value > StringComparison.OrdinalIgnoreCase)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _propertyNameComparison = value;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/JamesNK/Newtonsoft.Json/issues/1833