### PR TITLE
Added JsonContract.TypeNameHandling property

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TypeNameHandlingTests.cs
@@ -767,12 +767,8 @@ namespace Newtonsoft.Json.Tests.Serialization
             string json = JsonConvert.SerializeObject(container, Formatting.Indented,
                 new JsonSerializerSettings
                 {
-                    NullValueHandling = NullValueHandling.Ignore,
                     TypeNameHandling = TypeNameHandling.Auto,
-                    ContractResolver = new OmitArrayTypesContractResolver(),
-#pragma warning disable 618
-                    TypeNameAssemblyFormat = FormatterAssemblyStyle.Full
-#pragma warning restore 618
+                    ContractResolver = new OmitArrayTypesContractResolver()
                 });
 
             StringAssert.AreEqual(@"{

--- a/Src/Newtonsoft.Json.Tests/TestObjects/ClassWithIList.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/ClassWithIList.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class ClassWithIList
+    {
+        private string foo;
+        private readonly IList<long> bar;
+
+        public ClassWithIList()
+        {
+            bar = new List<long>();
+        }
+
+        public ClassWithIList(string _foo, IList<long> _bar)
+        {
+            foo = _foo;
+            bar = _bar;
+        }
+
+        public string Foo
+        {
+            get { return foo; }
+            set { foo = value; }
+        }
+
+        public IList<long> Bar
+        {
+            get { return bar; }
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Serialization/JsonContract.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonContract.cs
@@ -140,6 +140,12 @@ namespace Newtonsoft.Json.Serialization
         public JsonConverter? InternalConverter { get; internal set; }
 
         /// <summary>
+        /// Gets or sets the type name handling.
+        /// </summary>
+        /// <value>The type name handling.</value>
+        public TypeNameHandling? TypeNameHandling { get; set; }
+
+        /// <summary>
         /// Gets or sets all methods called immediately after deserialization of the object.
         /// </summary>
         /// <value>The methods called immediately after deserialization of the object.</value>

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -770,6 +770,7 @@ namespace Newtonsoft.Json.Serialization
         {
             TypeNameHandling resolvedTypeNameHandling =
                 member?.TypeNameHandling
+                ?? contract?.TypeNameHandling
                 ?? containerContract?.ItemTypeNameHandling
                 ?? containerMember?.ItemTypeNameHandling
                 ?? Serializer._typeNameHandling;

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs
@@ -998,6 +998,7 @@ namespace Newtonsoft.Json.Serialization
         {
             TypeNameHandling resolvedTypeNameHandling =
                 member?.TypeNameHandling
+                ?? contract.TypeNameHandling
                 ?? containerProperty?.ItemTypeNameHandling
                 ?? containerContract?.ItemTypeNameHandling
                 ?? Serializer._typeNameHandling;


### PR DESCRIPTION
This PR adds JsonContract.TypeNameHandling property.

### Motivation
Having JsonContract.TypeNameHandling property will allow finer control over type name serialization without having to resort to using JsonProperty which is not always possible. (classes outside the developer's control or too many classes)

### Background
During a migration of large project spanning hundreds of DTOs to Newtonsoft.Json, I wished to avoid array types from being serialized with type information, while at the same time have object types serialized with type information when appropriate (TypeNameHandling.Auto for object types, and TypeNameHandling.None for array types).

IMO it is not practical nor desirable to add JsonProperty to hundreds of DTOs, and the suggested property allows finer control at the JsonContract level which I believe is the most desirable approach.