### PR TITLE
Fix unit test in according to the name

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Converters/RegexConverterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Converters/RegexConverterTests.cs
@@ -178,7 +178,7 @@ namespace Newtonsoft.Json.Tests.Converters
         public void DeserializeStringRegex_NoStartAndEndSlashes_Error()
         {
             string json = @"{
-  ""Regex"": ""\/abc""
+  ""Regex"": ""abc""
 }";
 
             ExceptionAssert.Throws<JsonSerializationException>(
@@ -186,7 +186,7 @@ namespace Newtonsoft.Json.Tests.Converters
                 {
                     Converters = { new RegexConverter() }
                 }),
-                "Regex pattern must be enclosed by slashes. Path 'Regex', line 2, position 18.");
+                "Regex pattern must be enclosed by slashes. Path 'Regex', line 2, position 16.");
         }
 
 #pragma warning disable 618


### PR DESCRIPTION
There are three unit tests: DeserializeStringRegex_NoStartSlash_Error, DeserializeStringRegex_NoEndSlash_Error and DeserializeStringRegex_NoStartAndEndSlashes_Error.
Unit tests DeserializeStringRegex_NoEndSlash_Error and DeserializeStringRegex_NoStartAndEndSlashes_Error have the same body. It is not correct. In according to the test name regex in the unit test DeserializeStringRegex_NoStartAndEndSlashes_Error should not have start slash.