### PR TITLE
Fix date parse handling summary

### DIFF
--- a/Src/Newtonsoft.Json/DateParseHandling.cs
+++ b/Src/Newtonsoft.Json/DateParseHandling.cs
@@ -36,7 +36,7 @@ namespace Newtonsoft.Json
         None = 0,
 
         /// <summary>
-        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="Systme.DateTime"/>.
+        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="System.DateTime"/>.
         /// </summary>
         DateTime = 1,
 #if HAVE_DATE_TIME_OFFSET

--- a/Src/Newtonsoft.Json/DateParseHandling.cs
+++ b/Src/Newtonsoft.Json/DateParseHandling.cs
@@ -36,12 +36,12 @@ namespace Newtonsoft.Json
         None = 0,
 
         /// <summary>
-        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="DateTime"/>.
+        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="Systme.DateTime"/>.
         /// </summary>
         DateTime = 1,
 #if HAVE_DATE_TIME_OFFSET
         /// <summary>
-        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="DateTimeOffset"/>.
+        /// Date formatted strings, e.g. <c>"\/Date(1198908717056)\/"</c> and <c>"2012-03-21T05:40Z"</c>, are parsed to <see cref="System.DateTimeOffset"/>.
         /// </summary>
         DateTimeOffset = 2
 #endif


### PR DESCRIPTION
There is a small typo in `DateTime` and `DateTimeOffset` references in `DateParseHandling` summaries causing the references to be translated to `DateTime` and `DateTimeOffset` enum members instead of structs from `System` namespace, which I belive is the expected result. I added full namespace path `System`, so that should do the trick.