### PR TITLE
JToken.TryParse and JObject.TryParse

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
@@ -2095,6 +2095,40 @@ Parameter name: arrayIndex",
                 "Additional text encountered after finished reading JSON content: [. Path '', line 3, position 0.");
         }
 
+        [Test]
+        public void TryParse_NoComments()
+        {
+            string json = "{'prop':[1,2/*comment*/,3]}";
+
+            bool wasSuccess = JObject.TryParse(
+                json, 
+                new JsonLoadSettings
+                {
+                    CommentHandling = CommentHandling.Ignore
+                }, 
+                out JObject o
+            );
+
+            Assert.IsTrue(wasSuccess);
+            Assert.AreEqual(3, o["prop"].Count());
+            Assert.AreEqual(1, (int)o["prop"][0]);
+            Assert.AreEqual(2, (int)o["prop"][1]);
+            Assert.AreEqual(3, (int)o["prop"][2]);
+        }
+
+        [Test]
+        public void TryParse_ExcessiveContent()
+        {
+            string json = @"{'prop':[1,2,3]}/*comment*/
+//Another comment.
+[]";
+
+            bool wasSuccess = JObject.TryParse(json, out JObject o);
+            
+            Assert.IsFalse(wasSuccess);
+            Assert.IsNull(o);
+        }
+
 #if !(PORTABLE || DNXCORE50 || PORTABLE40) || NETSTANDARD2_0
         [Test]
         public void GetPropertyOwner_ReturnsJObject()

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -432,23 +432,24 @@ namespace Newtonsoft.Json.Linq
         }
 
         /// <summary>
-        /// 
+        /// Tries to load a <see cref="JObject"/> from a string that contains JSON.
         /// </summary>
-        /// <param name="json"></param>
-        /// <param name="jObject"></param>
-        /// <returns></returns>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="jObject">A <see cref="JObject"/> populated from the string that contains JSON.</param>
+        /// <returns>False if the method could load <see cref="JObject"/> without any exception</returns>
         public static bool TryParse(string json, out JObject? jObject)
         {
             return TryParse(json, null, out jObject);
         }
 
         /// <summary>
-        /// 
+        /// Tries to load a <see cref="JObject"/> from a string that contains JSON.
         /// </summary>
-        /// <param name="json"></param>
-        /// <param name="settings"></param>
-        /// <param name="jObject"></param>
-        /// <returns></returns>
+        /// <param name="json">A <see cref="String"/> that contains JSON.</param>
+        /// <param name="settings">The <see cref="JsonLoadSettings"/> used to load the JSON.
+        /// If this is <c>null</c>, default load settings will be used.</param>
+        /// <param name="jObject">A <see cref="JObject"/> populated from the string that contains JSON.</param>
+        /// <returns>False if the method could load <see cref="JObject"/> without any exception</returns>
         public static bool TryParse(string json, JsonLoadSettings? settings, out JObject? jObject)
         {
             bool wasSuccess = true;
@@ -495,7 +496,7 @@ namespace Newtonsoft.Json.Linq
         /// <example>
         ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParse" title="Parsing a JSON Object from Text" />
         /// </example>
-        public static JObject Parse(string json, JsonLoadSettings? settings)
+        public new static JObject Parse(string json, JsonLoadSettings? settings)
         {
             using (JsonReader reader = new JsonTextReader(new StringReader(json)))
             {

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -437,7 +437,7 @@ namespace Newtonsoft.Json.Linq
         /// <param name="json"></param>
         /// <param name="jObject"></param>
         /// <returns></returns>
-        public new static bool TryParse(string json, out JObject? jObject)
+        public static bool TryParse(string json, out JObject? jObject)
         {
             return TryParse(json, null, out jObject);
         }
@@ -449,41 +449,21 @@ namespace Newtonsoft.Json.Linq
         /// <param name="settings"></param>
         /// <param name="jObject"></param>
         /// <returns></returns>
-        public new static bool TryParse(string json, JsonLoadSettings? settings, out JObject? jObject)
+        public static bool TryParse(string json, JsonLoadSettings? settings, out JObject? jObject)
         {
-            jObject = null;
+            bool wasSuccess = true;
 
-            using (JsonReader reader = new JsonTextReader(new StringReader(json)))
+            try
             {
-                if (reader == null)
-                {
-                    return false;
-                }
-
-                if (reader.TokenType == JsonToken.None)
-                {
-                    return false;
-                }
-
-                reader.MoveToContent();
-
-                if (reader.TokenType != JsonToken.StartObject)
-                {
-                    return false;
-                }
-
-                jObject = new JObject();
-                jObject.SetLineInfo(reader as IJsonLineInfo, settings);
-
-                jObject.ReadTokenFrom(reader, settings);
-
-                while (reader.Read())
-                {
-                    // Any content encountered here other than a comment will throw in the reader.
-                }
-
-                return true;
+                jObject = Parse(json, settings);
             }
+            catch
+            {
+                jObject = null;
+                wasSuccess = false;
+            }
+
+            return wasSuccess;
         }
 
         /// <summary>

--- a/Src/Newtonsoft.Json/Linq/JObject.cs
+++ b/Src/Newtonsoft.Json/Linq/JObject.cs
@@ -432,6 +432,61 @@ namespace Newtonsoft.Json.Linq
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="jObject"></param>
+        /// <returns></returns>
+        public new static bool TryParse(string json, out JObject? jObject)
+        {
+            return TryParse(json, null, out jObject);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="settings"></param>
+        /// <param name="jObject"></param>
+        /// <returns></returns>
+        public new static bool TryParse(string json, JsonLoadSettings? settings, out JObject? jObject)
+        {
+            jObject = null;
+
+            using (JsonReader reader = new JsonTextReader(new StringReader(json)))
+            {
+                if (reader == null)
+                {
+                    return false;
+                }
+
+                if (reader.TokenType == JsonToken.None)
+                {
+                    return false;
+                }
+
+                reader.MoveToContent();
+
+                if (reader.TokenType != JsonToken.StartObject)
+                {
+                    return false;
+                }
+
+                jObject = new JObject();
+                jObject.SetLineInfo(reader as IJsonLineInfo, settings);
+
+                jObject.ReadTokenFrom(reader, settings);
+
+                while (reader.Read())
+                {
+                    // Any content encountered here other than a comment will throw in the reader.
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Load a <see cref="JObject"/> from a string that contains JSON.
         /// </summary>
         /// <param name="json">A <see cref="String"/> that contains JSON.</param>
@@ -460,7 +515,7 @@ namespace Newtonsoft.Json.Linq
         /// <example>
         ///   <code lang="cs" source="..\Src\Newtonsoft.Json.Tests\Documentation\LinqToJsonTests.cs" region="LinqToJsonCreateParse" title="Parsing a JSON Object from Text" />
         /// </example>
-        public new static JObject Parse(string json, JsonLoadSettings? settings)
+        public static JObject Parse(string json, JsonLoadSettings? settings)
         {
             using (JsonReader reader = new JsonTextReader(new StringReader(json)))
             {

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2179,6 +2179,17 @@ namespace Newtonsoft.Json.Linq
             }
         }
 
+        public static bool TryParse(string json, out JObject jObject)
+        {
+            return TryParse(json, null, out jObject);
+        }
+
+        public static bool TryParse(string json, JsonLoadSettings? settings, out JObject jObject)
+        {
+            jObject = null;
+            return false;
+        }
+
         /// <summary>
         /// Load a <see cref="JToken"/> from a string that contains JSON.
         /// </summary>

--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2179,15 +2179,38 @@ namespace Newtonsoft.Json.Linq
             }
         }
 
-        public static bool TryParse(string json, out JObject jObject)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="jToken"></param>
+        /// <returns></returns>
+        public static bool TryParse(string json, out JToken? jToken)
         {
-            return TryParse(json, null, out jObject);
+            return TryParse(json, null, out jToken);
         }
 
-        public static bool TryParse(string json, JsonLoadSettings? settings, out JObject jObject)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="settings"></param>
+        /// <param name="jToken"></param>
+        /// <returns></returns>
+        public static bool TryParse(string json, JsonLoadSettings? settings, out JToken? jToken)
         {
-            jObject = null;
-            return false;
+            bool wasSuccess = true;
+
+            try
+            {
+                jToken = Parse(json, settings);
+            } catch
+            {
+                jToken = null;
+                wasSuccess = false;
+            }
+
+            return wasSuccess;
         }
 
         /// <summary>


### PR DESCRIPTION
New methods that catch exception from the original JObject.Parse(...) method and return false, otherwise returns true and output the result JObject.

```diff

public partial class JObject {
+  public static bool TryParse(string json, out JObject? jObject)
+  public static bool TryParse(string json, JsonLoadSettings? settings, out JObject? jObject)
}

public partial class JToken{
+  public static bool TryParse(string json, out JToken? jToken)
+  public static bool TryParse(string json, JsonLoadSettings? settings, out JToken? jToken)
}

```