### PR TITLE
MissingMemberHandling.Error should not exception when ExtensionData is present

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/ExtensionDataTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ExtensionDataTests.cs
@@ -169,6 +169,54 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.AreEqual(3, (int)o1[2]);
         }
 
+
+        public class SimpleExtendableObject
+        {
+            [JsonExtensionData]
+            public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
+        }
+
+        public class ObjectWithExtendableChild
+        {
+            public SimpleExtendableObject Data;
+        }
+        [Test]
+        public void TestMissingMemberHandlingForDirectObjects()
+        {
+            string json = @"{""extensionData1"": [1,2,3]}";
+            SimpleExtendableObject e2 = JsonConvert.DeserializeObject<SimpleExtendableObject>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
+            JArray o1 = (JArray)e2.Data["extensionData1"];
+            Assert.AreEqual(JTokenType.Array, o1.Type);
+        }
+
+        [Test]
+        public void TestMissingMemberHandlingForChildObjects()
+        {
+            string json = @"{""Data"":{""extensionData1"": [1,2,3]}}";
+            ObjectWithExtendableChild e3 = JsonConvert.DeserializeObject<ObjectWithExtendableChild>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
+            JArray o1 = (JArray)e3.Data.Data["extensionData1"];
+            Assert.AreEqual(JTokenType.Array, o1.Type);
+        }
+
+
+        [Test]
+        public void TestMissingMemberHandlingForChildObjectsWithInvalidData()
+        {
+            string json = @"{""InvalidData"":{""extensionData1"": [1,2,3]}}";
+            try
+            {
+                ObjectWithExtendableChild e3 = JsonConvert.DeserializeObject<ObjectWithExtendableChild>(json, new JsonSerializerSettings {MissingMemberHandling = MissingMemberHandling.Error});
+                Assert.Fail("an exception was expected due to MissingMemberHandling.Error, and no place to Deserialize InvalidData to");
+            }
+            catch (JsonSerializationException)
+            {
+                Assert.Pass();
+            }
+
+        }
+
+
+
         public class ExtensionDataDeserializeWithNonDefaultConstructor
         {
             public ExtensionDataDeserializeWithNonDefaultConstructor(string name)

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -2223,7 +2223,7 @@ namespace Newtonsoft.Json.Serialization
                                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}.".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
                             }
 
-                            if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
+                            if (Serializer._missingMemberHandling == MissingMemberHandling.Error && contract.ExtensionDataSetter == null)
                             {
                                 throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
                             }
@@ -2342,7 +2342,7 @@ namespace Newtonsoft.Json.Serialization
                                     TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType)), null);
                                 }
 
-                                if (Serializer._missingMemberHandling == MissingMemberHandling.Error)
+                                if (Serializer._missingMemberHandling == MissingMemberHandling.Error && contract.ExtensionDataSetter == null)
                                 {
                                     throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType.Name));
                                 }


### PR DESCRIPTION
This is a PR to make it not an error to deserialize a json element into ExtensionData when MissingMemberHandling.Error is set on the serializer.

Without this, catching the extra members in a parent with an expandable child (Scenario C) is not currently possible because otherwise valid objects deserialized into the expandable child exception (Scenario B throws MissingMemberHandling.Error Exception)

Three scenarios have been identified and units added:
a) (TestMissingMemberHandlingForDirectObjects) 
    it is not an error to have extra fields on an entity with ExtensionData present.
b) (TestMissingMemberHandlingForChildObjects) 
   it is not an error to have extra fields on children when the children have ExtensionData present
c) (TestMissingMemberHandlingForChildObjects) 
   it is an error to have extra fields on the parent, even when the children have ExtensionData present.

This required changing 2 checks in the JsonSerializerInternalReader to only throw the MissingMemberHandling exception when the relevant ExtensionData was null.

As Written this is a mildly breaking change, as objects which previously failed to deserialize into their ExtensionData, will now begin to. I'm happy to alter this PR to have MissingMemberHandling have a new third state which allows ExtensionData, while throwing on missing fields.

I implemented this as a breaking change, as when i explicitly say "put all other fields into this extension data dictionary" i do not expect an exception "nowhere to put this data".