### PR TITLE
Add constructors to IsoDateTimeConverter for specifying the format

### DIFF
--- a/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/IsoDateTimeConverter.cs
@@ -41,6 +41,44 @@ namespace Newtonsoft.Json.Converters
         private CultureInfo _culture;
 
         /// <summary>
+        /// Constructor that uses the default format.
+        /// </summary>
+        public IsoDateTimeConverter() { }
+
+        /// <summary>
+        /// Constructor for parsing dates with a custom format.
+        /// </summary>
+        /// <param name="dateTimeFormat">The date time format used when converting a date to and from JSON.</param>
+        public IsoDateTimeConverter(string dateTimeFormat)
+        {
+            _dateTimeFormat = dateTimeFormat;
+        }
+
+        /// <summary>
+        /// Constructor for parsing dates with a custom format and style.
+        /// </summary>
+        /// <param name="dateTimeFormat">The date time format used when converting a date to and from JSON.</param>
+        /// <param name="dateTimeStyles">The date time styles used when converting a date to and from JSON.</param>
+        public IsoDateTimeConverter(string dateTimeFormat, DateTimeStyles dateTimeStyles)
+        {
+            _dateTimeFormat = dateTimeFormat;
+            _dateTimeStyles = dateTimeStyles;
+        }
+
+        /// <summary>
+        /// Constructor for parsing dates with a custom format, style and culture.
+        /// </summary>
+        /// <param name="dateTimeFormat">The date time format used when converting a date to and from JSON.</param>
+        /// <param name="dateTimeStyles">The date time styles used when converting a date to and from JSON.</param>
+        /// <param name="cultureName">The name of the culture used when converting a date to and from JSON.</param>
+        public IsoDateTimeConverter(string dateTimeFormat, DateTimeStyles dateTimeStyles, string cultureName)
+        {
+            _dateTimeFormat = dateTimeFormat;
+            _dateTimeStyles = dateTimeStyles;
+            _culture = new CultureInfo(cultureName);
+        }
+
+        /// <summary>
         /// Gets or sets the date time styles used when converting a date to and from JSON.
         /// </summary>
         /// <value>The date time styles used when converting a date to and from JSON.</value>


### PR DESCRIPTION
I want to be able to do this:

```csharp
[JsonConverter(typeof(IsoDateTimeConverter), "yyyy-MM-dd HH:mm:ss", DateTimeStyles.AssumeUniversal, "en-US")]
public DateTimeOffset Timestamp { get; set; }
```

So I added a new constructor to IsoDateTimeConverter. I have written custom converters for this purpose for a few projects before, so I think a standard solution for parsing custom dates (on a per property basis) might be a better way to do this.