### PR TITLE
Enhance the ability to find and compare missing members and required properties

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -370,13 +370,31 @@ namespace Newtonsoft.Json.Tests.Serialization
         [Test]
         public void CoercedEmptyStringWithRequired()
         {
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<Binding>("{requiredProperty:''}"); }, "Required property 'RequiredProperty' expects a value but got null. Path '', line 1, position 21.");
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
+            {
+                JsonConvert.DeserializeObject<Binding>("{requiredProperty:''}");
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.RequiredIsNull, ex.MemberErrorType);
+                Assert.AreEqual("RequiredProperty", ex.MemberName);
+                Assert.AreEqual("Binding", ex.ObjectTypeName);
+            }, "Required property 'RequiredProperty' on object of type 'Binding' expects a value but got null. Path '', line 1, position 21.");
         }
 
         [Test]
         public void CoercedEmptyStringWithRequired_DisallowNull()
         {
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<Binding_DisallowNull>("{requiredProperty:''}"); }, "Required property 'RequiredProperty' expects a non-null value. Path '', line 1, position 21.");
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
+            {
+                JsonConvert.DeserializeObject<Binding_DisallowNull>("{requiredProperty:''}");
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.RequiredIsNull, ex.MemberErrorType);
+                Assert.AreEqual("RequiredProperty", ex.MemberName);
+                Assert.AreEqual("Binding_DisallowNull", ex.ObjectTypeName);
+            }, "Required property 'RequiredProperty' on object of type 'Binding_DisallowNull' expects a non-null value. Path '', line 1, position 21.");
         }
 
         [Test]
@@ -389,7 +407,16 @@ namespace Newtonsoft.Json.Tests.Serialization
         [Test]
         public void CoercedEmptyStringWithRequiredConstructor()
         {
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<FooRequired>("{Bars:''}"); }, "Required property 'Bars' expects a value but got null. Path '', line 1, position 9.");
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
+            {
+                JsonConvert.DeserializeObject<FooRequired>("{Bars:''}");
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.RequiredIsNull, ex.MemberErrorType);
+                Assert.AreEqual("Bars", ex.MemberName);
+                Assert.AreEqual("FooRequired", ex.ObjectTypeName);
+            }, "Required property 'Bars' on object of type 'FooRequired' expects a value but got null. Path '', line 1, position 9.");
         }
 
         [Test]
@@ -419,7 +446,10 @@ namespace Newtonsoft.Json.Tests.Serialization
         [Test]
         public void Serialize_ItemRequired_DisallowedNull()
         {
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.SerializeObject(new DictionaryWithNoNull()); }, "Cannot write a null value for property 'Name'. Property requires a non-null value. Path ''.");
+            ExceptionAssert.Throws<JsonSerializationException>(() =>
+            {
+                JsonConvert.SerializeObject(new DictionaryWithNoNull());
+            }, "Cannot write a null value for property 'Name'. Property requires a non-null value. Path ''.");
         }
 
         [Test]
@@ -513,13 +543,13 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             Assert.AreEqual(@"{""Name"":""Name!""}", json);
 
-            ExceptionAssert.Throws<JsonSerializationException>(
+            ExceptionAssert.Throws<JsonMemberSerializationException>(
                 () => JsonConvert.DeserializeObject<RequiredPropertyTestClass>(@"{}"),
-                "Required property 'Name' not found in JSON. Path '', line 1, position 2.");
+                "Required property 'Name' on object of type 'RequiredPropertyTestClass' not found in JSON. Path '', line 1, position 2.");
 
-            ExceptionAssert.Throws<JsonSerializationException>(
+            ExceptionAssert.Throws<JsonMemberSerializationException>(
                 () => JsonConvert.DeserializeObject<RequiredPropertyTestClass>(@"{""Name"":null}"),
-                "Required property 'Name' expects a value but got null. Path '', line 1, position 13.");
+                "Required property 'Name' on object of type 'RequiredPropertyTestClass' expects a value but got null. Path '', line 1, position 13.");
 
             RequiredPropertyTestClass c3 = JsonConvert.DeserializeObject<RequiredPropertyTestClass>(@"{""Name"":""Name!""}");
 
@@ -541,9 +571,9 @@ namespace Newtonsoft.Json.Tests.Serialization
 
             Assert.AreEqual(@"{""Name"":""Name!""}", json);
 
-            ExceptionAssert.Throws<JsonSerializationException>(
+            ExceptionAssert.Throws<JsonMemberSerializationException>(
                 () => JsonConvert.DeserializeObject<RequiredPropertyConstructorTestClass>(@"{}"),
-                "Required property 'Name' not found in JSON. Path '', line 1, position 2.");
+                "Required property 'Name' on object of type 'RequiredPropertyConstructorTestClass' not found in JSON. Path '', line 1, position 2.");
 
             RequiredPropertyConstructorTestClass c3 = JsonConvert.DeserializeObject<RequiredPropertyConstructorTestClass>(@"{""Name"":""Name!""}");
 
@@ -2722,9 +2752,12 @@ keyword such as type of business.""
                 JsonConvert.DeserializeObject<RequiredMembersClass>(json);
                 Assert.Fail();
             }
-            catch (JsonSerializationException ex)
+            catch (JsonMemberSerializationException ex)
             {
-                Assert.IsTrue(ex.Message.StartsWith("Required property 'FirstName' expects a value but got null. Path ''"));
+                Assert.AreEqual(MemberSerializationError.RequiredIsNull, ex.MemberErrorType);
+                Assert.AreEqual("FirstName", ex.MemberName);
+                Assert.AreEqual("RequiredMembersClass", ex.ObjectTypeName);
+                Assert.IsTrue(ex.Message.StartsWith("Required property 'FirstName' on object of type 'RequiredMembersClass' expects a value but got null. Path ''"));
             }
         }
 
@@ -2759,7 +2792,7 @@ keyword such as type of business.""
             }
             catch (JsonSerializationException ex)
             {
-                Assert.IsTrue(ex.Message.StartsWith("Required property 'LastName' not found in JSON. Path ''"));
+                Assert.IsTrue(ex.Message.StartsWith("Required property 'LastName' on object of type 'RequiredMembersClass' not found in JSON. Path ''"));
             }
         }
 
@@ -2984,7 +3017,7 @@ keyword such as type of business.""
             }
             catch (JsonSerializationException ex)
             {
-                Assert.IsTrue(ex.Message.StartsWith("Required property 'TestProperty2' not found in JSON. Path ''"));
+                Assert.IsTrue(ex.Message.StartsWith("Required property 'TestProperty2' on object of type 'ConstructorAndRequiredTestClass' not found in JSON. Path ''"));
             }
         }
 
@@ -6115,10 +6148,10 @@ Path '', line 1, position 1.");
 
             Assert.IsNotNull(o);
             Assert.AreEqual(4, errors.Count);
-            Assert.IsTrue(errors[0].StartsWith("Required property 'NonAttributeProperty' not found in JSON. Path ''"));
-            Assert.IsTrue(errors[1].StartsWith("Required property 'UnsetProperty' not found in JSON. Path ''"));
-            Assert.IsTrue(errors[2].StartsWith("Required property 'AllowNullProperty' not found in JSON. Path ''"));
-            Assert.IsTrue(errors[3].StartsWith("Required property 'AlwaysProperty' not found in JSON. Path ''"));
+            Assert.IsTrue(errors[0].StartsWith("Required property 'NonAttributeProperty' on object of type 'RequiredObject' not found in JSON. Path ''"));
+            Assert.IsTrue(errors[1].StartsWith("Required property 'UnsetProperty' on object of type 'RequiredObject' not found in JSON. Path ''"));
+            Assert.IsTrue(errors[2].StartsWith("Required property 'AllowNullProperty' on object of type 'RequiredObject' not found in JSON. Path ''"));
+            Assert.IsTrue(errors[3].StartsWith("Required property 'AlwaysProperty' on object of type 'RequiredObject' not found in JSON. Path ''"));
         }
 
         [Test]
@@ -6140,9 +6173,9 @@ Path '', line 1, position 1.");
 
             Assert.IsNotNull(o);
             Assert.AreEqual(3, errors.Count);
-            Assert.IsTrue(errors[0].StartsWith("Required property 'NonAttributeProperty' expects a value but got null. Path ''"));
-            Assert.IsTrue(errors[1].StartsWith("Required property 'UnsetProperty' expects a value but got null. Path ''"));
-            Assert.IsTrue(errors[2].StartsWith("Required property 'AlwaysProperty' expects a value but got null. Path ''"));
+            Assert.IsTrue(errors[0].StartsWith("Required property 'NonAttributeProperty' on object of type 'RequiredObject' expects a value but got null. Path ''"));
+            Assert.IsTrue(errors[1].StartsWith("Required property 'UnsetProperty' on object of type 'RequiredObject' expects a value but got null. Path ''"));
+            Assert.IsTrue(errors[2].StartsWith("Required property 'AlwaysProperty' on object of type 'RequiredObject' expects a value but got null. Path ''"));
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingTests.cs
@@ -65,9 +65,15 @@ namespace Newtonsoft.Json.Tests.Serialization
             //  ]
             //}
 
-            ExceptionAssert.Throws<JsonSerializationException>(() =>
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
             {
                 ProductShort deserializedProductShort = (ProductShort)JsonConvert.DeserializeObject(output, typeof(ProductShort), new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.Missing, ex.MemberErrorType);
+                Assert.AreEqual("Price", ex.MemberName);
+                Assert.AreEqual("ProductShort", ex.ObjectTypeName);
             }, @"Could not find member 'Price' on object of type 'ProductShort'. Path 'Price', line 4, position 10.");
         }
 
@@ -141,7 +147,16 @@ namespace Newtonsoft.Json.Tests.Serialization
         {
             string json = @"{""Missing"":1}";
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<DoubleClass>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error }); }, "Could not find member 'Missing' on object of type 'DoubleClass'. Path 'Missing', line 1, position 11.");
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
+            {
+                JsonConvert.DeserializeObject<DoubleClass>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.Missing, ex.MemberErrorType);
+                Assert.AreEqual("Missing", ex.MemberName);
+                Assert.AreEqual("DoubleClass", ex.ObjectTypeName);
+            }, "Could not find member 'Missing' on object of type 'DoubleClass'. Path 'Missing', line 1, position 11.");
         }
 
         [Test]
@@ -160,7 +175,16 @@ namespace Newtonsoft.Json.Tests.Serialization
         {
             string json = @"{""Missing"":1}";
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<NameWithMissingError>(json); }, "Could not find member 'Missing' on object of type 'NameWithMissingError'. Path 'Missing', line 1, position 11.");
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
+            {
+                JsonConvert.DeserializeObject<NameWithMissingError>(json);
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.Missing, ex.MemberErrorType);
+                Assert.AreEqual("Missing", ex.MemberName);
+                Assert.AreEqual("NameWithMissingError", ex.ObjectTypeName);
+            }, "Could not find member 'Missing' on object of type 'NameWithMissingError'. Path 'Missing', line 1, position 11.");
         }
 
         [JsonObject(MissingMemberHandling = MissingMemberHandling.Error)]
@@ -266,9 +290,15 @@ namespace Newtonsoft.Json.Tests.Serialization
         {
             string json = @"{""InvalidData"":{""extensionData1"": [1,2,3]}}";
 
-            ExceptionAssert.Throws<JsonSerializationException>(() =>
+            ExceptionAssert.ValidateThrows<JsonMemberSerializationException>(() =>
             {
                 JsonConvert.DeserializeObject<ObjectWithExtendableChild>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
+            },
+            (ex) =>
+            {
+                Assert.AreEqual(MemberSerializationError.Missing, ex.MemberErrorType);
+                Assert.AreEqual("InvalidData", ex.MemberName);
+                Assert.AreEqual("ObjectWithExtendableChild", ex.ObjectTypeName);
             }, "Could not find member 'InvalidData' on object of type 'ObjectWithExtendableChild'. Path 'InvalidData', line 1, position 15.");
         }
     }

--- a/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
@@ -507,8 +507,8 @@ namespace Newtonsoft.Json.Tests.Serialization
             serializer.Deserialize(new JsonTextReader(new StringReader(json)), typeof(MyTypeWithRequiredMembers));
 
             Assert.AreEqual(2, errors.Count);
-            Assert.IsTrue(errors[0].StartsWith(" - Required1 - Required property 'Required1' not found in JSON. Path '', line 1, position 2."));
-            Assert.IsTrue(errors[1].StartsWith(" - Required2 - Required property 'Required2' not found in JSON. Path '', line 1, position 2."));
+            Assert.IsTrue(errors[0].StartsWith(" - Required1 - Required property 'Required1' on object of type 'MyTypeWithRequiredMembers' not found in JSON. Path '', line 1, position 2."));
+            Assert.IsTrue(errors[1].StartsWith(" - Required2 - Required property 'Required2' on object of type 'MyTypeWithRequiredMembers' not found in JSON. Path '', line 1, position 2."));
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
+++ b/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
@@ -368,7 +368,7 @@ namespace Newtonsoft.Json.Tests
 
     public static class ExceptionAssert
     {
-        public static TException Throws<TException>(Action action, params string[] possibleMessages)
+        public static TException ValidateThrows<TException>(Action action, Action<TException> exceptionValidationAction, params string[] possibleMessages)
             where TException : Exception
         {
             try
@@ -380,6 +380,8 @@ namespace Newtonsoft.Json.Tests
             }
             catch (TException ex)
             {
+                exceptionValidationAction?.Invoke(ex);
+
                 if (possibleMessages == null || possibleMessages.Length == 0)
                 {
                     return ex;
@@ -400,8 +402,14 @@ namespace Newtonsoft.Json.Tests
             }
         }
 
+        public static TException Throws<TException>(Action action, params string[] possibleMessages)
+            where TException : Exception
+        {
+            return ValidateThrows<TException>(action, null, possibleMessages);
+        }
+
 #if !(NET20 || NET35 || NET40 || PORTABLE40)
-        public static async Task<TException> ThrowsAsync<TException>(Func<Task> action, params string[] possibleMessages)
+            public static async Task<TException> ThrowsAsync<TException>(Func<Task> action, params string[] possibleMessages)
             where TException : Exception
         {
             try

--- a/Src/Newtonsoft.Json/JsonMemberSerializationException.cs
+++ b/Src/Newtonsoft.Json/JsonMemberSerializationException.cs
@@ -1,0 +1,148 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Newtonsoft.Json
+{
+    /// <summary>
+    /// The types of errors related to members
+    /// </summary>
+    public enum MemberErrorType {
+        NoMemberError=0,
+        RequiredNotFound=1,
+        RequiredIsNull=2,
+        MissingMember=3
+    }
+
+    /// <summary>
+    /// The exception thrown when an error occurs during JSON serialization or deserialization.
+    /// </summary>
+#if HAVE_BINARY_EXCEPTION_SERIALIZATION
+    [Serializable]
+#endif
+    public class JsonMemberSerializationException : JsonSerializationException
+    {
+
+        /// <summary>
+        /// Gets the member error type for a required or missing member.
+        /// </summary>
+        /// <value>The name of the missing JSON member.</value>
+        public MemberErrorType MemberErrorType { get; }
+
+        /// <summary>
+        /// Gets the name of the Json member.
+        /// </summary>
+        /// <value>The name of the JSON member.</value>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the object type name of the Json member.
+        /// </summary>
+        /// <value>The name of the JSON member's parent object type.</value>
+        public string ObjectTypeName { get; }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonMemberSerializationException"/> class.
+        /// </summary>
+        public JsonMemberSerializationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonMemberSerializationException"/> class
+        /// with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public  JsonMemberSerializationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonMemberSerializationException"/> class
+        /// with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
+        public JsonMemberSerializationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if HAVE_BINARY_EXCEPTION_SERIALIZATION
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonMemberSerializationException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="info"/> parameter is <c>null</c>.</exception>
+        /// <exception cref="SerializationException">The class name is <c>null</c> or <see cref="Exception.HResult"/> is zero (0).</exception>
+        public JsonMemberSerializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializationException"/> class
+        /// with a specified error message, JSON path, line number, line position, and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="path">The path to the JSON where the error occurred.</param>
+        /// <param name="lineNumber">The line number indicating where the error occurred.</param>
+        /// <param name="linePosition">The line position indicating where the error occurred.</param>
+        /// <param name="memberErrorType">The type of member error which occurred.</param>
+        /// <param name="memberName">The name of the member being parsed where the error occurred.</param>
+        /// <param name="objectTypeName">The name of the type of object being serialized where the error occurred.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
+        public JsonMemberSerializationException(string message, string path, int lineNumber, int linePosition, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? innerException)
+            : base(message, path, lineNumber, linePosition, innerException)
+        {
+            MemberErrorType = memberErrorType;
+            MemberName = memberName;
+            ObjectTypeName = objectTypeName;
+        }
+
+        internal static JsonMemberSerializationException Create(JsonReader reader, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName)
+        {
+            return Create(reader, message, memberErrorType, memberName, objectTypeName, null);
+        }
+
+        internal static JsonMemberSerializationException Create(JsonReader reader, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? ex)
+        {
+            return Create(reader as IJsonLineInfo, reader.Path, message, memberErrorType, memberName, objectTypeName, ex);
+        }
+
+        internal static JsonMemberSerializationException Create(IJsonLineInfo? lineInfo, string path, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? ex)
+        {
+            return new JsonMemberSerializationException(message, path, lineNumber, linePosition, memberErrorType, memberName, objectTypeName, ex);
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/JsonMemberSerializationException.cs
+++ b/Src/Newtonsoft.Json/JsonMemberSerializationException.cs
@@ -31,16 +31,6 @@ using System.Text;
 namespace Newtonsoft.Json
 {
     /// <summary>
-    /// The types of errors related to members
-    /// </summary>
-    public enum MemberErrorType {
-        NoMemberError=0,
-        RequiredNotFound=1,
-        RequiredIsNull=2,
-        MissingMember=3
-    }
-
-    /// <summary>
     /// The exception thrown when an error occurs during JSON serialization or deserialization.
     /// </summary>
 #if HAVE_BINARY_EXCEPTION_SERIALIZATION
@@ -53,13 +43,13 @@ namespace Newtonsoft.Json
         /// Gets the member error type for a required or missing member.
         /// </summary>
         /// <value>The name of the missing JSON member.</value>
-        public MemberErrorType MemberErrorType { get; }
+        public MemberSerializationError MemberErrorType { get; }
 
         /// <summary>
         /// Gets the name of the Json member.
         /// </summary>
         /// <value>The name of the JSON member.</value>
-        public string Name { get; }
+        public string MemberName { get; }
 
         /// <summary>
         /// Gets the object type name of the Json member.
@@ -122,7 +112,7 @@ namespace Newtonsoft.Json
         /// <param name="memberName">The name of the member being parsed where the error occurred.</param>
         /// <param name="objectTypeName">The name of the type of object being serialized where the error occurred.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or <c>null</c> if no inner exception is specified.</param>
-        public JsonMemberSerializationException(string message, string path, int lineNumber, int linePosition, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? innerException)
+        public JsonMemberSerializationException(string message, string path, int lineNumber, int linePosition, MemberSerializationError memberErrorType, string memberName, string objectTypeName, Exception innerException)
             : base(message, path, lineNumber, linePosition, innerException)
         {
             MemberErrorType = memberErrorType;
@@ -130,19 +120,20 @@ namespace Newtonsoft.Json
             ObjectTypeName = objectTypeName;
         }
 
-        internal static JsonMemberSerializationException Create(JsonReader reader, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName)
+        internal static JsonMemberSerializationException Create(JsonReader reader, MemberSerializationError memberErrorType, string memberName, string objectTypeName, string message)
         {
-            return Create(reader, message, memberErrorType, memberName, objectTypeName, null);
+            return Create(reader, memberErrorType, memberName, objectTypeName, message, null);
         }
 
-        internal static JsonMemberSerializationException Create(JsonReader reader, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? ex)
+        internal static JsonMemberSerializationException Create(JsonReader reader, MemberSerializationError memberErrorType, string memberName, string objectTypeName, string message, Exception ex)
         {
-            return Create(reader as IJsonLineInfo, reader.Path, message, memberErrorType, memberName, objectTypeName, ex);
+            return Create(reader as IJsonLineInfo, reader.Path, memberErrorType, memberName, objectTypeName, message, ex);
         }
 
-        internal static JsonMemberSerializationException Create(IJsonLineInfo? lineInfo, string path, string message, MemberErrorType memberErrorType, string memberName, string objectTypeName, Exception? ex)
+        internal static JsonMemberSerializationException Create(IJsonLineInfo lineInfo, string path, MemberSerializationError memberErrorType, string memberName, string objectTypeName, string message, Exception ex)
         {
-            return new JsonMemberSerializationException(message, path, lineNumber, linePosition, memberErrorType, memberName, objectTypeName, ex);
+            var e = JsonSerializationException.Create(lineInfo, path, message, ex);
+            return new JsonMemberSerializationException(e.Message, path, e.LineNumber, e.LinePosition, memberErrorType, memberName, objectTypeName, ex);
         }
     }
 }

--- a/Src/Newtonsoft.Json/MemberSerializationError.cs
+++ b/Src/Newtonsoft.Json/MemberSerializationError.cs
@@ -1,0 +1,48 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json
+{
+    /// <summary>
+    /// Specifies how constructors are used when initializing objects during deserialization by the <see cref="JsonSerializer"/>.
+    /// </summary>
+    public enum MemberSerializationError
+    {
+        /// <summary>
+        /// A member marked required was not found.
+        /// </summary>
+        RequiredNotFound = 0,
+
+        /// <summary>
+        /// A member marked required was found, but did not have a non-null value assigned.
+        /// </summary>
+        RequiredIsNull = 1,
+
+        /// <summary>
+        /// A member was found, but does not map to a valid member of the target serialization class.
+        /// </summary>
+        Missing = 2
+    }
+}

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -2225,7 +2225,7 @@ namespace Newtonsoft.Json.Serialization
 
                             if ((contract.MissingMemberHandling ?? Serializer._missingMemberHandling) == MissingMemberHandling.Error)
                             {
-                                throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
+                                throw JsonMemberSerializationException.Create(reader, MemberSerializationError.Missing, memberName, objectType.Name, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
                             }
                         }
 
@@ -2344,7 +2344,7 @@ namespace Newtonsoft.Json.Serialization
 
                                 if ((contract.MissingMemberHandling ?? Serializer._missingMemberHandling) == MissingMemberHandling.Error)
                                 {
-                                    throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType.Name));
+                                    throw JsonMemberSerializationException.Create(reader, MemberSerializationError.Missing, propertyName, contract.UnderlyingType.Name, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType.Name));
                                 }
 
                                 if (!reader.Read())
@@ -2515,7 +2515,7 @@ namespace Newtonsoft.Json.Serialization
                         case PropertyPresence.None:
                             if (resolvedRequired == Required.AllowNull || resolvedRequired == Required.Always)
                             {
-                                throw JsonSerializationException.Create(reader, "Required property '{0}' not found in JSON.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                                throw JsonMemberSerializationException.Create(reader, MemberSerializationError.RequiredNotFound, property.PropertyName, contract.UnderlyingType.Name, "Required property '{0}' on object of type '{1}' not found in JSON.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName, contract.UnderlyingType.Name));
                             }
 
                             if (setDefaultValue && !property.Ignored)
@@ -2534,11 +2534,11 @@ namespace Newtonsoft.Json.Serialization
                         case PropertyPresence.Null:
                             if (resolvedRequired == Required.Always)
                             {
-                                throw JsonSerializationException.Create(reader, "Required property '{0}' expects a value but got null.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                                throw JsonMemberSerializationException.Create(reader, MemberSerializationError.RequiredIsNull, property.PropertyName, contract.UnderlyingType.Name, "Required property '{0}' on object of type '{1}' expects a value but got null.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName, contract.UnderlyingType.Name));
                             }
                             if (resolvedRequired == Required.DisallowNull)
                             {
-                                throw JsonSerializationException.Create(reader, "Required property '{0}' expects a non-null value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName));
+                                throw JsonMemberSerializationException.Create(reader, MemberSerializationError.RequiredIsNull, property.PropertyName, contract.UnderlyingType.Name, "Required property '{0}' on object of type '{1}' expects a non-null value.".FormatWith(CultureInfo.InvariantCulture, property.PropertyName, contract.UnderlyingType.Name));
                             }
                             break;
                     }


### PR DESCRIPTION
Our team needs a way to isolate exceptions for missing members.
We want to be able to check for specific properties on specific object types so that we can avoid raising exceptions on certain json schema deprecated members, bug just log warnings instead.

We could have attempted to catch and parse exception messages with the existing exception type, but that seemed risky that the names could change later.

Design decisions that need review:

- Right now, this is one exception type to cover all member read exceptions. It might be better to split out MissingMember and Required exceptions into their own types?
- Write exceptions were not converted.
- The property `ObjectTypeName` was created instead of making a property of type `Type`.