### PR TITLE
Fix JsonPath character escaping for additional special characters (#2216)

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue2216.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue2216.cs
@@ -1,0 +1,70 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System.IO;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    [TestFixture]
+    public class Issue2216 : TestFixtureBase
+    {
+        [Test]
+        public void Test()
+        {
+            string json = @"{""a"": ""1"", ""*"": ""2"", ""$"": ""3"", ""@"": ""4""}";
+
+            StringReader stringReader = new StringReader(json);
+            JsonTextReader reader = new JsonTextReader(stringReader);
+            
+            reader.Read();
+            reader.Read();
+            reader.Read();
+            Assert.AreEqual("1", reader.Value);
+            Assert.AreEqual("a", reader.Path);
+
+            reader.Read();
+            reader.Read();
+            Assert.AreEqual("2", reader.Value);
+            Assert.AreEqual("['*']", reader.Path);
+
+            reader.Read();
+            reader.Read();
+            Assert.AreEqual("3", reader.Value);
+            Assert.AreEqual("['$']", reader.Path);
+
+            reader.Read();
+            reader.Read();
+            Assert.AreEqual("4", reader.Value);
+            Assert.AreEqual("['@']", reader.Path);
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/JsonPosition.cs
+++ b/Src/Newtonsoft.Json/JsonPosition.cs
@@ -42,7 +42,7 @@ namespace Newtonsoft.Json
 
     internal struct JsonPosition
     {
-        private static readonly char[] SpecialCharacters = { '.', ' ', '\'', '/', '"', '[', ']', '(', ')', '\t', '\n', '\r', '\f', '\b', '\\', '\u0085', '\u2028', '\u2029' };
+        private static readonly char[] SpecialCharacters = { '.', ' ', '\'', '/', '"', '[', ']', '(', ')', '\t', '\n', '\r', '\f', '\b', '\\', '\u0085', '\u2028', '\u2029', '*', '@' };
 
         internal JsonContainerType Type;
         internal int Position;
@@ -77,7 +77,7 @@ namespace Newtonsoft.Json
             {
                 case JsonContainerType.Object:
                     string propertyName = PropertyName!;
-                    if (propertyName.IndexOfAny(SpecialCharacters) != -1)
+                    if (propertyName.IndexOfAny(SpecialCharacters) != -1 || propertyName == "$")
                     {
                         sb.Append(@"['");
 


### PR DESCRIPTION
Trying to fix the bug mentioned.

The "$" gets special treatment because there are existing tests that have keys like "$id". If these should become "$['$id']" too, please let me know, I'm happy to do the changes (which are mainly paths in error messages is other tests).