### PR TITLE
Make JsonSerializationException.Create public

### DIFF
--- a/Src/Newtonsoft.Json/JsonSerializationException.cs
+++ b/Src/Newtonsoft.Json/JsonSerializationException.cs
@@ -115,14 +115,25 @@ namespace Newtonsoft.Json
             LinePosition = linePosition;
         }
 
-        internal static JsonSerializationException Create(JsonReader reader, string message)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializationException"/> class
+        /// with a specified error message
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public static JsonSerializationException Create(JsonReader reader, string message)
         {
             return Create(reader, message, null);
         }
 
-        internal static JsonSerializationException Create(JsonReader reader, string message, Exception ex)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializationException"/> class
+        /// with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
+        public static JsonSerializationException Create(JsonReader reader, string message, Exception innerException)
         {
-            return Create(reader as IJsonLineInfo, reader.Path, message, ex);
+            return Create(reader as IJsonLineInfo, reader.Path, message, innerException);
         }
 
         internal static JsonSerializationException Create(IJsonLineInfo lineInfo, string path, string message, Exception ex)


### PR DESCRIPTION
I'm writing my own `JsonConverter` which works perfectly, except for his erros being a bit cryptic.
There is an API that allows converters to provide more information, specifially about the place where error occured.
Unfortunately, there are internal for some reason.

This PR makes this methods public to solve this issue.