### PR TITLE
Fix wrong define is used in StringUtils.ToLower()

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -195,7 +195,7 @@ namespace Newtonsoft.Json.Utilities
 
         private static char ToLower(char c)
         {
-#if HAVE_CHAR_TO_STRING_WITH_CULTURE
+#if HAVE_CHAR_TO_LOWER_WITH_CULTURE
             c = char.ToLower(c, CultureInfo.InvariantCulture);
 #else
             c = char.ToLowerInvariant(c);


### PR DESCRIPTION
In `StringUtils.ToLower()` call to `char.ToLower(char, CultureInfo)` should be wrapped in `#if HAVE_CHAR_TO_LOWER_WITH_CULTURE` instead of `#if HAVE_CHAR_TO_STRING_WITH_CULTURE`.