### PR TITLE
Fixed merging with self bug.

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/MergeTests.cs
@@ -47,6 +47,14 @@ namespace Newtonsoft.Json.Tests.Linq
     public class MergeTests : TestFixtureBase
     {
         [Test]
+        public void MergeSelf()
+        {
+            var a = new JArray { "1", "2" };
+            a.Merge(a, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+            Assert.AreEqual(a, new JArray { "1", "2" });
+        }
+
+        [Test]
         public void MergeNullString()
         {
             var a = new JObject { ["a"] = 1 };

--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -1157,6 +1157,8 @@ namespace Newtonsoft.Json.Linq
 #endif
                     break;
                 case MergeArrayHandling.Replace:
+                    if (target == content)
+                        break;
                     target.ClearItems();
                     foreach (JToken item in content)
                     {


### PR DESCRIPTION
Issue https://github.com/JamesNK/Newtonsoft.Json/issues/2043

JArray cleared when merged with itself with setting `MergeArrayHandling = MergeArrayHandling.Replace`.