### PR TITLE
Changed StringUtil.ToCamelCase - serialization of text preceding non-letters

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
@@ -68,6 +68,7 @@ namespace Newtonsoft.Json.Tests.Utilities
             Assert.AreEqual("building Property", StringUtils.ToCamelCase("BUILDING Property"));
             Assert.AreEqual("building Property", StringUtils.ToCamelCase("Building Property"));
             Assert.AreEqual("building PROPERTY", StringUtils.ToCamelCase("BUILDING PROPERTY"));
+            Assert.AreEqual("text1", StringUtils.ToCamelCase("TEXT1"));
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Utilities/StringUtilsTests.cs
@@ -61,7 +61,8 @@ namespace Newtonsoft.Json.Tests.Utilities
             Assert.AreEqual("snA__ kEcAsE", StringUtils.ToCamelCase("SnA__ kEcAsE"));
             Assert.AreEqual("already_snake_case_ ", StringUtils.ToCamelCase("already_snake_case_ "));
             Assert.AreEqual("isJSONProperty", StringUtils.ToCamelCase("IsJSONProperty"));
-            Assert.AreEqual("shoutinG_CASE", StringUtils.ToCamelCase("SHOUTING_CASE"));
+            Assert.AreEqual("shouting_CASE", StringUtils.ToCamelCase("SHOUTING_CASE"));
+            Assert.AreEqual("shouting CASE", StringUtils.ToCamelCase("SHOUTING CASE"));
             Assert.AreEqual("9999-12-31T23:59:59.9999999Z", StringUtils.ToCamelCase("9999-12-31T23:59:59.9999999Z"));
             Assert.AreEqual("hi!! This is text. Time to test.", StringUtils.ToCamelCase("Hi!! This is text. Time to test."));
             Assert.AreEqual("building", StringUtils.ToCamelCase("BUILDING"));

--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -169,17 +169,13 @@ namespace Newtonsoft.Json.Utilities
                 }
 
                 bool hasNext = (i + 1 < chars.Length);
-                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]) && !char.IsDigit(chars[i + 1]))
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
                 {
-                    // if the next character is a space, which is not considered uppercase 
-                    // (otherwise we wouldn't be here...)
-                    // we want to ensure that the following:
-                    // 'FOO bar' is rewritten as 'foo bar', and not as 'foO bar'
-                    // The code was written in such a way that the first word in uppercase
-                    // ends when if finds an uppercase letter followed by a lowercase letter.
-                    // now a ' ' (space, (char)32) is considered not upper
-                    // but in that case we still want our current character to become lowercase
-                    if (char.IsSeparator(chars[i + 1]))
+                    // We want to ensure that the following:
+                    // 'FOO bar' is rewritten as 'foo bar', and not as 'foO bar'.
+                    // 'FOO_bar' is rewritten as 'foo_bar', and not as 'foO_bar'.
+                    // 'FOO1' is rewritten as 'foo1', and not as 'foO1'.
+                    if (!char.IsLower(chars[i + 1]))
                     {
                         chars[i] = ToLower(chars[i]);
                     }

--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -169,7 +169,7 @@ namespace Newtonsoft.Json.Utilities
                 }
 
                 bool hasNext = (i + 1 < chars.Length);
-                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]) && !char.IsDigit(chars[i + 1]))
                 {
                     // if the next character is a space, which is not considered uppercase 
                     // (otherwise we wouldn't be here...)


### PR DESCRIPTION
This is my proposed solution to issue #2223:

```C#
// 'FOO_bar' is rewritten as 'foo_bar', and not as 'foO_bar'.  
// 'FOO1' is rewritten as 'foo1', and not as 'foO1'.  
```


