### PR TITLE
BindToName not add $type when typeName empty

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -603,13 +603,16 @@ namespace Newtonsoft.Json.Serialization
         {
             string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormatHandling, Serializer._serializationBinder);
 
-            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+            if (!string.IsNullOrEmpty(typeName))
             {
-                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
-            }
+                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                {
+                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
+                }
 
-            writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
-            writer.WriteValue(typeName);
+                writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
+                writer.WriteValue(typeName);
+            }
         }
 
         private bool HasFlag(DefaultValueHandling value, DefaultValueHandling flag)


### PR DESCRIPTION
**Current:**
If the ISerializationBinder.BindToName returns NULL or an empty string as result, an empty type property is written to the JSON.

**Now:**
If the ISerializationBinder.BindToName returns NULL or an empty string as result, then no type property is written to the JSON.

Issues:
#2005 

