### PR TITLE
Change constraint on DuplicatePropertyNameHandling

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonLoadSettings.cs
@@ -69,7 +69,7 @@ namespace Newtonsoft.Json.Linq
             get => _duplicatePropertyNameHandling;
             set
             {
-                if (value < DuplicatePropertyNameHandling.Ignore || value > DuplicatePropertyNameHandling.Error)
+                if (value < DuplicatePropertyNameHandling.Replace || value > DuplicatePropertyNameHandling.Error)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }


### PR DESCRIPTION
Assigning DuplicatePropertyNameHandling to Replace resulted in ArgumentOutOfRangeException, eg.
var jsonLoadSettings = new JsonLoadSettings { DuplicatePropertyNameHandling = DuplicatePropertyNameHandling.Replace };
The setter checks if value is lesser than 1 (Ignore) or greater than 2 (Error).
It should check if the value is lesser than 0 (Replace) or greater than 2 (Error).