### PR TITLE
added mongodb compatibility setting for TypeNameHandling 

### DIFF
--- a/Src/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonReader.cs
@@ -298,7 +298,7 @@ namespace Newtonsoft.Json.Bson
             {
                 case State.ObjectStart:
                 {
-                    SetToken(JsonToken.PropertyName, JsonTypeReflector.RefPropertyName);
+                    SetToken(JsonToken.PropertyName, _jsonTypeReflectorProperties.RefPropertyName);
                     _bsonReaderState = BsonReaderState.ReferenceRef;
                     return true;
                 }
@@ -323,7 +323,7 @@ namespace Newtonsoft.Json.Bson
                 {
                     if (_bsonReaderState == BsonReaderState.ReferenceRef)
                     {
-                        SetToken(JsonToken.PropertyName, JsonTypeReflector.IdPropertyName);
+                        SetToken(JsonToken.PropertyName, _jsonTypeReflectorProperties.IdPropertyName);
                         _bsonReaderState = BsonReaderState.ReferenceId;
                         return true;
                     }

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1644,15 +1644,15 @@ namespace Newtonsoft.Json.Converters
                 {
                     switch (propertyName)
                     {
-                        case JsonTypeReflector.ArrayValuesPropertyName:
+                        case JsonTypeReflector.obsolete_ArrayValuesPropertyName:
                             propertyName = propertyName.Substring(1);
                             elementPrefix = manager.LookupPrefix(JsonNamespaceUri);
                             CreateElement(reader, document, currentNode, propertyName, manager, elementPrefix, attributeNameValues);
                             return;
-                        case JsonTypeReflector.IdPropertyName:
-                        case JsonTypeReflector.RefPropertyName:
-                        case JsonTypeReflector.TypePropertyName:
-                        case JsonTypeReflector.ValuePropertyName:
+                        case JsonTypeReflector.obsolete_IdPropertyName:
+                        case JsonTypeReflector.obsolete_RefPropertyName:
+                        case JsonTypeReflector.obsolete_TypePropertyName:
+                        case JsonTypeReflector.obsolete_ValuePropertyName:
                             string attributeName = propertyName.Substring(1);
                             string attributePrefix = manager.LookupPrefix(JsonNamespaceUri);
                             AddAttribute(reader, document, currentNode, propertyName, attributeName, manager, attributePrefix);
@@ -1902,11 +1902,11 @@ namespace Newtonsoft.Json.Converters
                                 case '$':
                                     switch (attributeName)
                                     {
-                                        case JsonTypeReflector.ArrayValuesPropertyName:
-                                        case JsonTypeReflector.IdPropertyName:
-                                        case JsonTypeReflector.RefPropertyName:
-                                        case JsonTypeReflector.TypePropertyName:
-                                        case JsonTypeReflector.ValuePropertyName:
+                                        case JsonTypeReflector.obsolete_ArrayValuesPropertyName:
+                                        case JsonTypeReflector.obsolete_IdPropertyName:
+                                        case JsonTypeReflector.obsolete_RefPropertyName:
+                                        case JsonTypeReflector.obsolete_TypePropertyName:
+                                        case JsonTypeReflector.obsolete_ValuePropertyName:
                                             // check that JsonNamespaceUri is in scope
                                             // if it isn't then add it to document and namespace manager
                                             string jsonPrefix = manager.LookupPrefix(JsonNamespaceUri);
@@ -1930,7 +1930,7 @@ namespace Newtonsoft.Json.Converters
                                             }
 
                                             // special case $values, it will have a non-primitive value
-                                            if (attributeName == JsonTypeReflector.ArrayValuesPropertyName)
+                                            if (attributeName == JsonTypeReflector.obsolete_ArrayValuesPropertyName)
                                             {
                                                 finished = true;
                                                 break;

--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -834,6 +834,7 @@ namespace Newtonsoft.Json
 
             using (JsonTextReader reader = new JsonTextReader(new StringReader(value)))
             {
+                reader._jsonTypeReflectorProperties = jsonSerializer._jsonTypeReflectorProperties;
                 return jsonSerializer.Deserialize(reader, type);
             }
         }

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -159,6 +159,8 @@ namespace Newtonsoft.Json
             protected internal set => _quoteChar = value;
         }
 
+        internal JsonTypeReflectorProperties _jsonTypeReflectorProperties = new JsonTypeReflectorProperties();
+
         /// <summary>
         /// Gets or sets how <see cref="DateTime"/> time zones are handled when reading JSON.
         /// </summary>
@@ -934,13 +936,13 @@ namespace Newtonsoft.Json
         internal void ReadIntoWrappedTypeObject()
         {
             ReaderReadAndAssert();
-            if (Value != null && Value.ToString() == JsonTypeReflector.TypePropertyName)
+            if (Value != null && Value.ToString() == _jsonTypeReflectorProperties.TypePropertyName)
             {
                 ReaderReadAndAssert();
                 if (Value != null && Value.ToString().StartsWith("System.Byte[]", StringComparison.Ordinal))
                 {
                     ReaderReadAndAssert();
-                    if (Value.ToString() == JsonTypeReflector.ValuePropertyName)
+                    if (Value.ToString() == _jsonTypeReflectorProperties.ValuePropertyName)
                     {
                         return;
                     }

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -48,6 +48,7 @@ namespace Newtonsoft.Json
     {
         internal TypeNameHandling _typeNameHandling;
         internal TypeNameAssemblyFormatHandling _typeNameAssemblyFormatHandling;
+        internal TypeNameProperties _typeNameProperties;
         internal PreserveReferencesHandling _preserveReferencesHandling;
         internal ReferenceLoopHandling _referenceLoopHandling;
         internal MissingMemberHandling _missingMemberHandling;
@@ -77,6 +78,8 @@ namespace Newtonsoft.Json
         private bool? _checkAdditionalContent;
         private string? _dateFormatString;
         private bool _dateFormatStringSet;
+
+        internal JsonTypeReflectorProperties _jsonTypeReflectorProperties = new JsonTypeReflectorProperties();
 
         /// <summary>
         /// Occurs when the <see cref="JsonSerializer"/> errors during serialization and deserialization.
@@ -188,6 +191,31 @@ namespace Newtonsoft.Json
                 }
 
                 _typeNameHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the properties to use when serializing typename information.
+        /// The default value is <see cref="Json.TypeNameProperties.Default" />
+        /// </summary>
+        public virtual TypeNameProperties TypeNameProperties
+        {
+            get => _typeNameProperties;
+            set
+            {
+                if (value < TypeNameProperties.Default || value > TypeNameProperties.Mongo)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _typeNameProperties = value;
+                if(_typeNameProperties == TypeNameProperties.Mongo)
+                {
+                    _jsonTypeReflectorProperties = new MongoJsonTypeReflectorProperties();
+                } else
+                {
+                    _jsonTypeReflectorProperties = new JsonTypeReflectorProperties();
+                }
             }
         }
 
@@ -562,6 +590,7 @@ namespace Newtonsoft.Json
             _preserveReferencesHandling = JsonSerializerSettings.DefaultPreserveReferencesHandling;
             _constructorHandling = JsonSerializerSettings.DefaultConstructorHandling;
             _typeNameHandling = JsonSerializerSettings.DefaultTypeNameHandling;
+            _typeNameProperties = JsonSerializerSettings.DefaultTypeNameProperties;
             _metadataPropertyHandling = JsonSerializerSettings.DefaultMetadataPropertyHandling;
             _context = JsonSerializerSettings.DefaultContext;
             _serializationBinder = DefaultSerializationBinder.Instance;
@@ -664,6 +693,10 @@ namespace Newtonsoft.Json
             if (settings._typeNameHandling != null)
             {
                 serializer.TypeNameHandling = settings.TypeNameHandling;
+            }
+            if (settings._typeNameProperties != null)
+            {
+                serializer.TypeNameProperties = settings.TypeNameProperties;
             }
             if (settings._metadataPropertyHandling != null)
             {

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -47,6 +47,7 @@ namespace Newtonsoft.Json
         internal const PreserveReferencesHandling DefaultPreserveReferencesHandling = PreserveReferencesHandling.None;
         internal const ConstructorHandling DefaultConstructorHandling = ConstructorHandling.Default;
         internal const TypeNameHandling DefaultTypeNameHandling = TypeNameHandling.None;
+        internal const TypeNameProperties DefaultTypeNameProperties = TypeNameProperties.Default;
         internal const MetadataPropertyHandling DefaultMetadataPropertyHandling = MetadataPropertyHandling.Default;
         internal static readonly StreamingContext DefaultContext;
 
@@ -85,6 +86,7 @@ namespace Newtonsoft.Json
         internal StreamingContext? _context;
         internal ConstructorHandling? _constructorHandling;
         internal TypeNameHandling? _typeNameHandling;
+        internal TypeNameProperties? _typeNameProperties;
         internal MetadataPropertyHandling? _metadataPropertyHandling;
 
         /// <summary>
@@ -173,6 +175,12 @@ namespace Newtonsoft.Json
         {
             get => _typeNameHandling ?? DefaultTypeNameHandling;
             set => _typeNameHandling = value;
+        }
+
+        public TypeNameProperties TypeNameProperties
+        {
+            get => _typeNameProperties ?? DefaultTypeNameProperties;
+            set => _typeNameProperties = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/JsonTextReader.Async.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.Async.cs
@@ -1677,13 +1677,14 @@ namespace Newtonsoft.Json
         private async Task ReadIntoWrappedTypeObjectAsync(CancellationToken cancellationToken)
         {
             await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
-            if (Value != null && Value.ToString() == JsonTypeReflector.TypePropertyName)
+
+            if (Value != null && Value.ToString() == _jsonTypeReflectorProperties.TypePropertyName)
             {
                 await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
                 if (Value != null && Value.ToString().StartsWith("System.Byte[]", StringComparison.Ordinal))
                 {
                     await ReaderReadAndAssertAsync(cancellationToken).ConfigureAwait(false);
-                    if (Value.ToString() == JsonTypeReflector.ValuePropertyName)
+                    if (Value.ToString() == _jsonTypeReflectorProperties.ValuePropertyName)
                     {
                         return;
                     }

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaBuilder.cs
@@ -212,7 +212,7 @@ namespace Newtonsoft.Json.Schema
                 throw JsonException.Create(token, token.Path, "Expected object while parsing schema object, got {0}.".FormatWith(CultureInfo.InvariantCulture, token.Type));
             }
 
-            if (schemaObject.TryGetValue(JsonTypeReflector.RefPropertyName, out JToken referenceToken))
+            if (schemaObject.TryGetValue(JsonTypeReflector.obsolete_RefPropertyName, out JToken referenceToken))
             {
                 JsonSchema deferredSchema = new JsonSchema();
                 deferredSchema.DeferredReference = (string)referenceToken;

--- a/Src/Newtonsoft.Json/Schema/JsonSchemaWriter.cs
+++ b/Src/Newtonsoft.Json/Schema/JsonSchemaWriter.cs
@@ -57,7 +57,7 @@ namespace Newtonsoft.Json.Schema
             if (schema.Id != null && _resolver.GetSchema(schema.Id) != null)
             {
                 _writer.WriteStartObject();
-                _writer.WritePropertyName(JsonTypeReflector.RefPropertyName);
+                _writer.WritePropertyName(JsonTypeReflector.obsolete_RefPropertyName);
                 _writer.WriteValue(schema.Id);
                 _writer.WriteEndObject();
             }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -97,7 +97,7 @@ namespace Newtonsoft.Json.Serialization
                 string? id = null;
                 if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore
                     && reader.TokenType == JsonToken.PropertyName
-                    && string.Equals(reader.Value!.ToString(), JsonTypeReflector.IdPropertyName, StringComparison.Ordinal))
+                    && string.Equals(reader.Value!.ToString(), Serializer._jsonTypeReflectorProperties.IdPropertyName, StringComparison.Ordinal))
                 {
                     reader.ReadAndAssert();
                     id = reader.Value?.ToString();
@@ -498,7 +498,7 @@ namespace Newtonsoft.Json.Serialization
                     // if the content is inside $value then read past it
                     if (Serializer.MetadataPropertyHandling != MetadataPropertyHandling.Ignore
                         && reader.TokenType == JsonToken.PropertyName
-                        && string.Equals(reader.Value!.ToString(), JsonTypeReflector.ValuePropertyName, StringComparison.Ordinal))
+                        && string.Equals(reader.Value!.ToString(), Serializer._jsonTypeReflectorProperties.ValuePropertyName, StringComparison.Ordinal))
                     {
                         reader.ReadAndAssert();
 
@@ -598,13 +598,13 @@ namespace Newtonsoft.Json.Serialization
             {
                 JObject current = (JObject)reader.CurrentToken!;
 
-                JProperty? refProperty = current.Property(JsonTypeReflector.RefPropertyName, StringComparison.Ordinal);
+                JProperty? refProperty = current.Property(Serializer._jsonTypeReflectorProperties.RefPropertyName, StringComparison.Ordinal);
                 if (refProperty != null)
                 {
                     JToken refToken = refProperty.Value;
                     if (refToken.Type != JTokenType.String && refToken.Type != JTokenType.Null)
                     {
-                        throw JsonSerializationException.Create(refToken, refToken.Path, "JSON reference {0} property must have a string or null value.".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.RefPropertyName), null);
+                        throw JsonSerializationException.Create(refToken, refToken.Path, "JSON reference {0} property must have a string or null value.".FormatWith(CultureInfo.InvariantCulture, Serializer._jsonTypeReflectorProperties.RefPropertyName), null);
                     }
 
                     string? reference = (string?)refProperty;
@@ -614,7 +614,7 @@ namespace Newtonsoft.Json.Serialization
                         JToken? additionalContent = refProperty.Next ?? refProperty.Previous;
                         if (additionalContent != null)
                         {
-                            throw JsonSerializationException.Create(additionalContent, additionalContent.Path, "Additional content found in JSON reference object. A JSON reference object should only have a {0} property.".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.RefPropertyName), null);
+                            throw JsonSerializationException.Create(additionalContent, additionalContent.Path, "Additional content found in JSON reference object. A JSON reference object should only have a {0} property.".FormatWith(CultureInfo.InvariantCulture, Serializer._jsonTypeReflectorProperties.RefPropertyName), null);
                         }
 
                         newValue = Serializer.GetReferenceResolver().ResolveReference(this, reference);
@@ -628,7 +628,7 @@ namespace Newtonsoft.Json.Serialization
                         return true;
                     }
                 }
-                JToken? typeToken = current[JsonTypeReflector.TypePropertyName];
+                JToken? typeToken = current[Serializer._jsonTypeReflectorProperties.TypePropertyName];
                 if (typeToken != null)
                 {
                     string? qualifiedTypeName = (string?)typeToken;
@@ -636,7 +636,7 @@ namespace Newtonsoft.Json.Serialization
                     typeTokenReader.ReadAndAssert();
                     ResolveTypeName(typeTokenReader, ref objectType, ref contract, member, containerContract, containerMember, qualifiedTypeName!);
 
-                    JToken? valueToken = current[JsonTypeReflector.ValuePropertyName];
+                    JToken? valueToken = current[Serializer._jsonTypeReflectorProperties.ValuePropertyName];
                     if (valueToken != null)
                     {
                         while (true)
@@ -644,7 +644,7 @@ namespace Newtonsoft.Json.Serialization
                             reader.ReadAndAssert();
                             if (reader.TokenType == JsonToken.PropertyName)
                             {
-                                if ((string)reader.Value! == JsonTypeReflector.ValuePropertyName)
+                                if ((string)reader.Value! == Serializer._jsonTypeReflectorProperties.ValuePropertyName)
                                 {
                                     return false;
                                 }
@@ -655,12 +655,12 @@ namespace Newtonsoft.Json.Serialization
                         }
                     }
                 }
-                JToken? idToken = current[JsonTypeReflector.IdPropertyName];
+                JToken? idToken = current[Serializer._jsonTypeReflectorProperties.IdPropertyName];
                 if (idToken != null)
                 {
                     id = (string?)idToken;
                 }
-                JToken? valuesToken = current[JsonTypeReflector.ArrayValuesPropertyName];
+                JToken? valuesToken = current[Serializer._jsonTypeReflectorProperties.ArrayValuesPropertyName];
                 if (valuesToken != null)
                 {
                     JsonReader listReader = valuesToken.CreateReader();
@@ -685,7 +685,7 @@ namespace Newtonsoft.Json.Serialization
             {
                 string propertyName = reader.Value!.ToString();
 
-                if (propertyName.Length > 0 && propertyName[0] == '$')
+                if (propertyName.Length > 0 && propertyName.StartsWith(Serializer._jsonTypeReflectorProperties.GetReflectionPropertyPrefix(), StringComparison.Ordinal))
                 {
                     // read metadata properties
                     // $type, $id, $ref, etc
@@ -695,12 +695,12 @@ namespace Newtonsoft.Json.Serialization
                     {
                         propertyName = reader.Value!.ToString();
 
-                        if (string.Equals(propertyName, JsonTypeReflector.RefPropertyName, StringComparison.Ordinal))
+                        if (string.Equals(propertyName, Serializer._jsonTypeReflectorProperties.RefPropertyName, StringComparison.Ordinal))
                         {
                             reader.ReadAndAssert();
                             if (reader.TokenType != JsonToken.String && reader.TokenType != JsonToken.Null)
                             {
-                                throw JsonSerializationException.Create(reader, "JSON reference {0} property must have a string or null value.".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.RefPropertyName));
+                                throw JsonSerializationException.Create(reader, "JSON reference {0} property must have a string or null value.".FormatWith(CultureInfo.InvariantCulture, Serializer._jsonTypeReflectorProperties.RefPropertyName));
                             }
 
                             string? reference = reader.Value?.ToString();
@@ -711,7 +711,7 @@ namespace Newtonsoft.Json.Serialization
                             {
                                 if (reader.TokenType == JsonToken.PropertyName)
                                 {
-                                    throw JsonSerializationException.Create(reader, "Additional content found in JSON reference object. A JSON reference object should only have a {0} property.".FormatWith(CultureInfo.InvariantCulture, JsonTypeReflector.RefPropertyName));
+                                    throw JsonSerializationException.Create(reader, "Additional content found in JSON reference object. A JSON reference object should only have a {0} property.".FormatWith(CultureInfo.InvariantCulture, Serializer._jsonTypeReflectorProperties.RefPropertyName));
                                 }
 
                                 newValue = Serializer.GetReferenceResolver().ResolveReference(this, reference);
@@ -728,7 +728,7 @@ namespace Newtonsoft.Json.Serialization
                                 metadataProperty = true;
                             }
                         }
-                        else if (string.Equals(propertyName, JsonTypeReflector.TypePropertyName, StringComparison.Ordinal))
+                        else if (string.Equals(propertyName, Serializer._jsonTypeReflectorProperties.TypePropertyName, StringComparison.Ordinal))
                         {
                             reader.ReadAndAssert();
                             string qualifiedTypeName = reader.Value!.ToString();
@@ -739,7 +739,7 @@ namespace Newtonsoft.Json.Serialization
 
                             metadataProperty = true;
                         }
-                        else if (string.Equals(propertyName, JsonTypeReflector.IdPropertyName, StringComparison.Ordinal))
+                        else if (string.Equals(propertyName, Serializer._jsonTypeReflectorProperties.IdPropertyName, StringComparison.Ordinal))
                         {
                             reader.ReadAndAssert();
 
@@ -748,7 +748,7 @@ namespace Newtonsoft.Json.Serialization
                             reader.ReadAndAssert();
                             metadataProperty = true;
                         }
-                        else if (string.Equals(propertyName, JsonTypeReflector.ArrayValuesPropertyName, StringComparison.Ordinal))
+                        else if (string.Equals(propertyName, Serializer._jsonTypeReflectorProperties.ArrayValuesPropertyName, StringComparison.Ordinal))
                         {
                             reader.ReadAndAssert();
                             object? list = CreateList(reader, objectType, contract, member, existingValue, id);
@@ -2472,12 +2472,11 @@ namespace Newtonsoft.Json.Serialization
         {
             if (Serializer.MetadataPropertyHandling == MetadataPropertyHandling.ReadAhead)
             {
-                switch (memberName)
-                {
-                    case JsonTypeReflector.IdPropertyName:
-                    case JsonTypeReflector.RefPropertyName:
-                    case JsonTypeReflector.TypePropertyName:
-                    case JsonTypeReflector.ArrayValuesPropertyName:
+                if (memberName == Serializer._jsonTypeReflectorProperties.IdPropertyName
+                    || memberName == Serializer._jsonTypeReflectorProperties.RefPropertyName
+                    || memberName == Serializer._jsonTypeReflectorProperties.TypePropertyName
+                    || memberName == Serializer._jsonTypeReflectorProperties.ArrayValuesPropertyName
+                    ){ 
                         reader.Skip();
                         return true;
                 }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -139,7 +139,7 @@ namespace Newtonsoft.Json.Serialization
                 {
                     writer.WriteStartObject();
                     WriteTypeProperty(writer, contract.CreatedType);
-                    writer.WritePropertyName(JsonTypeReflector.ValuePropertyName, false);
+                    writer.WritePropertyName(Serializer._jsonTypeReflectorProperties.ValuePropertyName, false);
 
                     JsonWriter.WriteValue(writer, contract.TypeCode, value);
 
@@ -375,7 +375,7 @@ namespace Newtonsoft.Json.Serialization
             }
 
             writer.WriteStartObject();
-            writer.WritePropertyName(JsonTypeReflector.RefPropertyName, false);
+            writer.WritePropertyName(Serializer._jsonTypeReflectorProperties.RefPropertyName, false);
             writer.WriteValue(reference);
             writer.WriteEndObject();
         }
@@ -612,7 +612,7 @@ namespace Newtonsoft.Json.Serialization
                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing object reference Id '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, reference, type)), null);
             }
 
-            writer.WritePropertyName(JsonTypeReflector.IdPropertyName, false);
+            writer.WritePropertyName(Serializer._jsonTypeReflectorProperties.IdPropertyName, false);
             writer.WriteValue(reference);
         }
 
@@ -624,8 +624,8 @@ namespace Newtonsoft.Json.Serialization
             {
                 TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
             }
-
-            writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
+            
+            writer.WritePropertyName(Serializer._jsonTypeReflectorProperties.TypePropertyName, false);
             writer.WriteValue(typeName);
         }
 
@@ -836,7 +836,7 @@ namespace Newtonsoft.Json.Serialization
                 {
                     WriteTypeProperty(writer, values.GetType());
                 }
-                writer.WritePropertyName(JsonTypeReflector.ArrayValuesPropertyName, false);
+                writer.WritePropertyName(Serializer._jsonTypeReflectorProperties.ArrayValuesPropertyName, false);
             }
 
             if (contract.ItemContract == null)

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -42,17 +42,17 @@ using System.Runtime.Serialization;
 
 namespace Newtonsoft.Json.Serialization
 {
-    internal static class JsonTypeReflector
-    {
+
+    internal static class JsonTypeReflector {
+        public const string obsolete_IdPropertyName = "$id";
+        public const string obsolete_RefPropertyName = "$ref";
+        public const string obsolete_TypePropertyName = "$type";
+        public const string obsolete_ValuePropertyName = "$value";
+        public const string obsolete_ArrayValuesPropertyName = "$values";
+
+
         private static bool? _dynamicCodeGeneration;
         private static bool? _fullyTrusted;
-
-        public const string IdPropertyName = "$id";
-        public const string RefPropertyName = "$ref";
-        public const string TypePropertyName = "$type";
-        public const string ValuePropertyName = "$value";
-        public const string ArrayValuesPropertyName = "$values";
-
         public const string ShouldSerializePrefix = "ShouldSerialize";
         public const string SpecifiedPostfix = "Specified";
 
@@ -528,4 +528,5 @@ namespace Newtonsoft.Json.Serialization
             }
         }
     }
+ 
 }

--- a/Src/Newtonsoft.Json/Serialization/JsonTypeReflectorProperties.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonTypeReflectorProperties.cs
@@ -1,0 +1,63 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if HAVE_CAS
+#endif
+#if !HAVE_LINQ
+using Newtonsoft.Json.Utilities.LinqBridge;
+#else
+#endif
+
+namespace Newtonsoft.Json
+{
+    internal class JsonTypeReflectorProperties
+    {
+        private readonly string ReflectionPropertyPrefix;
+        public string IdPropertyName { get => ReflectionPropertyPrefix + "id"; }
+        public string RefPropertyName { get => ReflectionPropertyPrefix + "ref"; }
+        public string TypePropertyName { get => ReflectionPropertyPrefix + "type"; }
+        public string ValuePropertyName { get => ReflectionPropertyPrefix + "value"; }
+        public string ArrayValuesPropertyName { get => ReflectionPropertyPrefix + "values"; }
+
+        public string GetReflectionPropertyPrefix()
+        {
+            return ReflectionPropertyPrefix;
+        }
+
+        protected JsonTypeReflectorProperties(string prefix)
+        {
+            ReflectionPropertyPrefix = prefix;
+        }
+
+        public JsonTypeReflectorProperties()
+        {
+            ReflectionPropertyPrefix = "$";
+        }
+    }
+    internal class MongoJsonTypeReflectorProperties : JsonTypeReflectorProperties
+    {
+        public MongoJsonTypeReflectorProperties() : base("_$") { }
+    }
+}

--- a/Src/Newtonsoft.Json/TypeNameProperties.cs
+++ b/Src/Newtonsoft.Json/TypeNameProperties.cs
@@ -1,0 +1,8 @@
+﻿namespace Newtonsoft.Json
+{
+    public enum TypeNameProperties
+    {
+        Default = 0,
+        Mongo = 1
+    }
+}


### PR DESCRIPTION
When the JsonSerializerSetting TypeNameProperties is set to Mongo, then all the json attributes related to typenames will begin with "_$" instead of "$" since Mongodb does not fully support "$" as the first character in an attribute.

XML to Json was out of the original scope of this change.
 
Also refactored TypeNameHandlingTests.cs so that they could run once against the default typename properties and once against the mongodb compatible properties.

Fixes #2267 

Testing done: Ran whole unit test suite and all pass.