### PR TITLE
Declare JsonTextReader CharPos as public rather than internal

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -100,9 +100,12 @@ namespace Newtonsoft.Json
             get => _chars;
             set => _chars = value;
         }
-
-        internal int CharPos => _charPos;
 #endif
+
+        /// <summary>
+        /// Gets the reader's character position.
+        /// </summary>
+        public int CharPos => _charPos;
 
         /// <summary>
         /// Gets or sets the reader's property name table.


### PR DESCRIPTION
**Problem**: Inability to capture malformed JSON when using `JsonTextReader` to iterate through tokens

**Solution**: Declare `CharPos` as public to allow reader's base stream to seek to location and read remaining malformed JSON as a string.