### PR TITLE
Publish test results when the tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,12 +47,14 @@ steps:
     testRunner: 'NUnit'
     testResultsFiles: '**/Working/*.xml'
   displayName: 'Publish NUnit results'
+  condition: succeededOrFailed()
 
 - task: PublishTestResults@2
   inputs:
     testRunner: 'VSTest'
     testResultsFiles: '**/Working/*.trx'
   displayName: 'Publish dotnet test results'
+  condition: succeededOrFailed()
 
 - task: PublishBuildArtifacts@1
   inputs:


### PR DESCRIPTION
Currently test results are not published when the tests fail, which is not convenient.
This PR ensures that test results are published when the tests fail.