### PR TITLE
Added `CreateProperty` method exposing the target `Type` to the `DefaultContractResolver`

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
@@ -797,6 +797,18 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
+        public void DefaultContractResolverExposesCorrectTypeToCreatePropertyMethod()
+        {
+            VehicleContractResolver resolver = new VehicleContractResolver();
+
+            JsonObjectContract trainContract = (JsonObjectContract)resolver.ResolveContract(typeof(Train));            
+            JsonObjectContract aircraftContract = (JsonObjectContract)resolver.ResolveContract(typeof(Aircraft));            
+
+            Assert.IsTrue(trainContract.Properties[nameof(Vehicle.Registration)].Ignored);
+            Assert.IsFalse(aircraftContract.Properties[nameof(Vehicle.Registration)].Ignored);
+        }
+
+        [Test]
         public void JsonRequiredAttribute()
         {
             DefaultContractResolver resolver = new DefaultContractResolver();

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Aircraft.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Aircraft.cs
@@ -1,0 +1,18 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public enum AircraftType
+    {
+        FixedWing,
+        RotaryWing
+    }
+    
+    public class Aircraft : Vehicle
+    {
+        public AircraftType Type { get; }
+        
+        public Aircraft(AircraftType type, string registration) : base(registration)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Train.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Train.cs
@@ -1,0 +1,10 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class Train : Vehicle
+    {
+        public int NumberOfCars { get; set; }
+        public Train(string registration) : base(registration)
+        {
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Vehicle.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Vehicle.cs
@@ -1,0 +1,12 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public abstract class Vehicle
+    {
+        public string Registration { get; }
+
+        protected Vehicle(string registration)
+        {
+            Registration = registration;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/VehicleContractResolver.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/VehicleContractResolver.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Reflection;
+using Newtonsoft.Json.Serialization;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class VehicleContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(type, member, memberSerialization);
+            
+            // Only ignore the registration for Trains
+            if (member.Name == nameof(Vehicle.Registration) && type == typeof(Train))
+            {
+                property.Ignored = true;
+            }
+
+            return property;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1372,7 +1372,7 @@ namespace Newtonsoft.Json.Serialization
 
             foreach (MemberInfo member in members)
             {
-                JsonProperty property = CreateProperty(member, memberSerialization);
+                JsonProperty property = CreateProperty(type, member, memberSerialization);
 
                 if (property != null)
                 {
@@ -1423,6 +1423,18 @@ namespace Newtonsoft.Json.Serialization
             return valueProvider;
         }
 
+        /// <summary>
+        /// Creates a <see cref="JsonProperty"/> for the given <see cref="MemberInfo"/>.
+        /// </summary>
+        /// <param name="type">The type to create the property for.</param>
+        /// <param name="memberSerialization">The member's parent <see cref="MemberSerialization"/>.</param>
+        /// <param name="member">The member to create a <see cref="JsonProperty"/> for.</param>
+        /// <returns>A created <see cref="JsonProperty"/> for the given <see cref="MemberInfo"/>.</returns>
+        protected virtual JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
+        {
+            return CreateProperty(member, memberSerialization);
+        }
+        
         /// <summary>
         /// Creates a <see cref="JsonProperty"/> for the given <see cref="MemberInfo"/>.
         /// </summary>


### PR DESCRIPTION
Attempts to address #2488

## Summary
When inheriting from the `DefaultContractResolver` and overriding the `CreateProperty(MemberInfo, MemberSerialization)` method, the `MemberInfo` made available provides the wrong `memberInfo.ReflectedType` when the member is declared on a base class.

This is because private getters and setters are inaccessible unless the property was gotten from the base type:
https://github.com/JamesNK/Newtonsoft.Json/blob/b6dc05be5a0f4808f06ec430f3bb59b24d3fbc3e/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs#L945-L954

This unfortunately has a side-affect where the target `Type` being resolved can be lost when creating the `JsonProperty` for a property defined on a base class, leaving the `CreateProperty` method with no context of what `Type` is being resolved.

While this isn't an issue internally, it could pose an issue for anyone overriding this method who needs to know the type being resolved (I've run into this issue and have implemented a temporary solution as shown in the linked issue).

This PR adds an extra method between `CreateProperties` and `CreateProperty`, which exposes the target `Type` as a parameter. 

### Before
`CreateProeprties(Type, MemberSerialization)` -> `CreateProperty(MemberInfo, MemberSerialization)`

### After
`CreateProeprties(Type, MemberSerialization)` -> `CreateProperty(Type, MemberInfo, MemberSerialization)` -> `CreateProperty(MemberInfo, MemberSerialization)`

This intermediate method serves no purpose but to expose the `Type` if necessary.