### PR TITLE
Allow configuring JsonTextReader settings via JsonToken.Parse and JArray.Parse

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JArrayTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JArrayTests.cs
@@ -647,5 +647,28 @@ Parameter name: index",
             Assert.AreEqual(true, ((IJsonLineInfo)a[1]).HasLineInfo());
             Assert.AreEqual(true, ((IJsonLineInfo)a[2]).HasLineInfo());
         }
+
+        [Test]
+        public void ParseAndToStringWithFloatingNumbersAsDouble()
+        {
+            JArray a = JArray.Parse("[1.0,2.00,3.000]");
+            string json = a.ToString(Formatting.None);
+
+            Assert.AreEqual("[1.0,2.0,3.0]", json);
+        }
+
+        [Test]
+        public void ParseAndToStringWithFloatingNumbersAsDecimal()
+        {
+            JArray a = JArray.Parse("[1.0,2.00,3.000]",
+                new JsonTextReaderSettings
+                {
+                    FloatParseHandling = FloatParseHandling.Decimal,
+                });
+
+            string json = a.ToString(Formatting.None);
+
+            Assert.AreEqual("[1.0,2.00,3.000]", json);
+        }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
@@ -123,6 +123,29 @@ namespace Newtonsoft.Json.Tests.Linq
         }
 
         [Test]
+        public void ParseAndToStringWithFloatingNumbersAsDouble()
+        {
+            JObject o = (JObject)JToken.Parse(@"{""x"":100.50,""y"":200.400}");
+            string json = o.ToString(Formatting.None);
+
+            Assert.AreEqual(@"{""x"":100.5,""y"":200.4}", json);
+        }
+
+        [Test]
+        public void ParseAndToStringWithFloatingNumbersAsDecimal()
+        {
+            JObject o = (JObject)JToken.Parse(@"{""x"":100.50,""y"":200.400}",
+                new JsonTextReaderSettings
+                {
+                    FloatParseHandling = FloatParseHandling.Decimal,
+                });
+
+            string json = o.ToString(Formatting.None);
+
+            Assert.AreEqual(@"{""x"":100.50,""y"":200.400}", json);
+        }
+
+        [Test]
         public void Parent()
         {
             JArray v = new JArray(new JConstructor("TestConstructor"), new JValue(new DateTime(2000, 12, 20)));

--- a/Src/Newtonsoft.Json/Linq/JArray.cs
+++ b/Src/Newtonsoft.Json/Linq/JArray.cs
@@ -150,7 +150,7 @@ namespace Newtonsoft.Json.Linq
         /// </example>
         public new static JArray Parse(string json)
         {
-            return Parse(json, null);
+            return Parse(json, null, null);
         }
 
         /// <summary>
@@ -165,9 +165,48 @@ namespace Newtonsoft.Json.Linq
         /// </example>
         public new static JArray Parse(string json, JsonLoadSettings? settings)
         {
+            return Parse(json, settings, null);
+        }
+
+        /// <summary>
+        /// Load a <see cref="JArray"/> from a string that contains JSON.
+        /// </summary>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="readerSettings">The <see cref="JsonTextReaderSettings"/> used to read the JSON.
+        /// If this is <c>null</c>, default read settings will be used.</param>
+        /// <returns>A <see cref="JArray"/> populated from the string that contains JSON.</returns>
+        /// <example>
+        ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParseArray" title="Parsing a JSON Array from Text" />
+        /// </example>
+        public new static JArray Parse(string json, JsonTextReaderSettings? readerSettings)
+        {
+            return Parse(json, null, readerSettings);
+        }
+
+        /// <summary>
+        /// Load a <see cref="JArray"/> from a string that contains JSON.
+        /// </summary>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="loadSettings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="readerSettings">The <see cref="JsonTextReaderSettings"/> used to read the JSON.
+        /// If this is <c>null</c>, default read settings will be used.</param>
+        /// <returns>A <see cref="JArray"/> populated from the string that contains JSON.</returns>
+        /// <example>
+        ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParseArray" title="Parsing a JSON Array from Text" />
+        /// </example>
+        public new static JArray Parse(string json, JsonLoadSettings? loadSettings, JsonTextReaderSettings? readerSettings)
+        {
             using (JsonReader reader = new JsonTextReader(new StringReader(json)))
             {
-                JArray a = Load(reader, settings);
+                if (!(readerSettings is null))
+                {
+                    reader.DateTimeZoneHandling = readerSettings.DateTimeZoneHandling;
+                    reader.DateParseHandling = readerSettings.DateParseHandling;
+                    reader.FloatParseHandling = readerSettings.FloatParseHandling;
+                }
+
+                JArray a = Load(reader, loadSettings);
 
                 while (reader.Read())
                 {

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2184,7 +2184,7 @@ namespace Newtonsoft.Json.Linq
         /// <returns>A <see cref="JToken"/> populated from the string that contains JSON.</returns>
         public static JToken Parse(string json)
         {
-            return Parse(json, null);
+            return Parse(json, null, null);
         }
 
         /// <summary>
@@ -2196,9 +2196,42 @@ namespace Newtonsoft.Json.Linq
         /// <returns>A <see cref="JToken"/> populated from the string that contains JSON.</returns>
         public static JToken Parse(string json, JsonLoadSettings? settings)
         {
+            return Parse(json, settings, null);
+        }
+
+        /// <summary>
+        /// Load a <see cref="JToken"/> from a string that contains JSON.
+        /// </summary>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="readerSettings">The <see cref="JsonTextReaderSettings"/> used to read the JSON.
+        /// If this is <c>null</c>, default read settings will be used.</param>
+        /// <returns>A <see cref="JToken"/> populated from the string that contains JSON.</returns>
+        public static JToken Parse(string json, JsonTextReaderSettings? readerSettings)
+        {
+            return Parse(json, null, readerSettings);
+        }
+
+        /// <summary>
+        /// Load a <see cref="JToken"/> from a string that contains JSON.
+        /// </summary>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="loadSettings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="readerSettings">The <see cref="JsonTextReaderSettings"/> used to read the JSON.
+        /// If this is <c>null</c>, default read settings will be used.</param>
+        /// <returns>A <see cref="JToken"/> populated from the string that contains JSON.</returns>
+        public static JToken Parse(string json, JsonLoadSettings? loadSettings, JsonTextReaderSettings? readerSettings)
+        {
             using (JsonReader reader = new JsonTextReader(new StringReader(json)))
             {
-                JToken t = Load(reader, settings);
+                if (!(readerSettings is null))
+                {
+                    reader.DateTimeZoneHandling = readerSettings.DateTimeZoneHandling;
+                    reader.DateParseHandling = readerSettings.DateParseHandling;
+                    reader.FloatParseHandling = readerSettings.FloatParseHandling;
+                }
+
+                JToken t = Load(reader, loadSettings);
 
                 while (reader.Read())
                 {

--- a/Src/Newtonsoft.Json/Linq/JsonTextReaderSettings.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonTextReaderSettings.cs
@@ -1,0 +1,81 @@
+﻿using System;
+
+namespace Newtonsoft.Json.Linq
+{
+    /// <summary>
+    /// Specifies the settings used when reading JSON.
+    /// </summary>
+    public class JsonTextReaderSettings
+    {
+        private DateTimeZoneHandling _dateTimeZoneHandling;
+        private DateParseHandling _dateParseHandling;
+        private FloatParseHandling _floatParseHandling;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonTextReaderSettings"/> class.
+        /// </summary>
+        public JsonTextReaderSettings()
+        {
+            _dateTimeZoneHandling = DateTimeZoneHandling.Local;
+            _floatParseHandling = FloatParseHandling.Double;
+            _dateParseHandling = DateParseHandling.None;
+        }
+
+        /// <summary>
+        /// Gets or sets how <see cref="DateTime"/> time zones are handled when reading JSON.
+        /// </summary>
+        public DateTimeZoneHandling DateTimeZoneHandling
+        {
+            get => _dateTimeZoneHandling;
+            set
+            {
+                if (value < DateTimeZoneHandling.Local || value > DateTimeZoneHandling.RoundtripKind)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _dateTimeZoneHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how date formatted strings, e.g. "\/Date(1198908717056)\/" and "2012-03-21T05:40Z", are parsed when reading JSON.
+        /// </summary>
+        public DateParseHandling DateParseHandling
+        {
+            get => _dateParseHandling;
+            set
+            {
+                if (value < DateParseHandling.None ||
+#if HAVE_DATE_TIME_OFFSET
+                    value > DateParseHandling.DateTimeOffset
+#else
+                    value > DateParseHandling.DateTime
+#endif
+                )
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _dateParseHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how floating point numbers, e.g. 1.0 and 9.9, are parsed when reading JSON text.
+        /// </summary>
+        public FloatParseHandling FloatParseHandling
+        {
+            get => _floatParseHandling;
+            set
+            {
+                if (value < FloatParseHandling.Double || value > FloatParseHandling.Decimal)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _floatParseHandling = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
By default, floating point numbers are parsed as `double` because the default value for `FloatParseHandling` is `Double`. This causes trailing zeros to be removed when using `JsonToken.Parse`, as described in #2162. And the same happens with `JArray.Parse`.

Because of that, parsing the JSON below with `JsonToken.Parse`
```json
{"x":100.50,"y":200.400}
```

Results in:
```json
{"x":100.5,"y":200.4}
```

And the trailing zeros are lost...

---

This PR adds method overloads to `JsonToken.Parse` and `JArray.Parse` to allow the developer to specify `xxxHandling` settings to configure the `JsonTextReader`.

Example of usage:

```csharp
JObject o = (JObject)JToken.Parse(@"{""x"":100.50,""y"":200.400}",
    new JsonTextReaderSettings
    {
        FloatParseHandling = FloatParseHandling.Decimal,
    });

string json = o.ToString(Formatting.None);
```

The code above results in the JSON below, preserving the trailing zeros as expected:

```json
{"x":100.50,"y":200.400}
```