### PR TITLE
Support cross platform generics

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue1972.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue1972.cs
@@ -1,0 +1,75 @@
+﻿#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+#if !(NET20 || NET35 || NET40)
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    [TestFixture]
+    public class Issue1972 : TestFixtureBase
+    {
+        [Test]
+        public void Test_ObjectsCrossPlatform()
+        {
+            JsonSerializerSettings jsonSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Objects
+            };
+
+            TestClass<int> a = new TestClass<int>() {
+                Prop1 = 123
+            };
+
+            string serializedData = JsonConvert.SerializeObject(a, jsonSettings);
+
+            // Swap "mscorlib" and "System.Private.CoreLib" to simulate cross-platform serialization
+            string serializedDataChangedAssembly;
+            if (serializedData.Contains("mscorlib"))
+                serializedDataChangedAssembly = serializedData.Replace("mscorlib", "System.Private.CoreLib");
+            else
+                serializedDataChangedAssembly = serializedData.Replace("System.Private.CoreLib", "mscorlib");
+
+            TestClass<int> deserialized = JsonConvert.DeserializeObject<TestClass<int>>(serializedDataChangedAssembly, jsonSettings);
+
+            Assert.AreEqual(a.Prop1, deserialized.Prop1);
+        }
+
+        class TestClass<T>
+        {
+            public T Prop1 { get; set; }
+        }
+    }
+}
+#endif

--- a/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultSerializationBinder.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // Copyright (c) 2007 James Newton-King
 //
 // Permission is hereby granted, free of charge, to any person
@@ -87,6 +87,20 @@ namespace Newtonsoft.Json.Serialization
                             assembly = a;
                             break;
                         }
+                    }
+                }
+#endif
+
+#if NETFRAMEWORK
+                // Handle cross-platform .NET Framework to .NET Core 
+                // NET Framework uses mscorlib.dll while .NET core uses System.Private.CoreLib.dll
+                // Type.GetType() automatically handles resolution from mscorlib to System.Private.CoreLib.dll
+                // but not the other way around, we need to handle that manually that here on .NET Framework systems which use mscorlib
+                if (assembly == null) 
+                {
+                    if (assemblyName == "System.Private.CoreLib") 
+                    {
+                        assembly = Assembly.Load(new AssemblyName("mscorlib"));
                     }
                 }
 #endif


### PR DESCRIPTION
Resolve #1972 by loading `mscorlib` assembly on .NET Framework assemblies instead of `System.Private.CoreLib` 

NET Framework uses mscorlib.dll while .NET core uses System.Private.CoreLib.dll. Type.GetType() automatically handles resolution from mscorlib to System.Private.CoreLib.dll but not the other way around.

This will help those with multiple systems transitioning from .NET 5 and .NET Framework 4. That is, deserializing on a .NET Framework system with json that was serialized on a .NET 5 system.