### PR TITLE
Exposed the target Type to the CreateProperty method

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Documentation/ConditionalPropertiesTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Documentation/ConditionalPropertiesTests.cs
@@ -62,9 +62,9 @@ namespace Newtonsoft.Json.Tests.Documentation
     {
         public new static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();
 
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
         {
-            JsonProperty property = base.CreateProperty(member, memberSerialization);
+            JsonProperty property = base.CreateProperty(type, member, memberSerialization);
 
             if (property.DeclaringType == typeof(Employee) && property.PropertyName == "Manager")
             {

--- a/Src/Newtonsoft.Json.Tests/Issues/Issue1576.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue1576.cs
@@ -81,9 +81,9 @@ namespace Newtonsoft.Json.Tests.Issues
 
         public class CustomContractResolver : DefaultContractResolver
         {
-            protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+            protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
             {
-                var property = base.CreateProperty(member, memberSerialization);
+                var property = base.CreateProperty(type, member, memberSerialization);
 
                 if (member.Name == "Items")
                 {

--- a/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ContractResolverTests.cs
@@ -797,6 +797,19 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
+        public void DefaultContractResolverExposesCorrectTypeToCreatePropertyMethod()
+        {
+            VehicleContractResolver resolver = new VehicleContractResolver();
+
+            JsonObjectContract trainContract = (JsonObjectContract)resolver.ResolveContract(typeof(Train));            
+            JsonObjectContract aircraftContract = (JsonObjectContract)resolver.ResolveContract(typeof(Aircraft));            
+
+            Assert.IsTrue(trainContract.Properties[nameof(Vehicle.Registration)].Ignored);
+            Assert.IsFalse(aircraftContract.Properties[nameof(Vehicle.Registration)].Ignored);
+        }
+
+
+        [Test]
         public void JsonRequiredAttribute()
         {
             DefaultContractResolver resolver = new DefaultContractResolver();

--- a/Src/Newtonsoft.Json.Tests/Serialization/ShouldSerializeTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/ShouldSerializeTests.cs
@@ -624,9 +624,9 @@ namespace Newtonsoft.Json.Tests.Serialization
     {
         public static new readonly ShouldDeserializeContractResolver Instance = new ShouldDeserializeContractResolver();
 
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
         {
-            JsonProperty property = base.CreateProperty(member, memberSerialization);
+            JsonProperty property = base.CreateProperty(type, member, memberSerialization);
 
             MethodInfo shouldDeserializeMethodInfo = member.DeclaringType.GetMethod("ShouldDeserialize" + member.Name);
 

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Aircraft.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Aircraft.cs
@@ -1,0 +1,18 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public enum AircraftType
+    {
+        FixedWing,
+        RotaryWing
+    }
+
+    public class Aircraft : Vehicle
+    {
+        public AircraftType Type { get; }
+
+        public Aircraft(AircraftType type, string registration) : base(registration)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/JsonPropertyConverterContractResolver.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/JsonPropertyConverterContractResolver.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System;
 using System.Reflection;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -31,9 +32,9 @@ namespace Newtonsoft.Json.Tests.TestObjects
 {
     public class JsonPropertyConverterContractResolver : DefaultContractResolver
     {
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
         {
-            JsonProperty property = base.CreateProperty(member, memberSerialization);
+            JsonProperty property = base.CreateProperty(type, member, memberSerialization);
             if (property.PropertyName == "JavaScriptDate")
             {
                 property.Converter = new JavaScriptDateTimeConverter();

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Train.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Train.cs
@@ -1,0 +1,10 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class Train : Vehicle
+    {
+        public int NumberOfCars { get; set; }
+        public Train(string registration) : base(registration)
+        {
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/Vehicle.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/Vehicle.cs
@@ -1,0 +1,12 @@
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public abstract class Vehicle
+    {
+        public string Registration { get; }
+
+        protected Vehicle(string registration)
+        {
+            Registration = registration;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json.Tests/TestObjects/VehicleContractResolver.cs
+++ b/Src/Newtonsoft.Json.Tests/TestObjects/VehicleContractResolver.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Reflection;
+using Newtonsoft.Json.Serialization;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class VehicleContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(type, member, memberSerialization);
+
+            // Only ignore the registration for Trains
+            if (member.Name == nameof(Vehicle.Registration) && type == typeof(Train))
+            {
+                property.Ignored = true;
+            }
+
+            return property;
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1372,7 +1372,7 @@ namespace Newtonsoft.Json.Serialization
 
             foreach (MemberInfo member in members)
             {
-                JsonProperty property = CreateProperty(member, memberSerialization);
+                JsonProperty property = CreateProperty(type, member, memberSerialization);
 
                 if (property != null)
                 {
@@ -1426,10 +1426,11 @@ namespace Newtonsoft.Json.Serialization
         /// <summary>
         /// Creates a <see cref="JsonProperty"/> for the given <see cref="MemberInfo"/>.
         /// </summary>
+        /// <param name="type">The type to create the property for.</param>
         /// <param name="memberSerialization">The member's parent <see cref="MemberSerialization"/>.</param>
         /// <param name="member">The member to create a <see cref="JsonProperty"/> for.</param>
         /// <returns>A created <see cref="JsonProperty"/> for the given <see cref="MemberInfo"/>.</returns>
-        protected virtual JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected virtual JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
         {
             JsonProperty property = new JsonProperty();
             property.PropertyType = ReflectionUtils.GetMemberUnderlyingType(member);


### PR DESCRIPTION
Attempts to address #2488

## Summary
When inheriting from the `DefaultContractResolver` and overriding the `CreateProperty(MemberInfo, MemberSerialization)` method, the `MemberInfo` made available provides the wrong `memberInfo.ReflectedType` when the member is declared on a base class.

This is because private getters and setters are inaccessible unless the property was gotten from the base type:
https://github.com/JamesNK/Newtonsoft.Json/blob/b6dc05be5a0f4808f06ec430f3bb59b24d3fbc3e/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs#L945-L954

This unfortunately has a side-affect where the target `Type` being resolved can be lost when creating the `JsonProperty` for a property defined on a base class, leaving the `CreateProperty` method with no context of what `Type` is being resolved.

While this isn't an issue internally, it could pose an issue for anyone overriding this method who needs to know the type being resolved (I've run into this issue and have implemented a temporary solution as shown in the linked issue).

This PR adds the target `Type` as a parameter to the `CreateProperty` method, making the signature `CreateProperty(Type, MemberInfo, MemberSerialization)`

