### PR TITLE
Fix MaxDepth problems introduced between 12.0.3 and 13.0.1

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -7996,14 +7996,10 @@ This is just junk, though.";
         public void SetMaxDepth_DepthExceeded()
         {
             JsonTextReader reader = new JsonTextReader(new StringReader("[[['text']]]"));
-            Assert.AreEqual(64, reader.MaxDepth);
 
             JsonSerializerSettings settings = new JsonSerializerSettings();
             Assert.AreEqual(64, settings.MaxDepth);
             Assert.AreEqual(false, settings._maxDepthSet);
-
-            // Default should be the same
-            Assert.AreEqual(reader.MaxDepth, settings.MaxDepth);
 
             settings.MaxDepth = 2;
             Assert.AreEqual(2, settings.MaxDepth);
@@ -8029,8 +8025,6 @@ This is just junk, though.";
             Assert.AreEqual(2, serializer.MaxDepth);
 
             serializer.Deserialize(reader);
-
-            Assert.AreEqual(64, reader.MaxDepth);
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonReader.cs
+++ b/Src/Newtonsoft.Json/JsonReader.cs
@@ -228,7 +228,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Gets or sets the maximum depth allowed when reading JSON. Reading past this depth will throw a <see cref="JsonReaderException"/>.
         /// A null value means there is no maximum. 
-        /// The default value is <c>128</c>.
+        /// The default value is null.
         /// </summary>
         public int? MaxDepth
         {
@@ -329,7 +329,6 @@ namespace Newtonsoft.Json
             _dateTimeZoneHandling = DateTimeZoneHandling.RoundtripKind;
             _dateParseHandling = DateParseHandling.DateTime;
             _floatParseHandling = FloatParseHandling.Double;
-            _maxDepth = 64;
 
             CloseInput = true;
         }

--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -514,7 +514,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Gets or sets the maximum depth allowed when reading JSON. Reading past this depth will throw a <see cref="JsonReaderException"/>.
         /// A null value means there is no maximum.
-        /// The default value is <c>128</c>.
+        /// The default value is <c>64</c>.
         /// </summary>
         public virtual int? MaxDepth
         {

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -326,7 +326,7 @@ namespace Newtonsoft.Json
         /// <summary>
         /// Gets or sets the maximum depth allowed when reading JSON. Reading past this depth will throw a <see cref="JsonReaderException"/>.
         /// A null value means there is no maximum.
-        /// The default value is <c>128</c>.
+        /// The default value is <c>64</c>.
         /// </summary>
         public int? MaxDepth
         {


### PR DESCRIPTION
Fixes https://github.com/JamesNK/Newtonsoft.Json/issues/2501 - have verified that the example provided in F# fails with no change and is resolved with the change.

Between 12.0.3 and 13.0.1 looks like `_maxDepth = 64;` was set in the `JsonReader` constructor - any inheritors which use this default constructor end up with a max depth of 64 as a result - from the existing tests on max depth, it seems that this setting is not actually required in order to ensure the max depth is respected.

I've also updated a few doc comments which erroneously claim the max depth as 128.

Update: as much as the initial fix (https://github.com/JamesNK/Newtonsoft.Json/pull/2462) prevents a DOS attack, it does create other problems, such as 2501 - max depth is a bit tricky throughout the library, one option would be to make it mandatory on the `JsonReader` perhaps.