### PR TITLE
Workaround for issue #1241

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue1241.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue1241.cs
@@ -1,0 +1,58 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.Globalization;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    [TestFixture]
+    public class Issue1241
+    {
+        [Test]
+        public void Test()
+        {
+            string json = @"{""Property"": ""2000-12-12T12:12:12+12:00""}";
+
+            JsonLoadSettings settings = new JsonLoadSettings()
+            {
+                DateParseHandling = DateParseHandling.None
+            };
+
+            JObject jobject = JObject.Parse(json, settings);
+            JToken jtoken = jobject["Property"];
+
+            Assert.AreEqual("2000-12-12T12:12:12+12:00", jtoken.Value<string>());
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -457,6 +457,11 @@ namespace Newtonsoft.Json.Linq
         {
             using (JsonReader reader = new JsonTextReader(new StringReader(json)))
             {
+                if (settings != null)
+                {
+                    reader.DateParseHandling = settings.DateParseHandling;
+                }
+
                 JObject o = Load(reader, settings);
 
                 while (reader.Read())

--- a/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
@@ -10,6 +10,7 @@ namespace Newtonsoft.Json.Linq
         private CommentHandling _commentHandling;
         private LineInfoHandling _lineInfoHandling;
         private DuplicatePropertyNameHandling _duplicatePropertyNameHandling;
+        private DateParseHandling _dateParseHandling;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonLoadSettings"/> class.
@@ -19,6 +20,7 @@ namespace Newtonsoft.Json.Linq
             _lineInfoHandling = LineInfoHandling.Load;
             _commentHandling = CommentHandling.Ignore;
             _duplicatePropertyNameHandling = DuplicatePropertyNameHandling.Replace;
+            _dateParseHandling = DateParseHandling.DateTime;
         }
 
         /// <summary>
@@ -75,6 +77,30 @@ namespace Newtonsoft.Json.Linq
                 }
 
                 _duplicatePropertyNameHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how date formatted strings, e.g. "\/Date(1198908717056)\/" and "2012-03-21T05:40Z", are parsed when reading JSON.
+        /// The default value is <see cref="DateParseHandling.DateTime" />.
+        /// </summary>
+        public DateParseHandling DateParseHandling
+        {
+            get => _dateParseHandling;
+            set
+            {
+                if (value < DateParseHandling.None ||
+#if HAVE_DATE_TIME_OFFSET
+                    value > DateParseHandling.DateTimeOffset
+#else
+                    value > DateParseHandling.DateTime
+#endif
+                    )
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _dateParseHandling = value;
             }
         }
     }


### PR DESCRIPTION
Added DateParseHandling option to JsonLoadSettings as a workaround for #1241.

The problem is that JObject.Parse method creates a JsonTextReader with default settings to parse a JSON string.

When the reader finds a string like `2000-12-12T12:12:12+12:00`, [it parses the value as DateTime](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonTextReader.cs#L218) since the default value of DateParseHandling is DateParseHandling.DateTime.

JToken.ToObject(JsonSerializer) method couldn't be a workaround because the token already converted the value to DateTime when it Parse-d and it has no information about the raw value.

I'm not sure if adding DateParseHandling option to JsonLoadSettings is a great idea but it should be an acceptable solution to work this around maintaining backward compatibilities.