### PR TITLE
Improve performance of calling ICustomTypeDescriptor.GetProperties

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -744,13 +744,15 @@ namespace Newtonsoft.Json.Linq
 
         PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes)
         {
-            PropertyDescriptorCollection descriptors = new PropertyDescriptorCollection(null);
-
+            var propertiesArray = new PropertyDescriptor[Count];
+            var i = 0;
             foreach (KeyValuePair<string, JToken?> propertyValue in this)
             {
-                descriptors.Add(new JPropertyDescriptor(propertyValue.Key));
+                propertiesArray[i] = new JPropertyDescriptor(propertyValue.Key);
+                i++;
             }
 
+            var descriptors = new PropertyDescriptorCollection(propertiesArray);
             return descriptors;
         }
 


### PR DESCRIPTION
Hi,

I noticed this 

> A frequent performance issue that comes up is JSON.NET's JObject, which for reasons we haven't fully researched, has very slow reflection characteristics when used as a model in Handlebars.Net. 

from https://github.com/rexm/Handlebars.Net/blob/master/README.md

also see https://github.com/rexm/Handlebars.Net/issues/56#issuecomment-114599359

I checked the code of `ICustomTypeDescriptor.GetProperties` and I see that `PropertyDescriptorCollection` starts with a capacity of 0... (see https://referencesource.microsoft.com/#System/compmod/system/componentmodel/PropertyDescriptorCollection.cs,97) - not sure if that's the real issue, but it isn't a good init capacity if you known the capacity already ;)

So I improved that by creating an own array and don't use the PropertyDescriptorCollection.Add