### PR TITLE
DataTableConverter.cs: allow non-primitve type

### DIFF
--- a/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataTableConverter.cs
@@ -192,7 +192,7 @@ namespace Newtonsoft.Json.Converters
                 }
                 else
                 {
-                    object columnValue = (reader.Value != null)
+                    object columnValue = (reader.Value != null) || (reader.TokenType == JsonToken.StartObject)
                         ? serializer.Deserialize(reader, column.DataType) ?? DBNull.Value
                         : DBNull.Value;
 
@@ -232,6 +232,9 @@ namespace Newtonsoft.Json.Converters
 
                     Type arrayType = GetColumnDataType(reader);
                     return arrayType.MakeArrayType();
+                case JsonToken.StartObject:
+                    // compound column type
+                    return typeof(JObject);
                 default:
                     throw JsonSerializationException.Create(reader, "Unexpected JSON token when reading DataTable: {0}".FormatWith(CultureInfo.InvariantCulture, tokenType));
             }


### PR DESCRIPTION
extend DataTableConverter to read compound values

#2355 
