### PR TITLE
Use TypeConverter.ConvertTo to give additional type information

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -524,7 +524,7 @@ namespace Newtonsoft.Json.Utilities
 
             if (fromConverter != null && fromConverter.CanConvertFrom(initialType))
             {
-                value = fromConverter.ConvertFrom(null, culture, initialValue);
+                value = fromConverter.ConvertTo(null, culture, initialValue, targetType);
                 return ConvertResult.Success;
             }
 #endif


### PR DESCRIPTION
This gives more type information to the converter, which is useful for certain generic converters. My example converter is one that wraps values in F# newtypes:

```f#
 type ToNewtypeConverter () =
    inherit TypeConverter ()

    override this.ConvertTo (context : ITypeDescriptorContext, culture : CultureInfo, value : obj, destinationType : Type) : obj =
        let objectType = value.GetType()
        let (case, argType) = unionCases destinationType |> isNewtype |> Option.get
        FSharpValue.MakeUnion(case, [|value|])
```