### PR TITLE
Add ByteArrayFormatHandling to control how byte[] are serialized

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -1135,6 +1135,34 @@ _____'propertyName': NaN,
         }
 
         [Test]
+        public void WriteBytesInArray_WithArrayFormatting()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringWriter sw = new StringWriter(sb);
+
+            byte[] data = new byte[] { 1, 2, 3 };
+
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.ByteArrayFormatHandling = ByteArrayFormatHandling.Array;
+                Assert.AreEqual(ByteArrayFormatHandling.Array, jsonWriter.ByteArrayFormatHandling);
+
+                jsonWriter.WriteStartArray();
+                jsonWriter.WriteValue(data);
+                jsonWriter.WriteValue(data);
+                jsonWriter.WriteValue((object)data);
+                jsonWriter.WriteValue((byte[])null);
+                jsonWriter.WriteValue((Uri)null);
+                jsonWriter.WriteEndArray();
+            }
+
+            string expected = "[[1,2,3],[1,2,3],[1,2,3],null,null]";
+            string result = sb.ToString();
+
+            StringAssert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void Path()
         {
             StringBuilder sb = new StringBuilder();

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -1037,6 +1037,9 @@ namespace Newtonsoft.Json.Tests.Serialization
             serializer.FloatParseHandling = FloatParseHandling.Decimal;
             Assert.AreEqual(FloatParseHandling.Decimal, serializer.FloatParseHandling);
 
+            serializer.ByteArrayFormatHandling = ByteArrayFormatHandling.Array;
+            Assert.AreEqual(ByteArrayFormatHandling.Array, serializer.ByteArrayFormatHandling);
+
             serializer.Formatting = Formatting.Indented;
             Assert.AreEqual(Formatting.Indented, serializer.Formatting);
 
@@ -1150,6 +1153,9 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             settings.FloatParseHandling = FloatParseHandling.Decimal;
             Assert.AreEqual(FloatParseHandling.Decimal, settings.FloatParseHandling);
+
+            settings.ByteArrayFormatHandling = ByteArrayFormatHandling.Array;
+            Assert.AreEqual(ByteArrayFormatHandling.Array, settings.ByteArrayFormatHandling);
 
             settings.Formatting = Formatting.Indented;
             Assert.AreEqual(Formatting.Indented, settings.Formatting);
@@ -1281,6 +1287,9 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             serializerProxy.FloatParseHandling = FloatParseHandling.Decimal;
             Assert.AreEqual(FloatParseHandling.Decimal, serializerProxy.FloatParseHandling);
+
+            serializerProxy.ByteArrayFormatHandling = ByteArrayFormatHandling.Array;
+            Assert.AreEqual(ByteArrayFormatHandling.Array, serializerProxy.ByteArrayFormatHandling);
 
             serializerProxy.Formatting = Formatting.Indented;
             Assert.AreEqual(Formatting.Indented, serializerProxy.Formatting);
@@ -6715,6 +6724,19 @@ This is just junk, though.";
             // [1.1,0.0,0.0]
 
             Assert.AreEqual("[1.1,0.0,0.0]", json);
+        }
+
+        [Test]
+        public void SerializeByteArrayHandling()
+        {
+            string json;
+            byte[] b = new byte[] { 1, 2, 3 };
+
+            json = JsonConvert.SerializeObject(b);
+            Assert.AreEqual("\"AQID\"", json);
+
+            json = JsonConvert.SerializeObject(b, new JsonSerializerSettings { ByteArrayFormatHandling = ByteArrayFormatHandling.Array });
+            Assert.AreEqual("[1,2,3]", json);
         }
 
 #if !(NET20 || NET35 || NET40 || PORTABLE40)

--- a/Src/Newtonsoft.Json/ByteArrayFormatHandling.cs
+++ b/Src/Newtonsoft.Json/ByteArrayFormatHandling.cs
@@ -1,0 +1,18 @@
+﻿namespace Newtonsoft.Json
+{
+  /// <summary>
+  /// Specifies how byte arrays are formatted when writing JSON text.
+  /// </summary>
+  public enum ByteArrayFormatHandling
+  {
+    /// <summary>
+    /// Byte arrays are written as Base64 encoded string, e.g. <c>"AQIDBAU="</c>.
+    /// </summary>
+    Base64EncodedString,
+
+    /// <summary>
+    /// Byte arrays are written as JSON array, e.g. <c>"[1,2,3,4,5]"</c>.
+    /// </summary>
+    Array
+  }
+}

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -68,6 +68,7 @@ namespace Newtonsoft.Json
         private DateParseHandling? _dateParseHandling;
         private FloatFormatHandling? _floatFormatHandling;
         private FloatParseHandling? _floatParseHandling;
+        private ByteArrayFormatHandling? _byteArrayFormatHandling;
         private StringEscapeHandling? _stringEscapeHandling;
         private CultureInfo _culture;
         private int? _maxDepth;
@@ -480,6 +481,17 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Gets or sets how byte arrays,
+        /// are written as JSON text.
+        /// The default value is <see cref="Json.ByteArrayFormatHandling.Base64EncodedString" />.
+        /// </summary>
+        public virtual ByteArrayFormatHandling ByteArrayFormatHandling
+        {
+            get => _byteArrayFormatHandling ?? JsonSerializerSettings.DefaultByteArrayFormatHandling;
+            set => _byteArrayFormatHandling = value;
+        }
+
+        /// <summary>
         /// Gets or sets how strings are escaped when writing JSON text.
         /// The default value is <see cref="Json.StringEscapeHandling.Default" />.
         /// </summary>
@@ -769,6 +781,10 @@ namespace Newtonsoft.Json
             if (settings._floatParseHandling != null)
             {
                 serializer._floatParseHandling = settings._floatParseHandling;
+            }
+            if (settings._byteArrayFormatHandling != null)
+            {
+                serializer._byteArrayFormatHandling = settings._byteArrayFormatHandling;
             }
             if (settings._stringEscapeHandling != null)
             {
@@ -1120,6 +1136,13 @@ namespace Newtonsoft.Json
                 jsonWriter.FloatFormatHandling = _floatFormatHandling.GetValueOrDefault();
             }
 
+            ByteArrayFormatHandling? previousByteArrayFormatHandling = null;
+            if (_byteArrayFormatHandling != null && jsonWriter.ByteArrayFormatHandling != _byteArrayFormatHandling)
+            {
+                previousByteArrayFormatHandling = jsonWriter.ByteArrayFormatHandling;
+                jsonWriter.ByteArrayFormatHandling = _byteArrayFormatHandling.GetValueOrDefault();
+            }
+
             StringEscapeHandling? previousStringEscapeHandling = null;
             if (_stringEscapeHandling != null && jsonWriter.StringEscapeHandling != _stringEscapeHandling)
             {
@@ -1169,6 +1192,10 @@ namespace Newtonsoft.Json
             if (previousFloatFormatHandling != null)
             {
                 jsonWriter.FloatFormatHandling = previousFloatFormatHandling.GetValueOrDefault();
+            }
+            if (previousByteArrayFormatHandling != null)
+            {
+                jsonWriter.ByteArrayFormatHandling = previousByteArrayFormatHandling.GetValueOrDefault();
             }
             if (previousStringEscapeHandling != null)
             {

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -56,6 +56,7 @@ namespace Newtonsoft.Json
         internal const DateParseHandling DefaultDateParseHandling = DateParseHandling.DateTime;
         internal const FloatParseHandling DefaultFloatParseHandling = FloatParseHandling.Double;
         internal const FloatFormatHandling DefaultFloatFormatHandling = FloatFormatHandling.String;
+        internal const ByteArrayFormatHandling DefaultByteArrayFormatHandling = ByteArrayFormatHandling.Base64EncodedString;
         internal const StringEscapeHandling DefaultStringEscapeHandling = StringEscapeHandling.Default;
         internal const TypeNameAssemblyFormatHandling DefaultTypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
         internal static readonly CultureInfo DefaultCulture;
@@ -68,6 +69,7 @@ namespace Newtonsoft.Json
         internal DateParseHandling? _dateParseHandling;
         internal FloatFormatHandling? _floatFormatHandling;
         internal FloatParseHandling? _floatParseHandling;
+        internal ByteArrayFormatHandling? _byteArrayFormatHandling;
         internal StringEscapeHandling? _stringEscapeHandling;
         internal CultureInfo _culture;
         internal bool? _checkAdditionalContent;
@@ -402,6 +404,16 @@ namespace Newtonsoft.Json
         {
             get => _floatParseHandling ?? DefaultFloatParseHandling;
             set => _floatParseHandling = value;
+        }
+
+        /// <summary>
+        /// Gets or sets how byte arrays are written as JSON.
+        /// The default value is <see cref="Json.ByteArrayFormatHandling.Base64EncodedString" />.
+        /// </summary>
+        public ByteArrayFormatHandling ByteArrayFormatHandling
+        {
+            get => _byteArrayFormatHandling ?? DefaultByteArrayFormatHandling;
+            set => _byteArrayFormatHandling = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/JsonTextWriter.cs
+++ b/Src/Newtonsoft.Json/JsonTextWriter.cs
@@ -670,10 +670,27 @@ namespace Newtonsoft.Json
             else
             {
                 InternalWriteValue(JsonToken.Bytes);
-                _writer.Write(_quoteChar);
-                Base64Encoder.Encode(value, 0, value.Length);
-                Base64Encoder.Flush();
-                _writer.Write(_quoteChar);
+
+                if (ByteArrayFormatHandling == ByteArrayFormatHandling.Base64EncodedString)
+                {
+                    _writer.Write(_quoteChar);
+                    Base64Encoder.Encode(value, 0, value.Length);
+                    Base64Encoder.Flush();
+                    _writer.Write(_quoteChar);
+                }
+                else
+                {
+                    _writer.Write('[');
+
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        WriteIntegerValue(value[i]);
+                        if (i != value.Length - 1)
+                            WriteValueDelimiter();
+                    }
+
+                    _writer.Write(']');
+                }
             }
         }
 

--- a/Src/Newtonsoft.Json/JsonWriter.cs
+++ b/Src/Newtonsoft.Json/JsonWriter.cs
@@ -226,6 +226,7 @@ namespace Newtonsoft.Json
         private DateTimeZoneHandling _dateTimeZoneHandling;
         private StringEscapeHandling _stringEscapeHandling;
         private FloatFormatHandling _floatFormatHandling;
+        private ByteArrayFormatHandling _byteArrayFormatHandling;
         private string _dateFormatString;
         private CultureInfo _culture;
 
@@ -260,6 +261,23 @@ namespace Newtonsoft.Json
                 }
 
                 _dateFormatHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how byte arrays are written to JSON text.
+        /// </summary>
+        public ByteArrayFormatHandling ByteArrayFormatHandling
+        {
+            get => _byteArrayFormatHandling;
+            set
+            {
+                if (value < ByteArrayFormatHandling.Base64EncodedString || value > ByteArrayFormatHandling.Array)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _byteArrayFormatHandling = value;
             }
         }
 

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerProxy.cs
@@ -192,6 +192,12 @@ namespace Newtonsoft.Json.Serialization
             set => _serializer.FloatParseHandling = value;
         }
 
+        public override ByteArrayFormatHandling ByteArrayFormatHandling 
+        {
+            get => _serializer.ByteArrayFormatHandling;
+            set => _serializer.ByteArrayFormatHandling = value;
+        }
+
         public override StringEscapeHandling StringEscapeHandling
         {
             get => _serializer.StringEscapeHandling;


### PR DESCRIPTION
I implemented an initial draft of how a ByteArrayFormatHandling setting could look. This allows users to configure if byte arrays should be serialized as Base64-encoded string (default) or as JSON array.