### PR TITLE
Added Record Separator (ASCII RS/0x1E) as a valid top level record separator in multiple content mode

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -1455,6 +1455,12 @@ namespace Newtonsoft.Json
                         // finished parsing
                         SetStateBasedOnCurrent();
                         return false;
+                    case '\x1E':
+                        _charPos++;
+
+                        // finished parsing
+                        SetStateBasedOnCurrent();
+                        return false;
                     case ' ':
                     case StringUtils.Tab:
                         // eat


### PR DESCRIPTION
Added Record Separator (ASCII RS/0x1E) as a valid top level record separator in multiple content mode. We use ASCII RS as record separator in our json record stream.

See:
https://github.com/JamesNK/Newtonsoft.Json/issues/1355
https://github.com/JamesNK/Newtonsoft.Json/commit/6aed848eca0bb7ee8612495c203dc44a71e0f12a