### PR TITLE
Added a new way to parse floats as a string

### DIFF
--- a/Src/Newtonsoft.Json/FloatParseHandling.cs
+++ b/Src/Newtonsoft.Json/FloatParseHandling.cs
@@ -38,6 +38,11 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Floating point numbers are parsed to <see cref="Decimal"/>.
         /// </summary>
-        Decimal = 1
+        Decimal = 1,
+
+        /// <summary>
+        /// Floating point numbers are parsed to <see cref="string"/>.
+        /// </summary>
+        String = 2
     }
 }

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -2208,7 +2208,7 @@ namespace Newtonsoft.Json
                                         throw ThrowReaderError("Input string '{0}' is not a valid decimal.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
                                     }
                                 }
-                                else
+                                else if (_floatParseHandling == FloatParseHandling.Double)
                                 {
                                     string number = _stringReference.ToString();
 
@@ -2220,6 +2220,10 @@ namespace Newtonsoft.Json
                                     {
                                         throw ThrowReaderError("Input string '{0}' is not a valid number.".FormatWith(CultureInfo.InvariantCulture, _stringReference.ToString()));
                                     }
+                                }
+                                else
+                                {
+                                    numberValue = _stringReference.ToString();
                                 }
 
                                 numberType = JsonToken.Float;


### PR DESCRIPTION
I noticed if you read a file with a high precision double in it like `0.094369298521547657`, if you read a file into a JToken and then dump it back to a file, the value will be different. I'm working on building a library that reads and writes json files and it would be very nice if I could count on these values not changing. Because `double` and `decimal` don't have high enough precision, I propose that we add a new `FloatParseHandling` value of `String` so that we can support reading and writing these values without modifying them.

Is this change ok?
If so should I add some testing for this or make the modifications elsewhere?