### PR TITLE
Implement serialization of comments

### DIFF
--- a/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/Src/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -47,6 +47,7 @@ namespace Newtonsoft.Json
         internal bool? _itemIsReference;
         internal ReferenceLoopHandling? _itemReferenceLoopHandling;
         internal TypeNameHandling? _itemTypeNameHandling;
+        internal string? _comment;
 
         /// <summary>
         /// Gets or sets the <see cref="JsonConverter"/> type used when serializing the property's collection items.
@@ -202,6 +203,16 @@ namespace Newtonsoft.Json
         {
             get => _itemIsReference ?? default;
             set => _itemIsReference = value;
+        }
+
+        /// <summary>
+        /// Gets or sets or sets the comment of the property that is written above the property name.
+        /// </summary>
+        /// <value>The contents of the comment.</value>
+        public string? Comment
+        {
+            get => _comment ?? default;
+            set => _comment = value;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -769,6 +769,7 @@ namespace Newtonsoft.Json.Serialization
                 property.ReferenceLoopHandling = property.ReferenceLoopHandling ?? matchingMemberProperty.ReferenceLoopHandling;
                 property.ObjectCreationHandling = property.ObjectCreationHandling ?? matchingMemberProperty.ObjectCreationHandling;
                 property.TypeNameHandling = property.TypeNameHandling ?? matchingMemberProperty.TypeNameHandling;
+                property.Comment = property.Comment ?? matchingMemberProperty.Comment;
             }
 
             return property;
@@ -1544,6 +1545,7 @@ namespace Newtonsoft.Json.Serialization
                 property.ObjectCreationHandling = propertyAttribute._objectCreationHandling;
                 property.TypeNameHandling = propertyAttribute._typeNameHandling;
                 property.IsReference = propertyAttribute._isReference;
+                property.Comment = propertyAttribute.Comment;
 
                 property.ItemIsReference = propertyAttribute._itemIsReference;
                 property.ItemConverter = propertyAttribute.ItemConverterType != null ? JsonTypeReflector.CreateJsonConverterInstance(propertyAttribute.ItemConverterType, propertyAttribute.ItemConverterParameters) : null;

--- a/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonProperty.cs
@@ -246,6 +246,12 @@ namespace Newtonsoft.Json.Serialization
         public TypeNameHandling? TypeNameHandling { get; set; }
 
         /// <summary>
+        /// Gets or sets or sets the comment of the property that is written above the property name.
+        /// </summary>
+        /// <value>The contents of the comment.</value>
+        public string? Comment { get; set; }
+
+        /// <summary>
         /// Gets or sets a predicate used to determine whether the property should be serialized.
         /// </summary>
         /// <value>A predicate used to determine whether the property should be serialized.</value>
@@ -316,6 +322,15 @@ namespace Newtonsoft.Json.Serialization
             else
             {
                 writer.WritePropertyName(propertyName);
+            }
+        }
+
+        internal void WriteComment(JsonWriter writer)
+        {
+            string? comment = Comment;
+            if (comment != null)
+            {
+                writer.WriteComment(" " + comment + " ");
             }
         }
     }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -472,6 +472,7 @@ namespace Newtonsoft.Json.Serialization
                         continue;
                     }
 
+                    property.WriteComment(writer);
                     property.WritePropertyName(writer);
                     SerializeValue(writer, memberValue, memberContract, property, contract, member);
                 }


### PR DESCRIPTION
This draft PR implements the comments feature mentioned in #1211.

This class:
```csharp
class Root
{
    [JsonProperty("test")]
    public float test = 0.42f;
    [JsonProperty("growIncrement", Comment = "Lorem Ipsum")]
    public float GrowIncrement = 0.42f;
}
```
should be serialized to something like this:
```jsonc
{
    "test": 0.42,
    /* Lorem Ipsum */
    "growIncrement": 0.42
}
```

I'm doing a draft pull request to get some opinions and advice on the requested feature and the implementation. Besides adding tests, what can be done better?

This implementation currently emits this JSON (when formatted):
```jsonc
{
  "test": 0.42/* Lorem Ipsum */,
  "growIncrement": 0.42
}
```

How do I prevent the comment being written before the comma of the preceeding property? I suspect the reason being that the AutoClose of the property state is not called before the `WriteComment`. How do I solve this properly?
The comment should also have the same indentation as the property `growIncrement`.

Feature Request: https://stackoverflow.com/questions/9495718
Resolves #1211