### PR TITLE
Add property info to converter WriteJson

### DIFF
--- a/Src/Newtonsoft.Json/JsonConverter.cs
+++ b/Src/Newtonsoft.Json/JsonConverter.cs
@@ -24,8 +24,9 @@
 #endregion
 
 using System;
-using Newtonsoft.Json.Utilities;
 using System.Globalization;
+using Newtonsoft.Json.Utilities;
+using Newtonsoft.Json.Serialization;
 
 namespace Newtonsoft.Json
 {
@@ -41,6 +42,18 @@ namespace Newtonsoft.Json
         /// <param name="value">The value.</param>
         /// <param name="serializer">The calling serializer.</param>
         public abstract void WriteJson(JsonWriter writer, object value, JsonSerializer serializer);
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <param name="serializer">The containing property.</param>
+        public void WriteJson(JsonWriter writer, object value, JsonSerializer serializer, JsonProperty containerProperty)
+        {
+            WriteJson(writer, value, serializer, containerProperty);
+        }
 
         /// <summary>
         /// Reads the JSON representation of the object.

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -647,7 +647,7 @@ namespace Newtonsoft.Json.Serialization
                     TraceWriter.Trace(TraceLevel.Info, JsonPosition.FormatMessage(null, writer.Path, "Started serializing {0} with converter {1}.".FormatWith(CultureInfo.InvariantCulture, value.GetType(), converter.GetType())), null);
                 }
 
-                converter.WriteJson(writer, value, GetInternalSerializer());
+                converter.WriteJson(writer, value, GetInternalSerializer(), containerProperty);
 
                 if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Info)
                 {


### PR DESCRIPTION
Previously it was impossible to determine the expected type of an object to be serialized in a custom converter. This commit makes that information accessible.

My use case is that I've written a custom converter that sometimes wants to bail out to the default behavior. Preserving TypeNameHandling.Auto becomes impossible without this information. 

If this general idea seems reasonable, I'm willing to write a unit test and clean up support for the generic version. 