### PR TITLE
Type name discriminator is now omitted when null

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -618,15 +618,18 @@ namespace Newtonsoft.Json.Serialization
 
         private void WriteTypeProperty(JsonWriter writer, Type type)
         {
-            string typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormatHandling, Serializer._serializationBinder);
+            string? typeName = ReflectionUtils.GetTypeName(type, Serializer._typeNameAssemblyFormatHandling, Serializer._serializationBinder);
 
-            if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+            if (typeName != null)
             {
-                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
-            }
+                if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
+                {
+                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(null, writer.Path, "Writing type name '{0}' for {1}.".FormatWith(CultureInfo.InvariantCulture, typeName, type)), null);
+                }
 
-            writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
-            writer.WriteValue(typeName);
+                writer.WritePropertyName(JsonTypeReflector.TypePropertyName, false);
+                writer.WriteValue(typeName);
+            }
         }
 
         private bool HasFlag(DefaultValueHandling value, DefaultValueHandling flag)

--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -147,14 +147,14 @@ namespace Newtonsoft.Json.Utilities
             return v?.GetType();
         }
 
-        public static string GetTypeName(Type t, TypeNameAssemblyFormatHandling assemblyFormat, ISerializationBinder? binder)
+        public static string? GetTypeName(Type t, TypeNameAssemblyFormatHandling assemblyFormat, ISerializationBinder? binder)
         {
-            string fullyQualifiedTypeName = GetFullyQualifiedTypeName(t, binder);
+            string? fullyQualifiedTypeName = GetFullyQualifiedTypeName(t, binder);
 
             switch (assemblyFormat)
             {
                 case TypeNameAssemblyFormatHandling.Simple:
-                    return RemoveAssemblyDetails(fullyQualifiedTypeName);
+                    return fullyQualifiedTypeName != null ? RemoveAssemblyDetails(fullyQualifiedTypeName) : null;
                 case TypeNameAssemblyFormatHandling.Full:
                     return fullyQualifiedTypeName;
                 default:
@@ -162,7 +162,7 @@ namespace Newtonsoft.Json.Utilities
             }
         }
 
-        private static string GetFullyQualifiedTypeName(Type t, ISerializationBinder? binder)
+        private static string? GetFullyQualifiedTypeName(Type t, ISerializationBinder? binder)
         {
             if (binder != null)
             {
@@ -174,6 +174,11 @@ namespace Newtonsoft.Json.Utilities
                     return t.AssemblyQualifiedName;
                 }
 #endif
+                if (assemblyName == null && typeName == null)
+                {
+                    return null;
+                }
+
                 return typeName + (assemblyName == null ? "" : ", " + assemblyName);
             }
 


### PR DESCRIPTION
### Summary
Type name discriminator is now omitted when custom serialization binder returns null for both assembly name and type name, previous behavior would insert an empty string `$type` property. 
For example:
```js
{ 
    "$type": "",
    "Name": "Caroline Customer"
}
```

Now becomes:
```js
{ 
    "Name": "Caroline Customer"
}
```

### Motivation
When implementing a custom `ISerializationBinder`, we only wanted a `$type` property to be inserted in the json for a specific set of types, but not others. When using `TypeNameHandling.Auto` this happens automatically when the object being serialized is the same as its declared type. However, this caused issues when using interfaces such as `IEnumerable` to represent json arrays, as these would then include an undesired `$type` property. 

### Solution
This PR allows a developer to control whether a `$type` property is included by implementing a custom `ISerializationBinder` and setting both assembly name and type name to null in `BindToName()` when they wish it to be omitted.

This PR also addresses [this](https://github.com/JamesNK/Newtonsoft.Json/issues/2005) pre-existing open issue and [this](https://github.com/JamesNK/Newtonsoft.Json/pull/2036) pre-existing PR. 

### Considerations
The function `GetFullyQualifiedTypeName()` in ReflectionUtils.cs already has specified behavior when both assembly name and type name are null, namely to simply return the default `AssemblyQualifiedName`. This seems to us to be undesirable behavior, but this is only the case for .NET 2.0 and .NET 3.5. In other .NET versions the current behavior is the example listed in the summary (an empty string `$type` property).

```C#
#if (NET20 || NET35)
    // for older SerializationBinder implementations that didn't have BindToName
    if (assemblyName == null & typeName == null)
    {
        return t.AssemblyQualifiedName;
    }
#endif
```

This means that behavior is different for `NET20` and `NET35` than other versions. We were hesitant to consolidate this though, as programs using `NET20` or `NET35` might inadvertently depend on the `AssemblyQualifiedName` being returned. 