### PR TITLE
Duplicate properties handling

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadAsyncTests.cs
@@ -1752,7 +1752,29 @@ third line", jsonTextReader.Value);
             Assert.IsTrue(reader.ReadAsInt32Async(token).IsCanceled);
             Assert.IsTrue(reader.ReadAsStringAsync(token).IsCanceled);
         }
-    }
-}
 
+        [Test]
+        public async void AsyncThrowOnDuplicateKeysDeserializing()
+        {
+            string json = @"
+                {
+                    ""a"": 1,
+                    ""b"": [
+                        {
+                            ""c"": {
+                                ""d"": 1,
+                                ""d"": ""2""
+                            }
+                        }
+                    ]
+                }
+            ";
+
+            JsonLoadSettings settings = new JsonLoadSettings { DuplicatePropertyNamesHandling = DuplicatePropertyNamesHandling.Throw };
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            await ExceptionAssert.ThrowsAsync<JsonException>( async () => await JToken.ReadFromAsync(reader, settings));
+        }
+    }
+
+}
 #endif

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadAsyncTests.cs
@@ -1754,7 +1754,7 @@ third line", jsonTextReader.Value);
         }
 
         [Test]
-        public async void AsyncThrowOnDuplicateKeysDeserializing()
+        public async Task ThrowOnDuplicateKeysDeserializingAsync()
         {
             string json = @"
                 {

--- a/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextReaderTests/ReadTests.cs
@@ -1743,5 +1743,32 @@ third line", jsonTextReader.Value);
             {
             }
         }
+
+        [Test]
+        public void ThrowOnDuplicateKeysDeserializing()
+        {
+            string json = @"
+                {
+                    ""a"": 1,
+                    ""b"": [
+                        {
+                            ""c"": {
+                                ""d"": 1,
+                                ""d"": ""2""
+                            }
+                        }
+                    ]
+                }
+            ";
+
+            JsonLoadSettings settings = new JsonLoadSettings {DuplicatePropertyNamesHandling = DuplicatePropertyNamesHandling.Throw};
+
+            ExceptionAssert.Throws<JsonException>(() => JObject.Parse(json, settings));
+            ExceptionAssert.Throws<JsonException>(() =>
+            {
+                JsonTextReader reader = new JsonTextReader(new StringReader(json));
+                JToken.ReadFrom(reader, settings);
+            });
+        }
     }
 }

--- a/Src/Newtonsoft.Json/Linq/DuplicatePropertyNamesHandling.cs
+++ b/Src/Newtonsoft.Json/Linq/DuplicatePropertyNamesHandling.cs
@@ -1,0 +1,42 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Linq
+{
+    /// <summary>
+    /// Specifies how duplicate property names are handled when loading JSON.
+    /// </summary>
+    public enum DuplicatePropertyNamesHandling
+    {
+        /// <summary>
+        /// Ignore duplicate properties, use only last value (default)
+        /// </summary>
+        Ignore = 0,
+        /// <summary>
+        /// Throw exception
+        /// </summary>
+        Throw = 1
+    }
+}

--- a/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
@@ -160,6 +160,10 @@ namespace Newtonsoft.Json.Linq
                         }
                         else
                         {
+                            if (settings != null && settings.DuplicatePropertyNamesHandling == DuplicatePropertyNamesHandling.Throw)
+                            {
+                                throw JsonException.Create(lineInfo, property.Path, $"Property with the same name ('{propertyName}') already exists");
+                            }
                             existingPropertyWithName.Replace(property);
                         }
                         parent = property;

--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -849,6 +849,10 @@ namespace Newtonsoft.Json.Linq
                         }
                         else
                         {
+                            if (settings != null && settings.DuplicatePropertyNamesHandling == DuplicatePropertyNamesHandling.Throw)
+                            {
+                                throw JsonException.Create(lineInfo, property.Path, $"Property with the same name ('{propertyName}') already exists");
+                            }
                             existingPropertyWithName.Replace(property);
                         }
                         parent = property;

--- a/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
@@ -9,6 +9,7 @@ namespace Newtonsoft.Json.Linq
     {
         private CommentHandling _commentHandling;
         private LineInfoHandling _lineInfoHandling;
+        private DuplicatePropertyNamesHandling _duplicatePropertyNamesHandling;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonLoadSettings"/> class.
@@ -17,6 +18,7 @@ namespace Newtonsoft.Json.Linq
         {
             _lineInfoHandling = LineInfoHandling.Load;
             _commentHandling = CommentHandling.Ignore;
+            _duplicatePropertyNamesHandling = DuplicatePropertyNamesHandling.Ignore;
         }
 
         /// <summary>
@@ -52,6 +54,24 @@ namespace Newtonsoft.Json.Linq
                 }
 
                 _lineInfoHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how duplicate property names are handled when loading JSON.
+        /// </summary>
+        /// <value>The JSON duplicate property names handling.</value>
+        public DuplicatePropertyNamesHandling DuplicatePropertyNamesHandling
+        {
+            get => this._duplicatePropertyNamesHandling;
+            set
+            {
+                if (value< DuplicatePropertyNamesHandling.Ignore|| value> DuplicatePropertyNamesHandling.Throw)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                this._duplicatePropertyNamesHandling = value;
             }
         }
     }


### PR DESCRIPTION
Fixes #931
Added property for JsonLoadSettings for handling elements with the same name. 
By default duplicates are ignored and only last value used. 
To throw an exception set `DuplicatePropertyNamesHandling = DuplicatePropertyNamesHandling.Throw`.