### PR TITLE
Missing nullability annotation

### DIFF
--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -587,7 +587,7 @@ namespace Newtonsoft.Json
         /// A JSON string representation of the object.
         /// </returns>
         [DebuggerStepThrough]
-        public static string SerializeObject(object? value, JsonSerializerSettings settings)
+        public static string SerializeObject(object? value, JsonSerializerSettings? settings)
         {
             return SerializeObject(value, null, settings);
         }


### PR DESCRIPTION
In the param description it says _"If this is null, default serialization settings will be used"_ but the param is not marked as nullable.