### PR TITLE
Fix #1984

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue1984.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue1984.cs
@@ -1,0 +1,64 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40)
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    public class Issue1984
+    {
+        [Test]
+        public void Test_NullValue()
+        {
+            var actual = JsonConvert.DeserializeObject<A>("{ Values: null}");
+            Assert.IsNotNull(actual);
+            Assert.IsNull(actual.Values);
+        }
+
+        [Test]
+        public void Test_WithoutValue()
+        {
+            var actual = JsonConvert.DeserializeObject<A>("{ }");
+            Assert.IsNotNull(actual);
+            Assert.IsNull(actual.Values);
+        }
+        
+        public class A
+        {
+            public ImmutableArray<string>? Values { get; set; }
+        }
+    }
+}
+#endif

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1216,7 +1216,7 @@ namespace Newtonsoft.Json.Serialization
 
             if (typeof(IEnumerable).IsAssignableFrom(t))
             {
-                return CreateArrayContract(t);
+                return CreateArrayContract(objectType);
             }
 
             if (CanConvertToString(t))


### PR DESCRIPTION
This is an attempt to fix #1984.
The issue is that the type passed to the contract does not allow to create a contract that indicates that the type is nulable and is an array at the same type.
The change is to pass the full type to the contract constructor?