### PR TITLE
Simplify `#if` preprocessor statements

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/SerializationErrorHandlingTests.cs
@@ -391,11 +391,11 @@ namespace Newtonsoft.Json.Tests.Serialization
 #if !(NET20 || NET35)
                 "[1] - 1 - The string was not recognized as a valid DateTime. There is an unknown word starting at index 0.",
                 "[1] - 1 - String was not recognized as a valid DateTime.",
-                "[1] - 1 - The string 'I am not a date and will error!' was not recognized as a valid DateTime. There is an unknown word starting at index '0'."
+                "[1] - 1 - The string 'I am not a date and will error!' was not recognized as a valid DateTime. There is an unknown word starting at index '0'.",
 #else
     // handle typo fix in later versions of .NET
                 "[1] - 1 - The string was not recognized as a valid DateTime. There is an unknown word starting at index 0.",
-                "[1] - 1 - The string was not recognized as a valid DateTime. There is a unknown word starting at index 0."
+                "[1] - 1 - The string was not recognized as a valid DateTime. There is a unknown word starting at index 0.",
 #endif
             };
 

--- a/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
+++ b/Src/Newtonsoft.Json.Tests/TestFixtureBase.cs
@@ -277,25 +277,26 @@ namespace Newtonsoft.Json.Tests
 
 #if DNXCORE50
         protected TestFixtureBase()
+        {
+            // suppress writing to console with dotnet test to keep build log size small
+            Console.SetOut(new StringWriter());
+
+            JsonConvert.DefaultSettings = null;
+        }
 #else
         [SetUp]
         protected void TestSetup()
-#endif
         {
-#if !(DNXCORE50)
             //CultureInfo turkey = CultureInfo.CreateSpecificCulture("tr");
             //Thread.CurrentThread.CurrentCulture = turkey;
             //Thread.CurrentThread.CurrentUICulture = turkey;
 
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
-#else
-            // suppress writing to console with dotnet test to keep build log size small
-            Console.SetOut(new StringWriter());
-#endif
 
             JsonConvert.DefaultSettings = null;
         }
+#endif
 
         protected void WriteEscapedJson(string json)
         {

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -184,13 +184,13 @@ namespace Newtonsoft.Json
             get => _dateParseHandling;
             set
             {
-                if (value < DateParseHandling.None ||
 #if HAVE_DATE_TIME_OFFSET
-                    value > DateParseHandling.DateTimeOffset
+                bool valueExceedsDateTime = value > DateParseHandling.DateTimeOffset;
 #else
-                    value > DateParseHandling.DateTime
+                bool valueExceedsDateTime = value > DateParseHandling.DateTime;
 #endif
-                    )
+
+                if (value < DateParseHandling.None || valueExceedsDateTime)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }


### PR DESCRIPTION
While the `#if` preprocessor directive is powerful it can play havoc with source analysis tools, syntax highlighters and semantic code analysis when used to build fragments of statements that would otherwise be invalid.

This becomes more important as online analysis tools take off such as GitHub's C# support for semantic code features we've been working on over at https://github.com/tree-sitter/tree-sitter-c-sharp and with the rise of lightweight code editors such as VS Code that do not have a complete compiler at their disposal.

By simply restructuring these`#if` fragments we can make them lightweight-friendly allowing syntax highlighter and analysis tools to deal with them correctly.

There are only three places in the JSON.Net source code where partial-code fragments were in `#if` directives, they are:

1. SerializationErrorHandlingTests - easily solved with a dangling `,` between the sections
2. TextFixtureBase.cs - split the two possible functions out and is now much easier to read as well
3. JsonReader.cs - moved the `#if` outside of the if statement

Here is a screenshot from VSCode showing it struggling with TextFixtureBase:

![image](https://user-images.githubusercontent.com/118951/95201938-8758b480-07d8-11eb-947b-355235f5f059.png)