### PR TITLE
Epsilon for double value comparison can now be set

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenTests.cs
@@ -1221,6 +1221,29 @@ namespace Newtonsoft.Json.Tests.Linq
 
             Assert.IsTrue(v1.DeepEquals(v2));
         }
+        
+        [Test]
+        public void DoubleDeepEqualsWithCustomEpsilon()
+        {
+            var epsilon = 0.001;
+            var d1 = 0.1;
+            var d2 = 0.1 + epsilon;
+            JValue v1 = new JValue(d1);
+            JValue v2 = new JValue(d2);
+
+            Assert.IsFalse(v1.DeepEquals(v2));
+
+            var defaultEpsilon = MathUtils.Epsilon;
+            try
+            {
+                MathUtils.Epsilon = epsilon;
+                Assert.IsTrue(v1.DeepEquals(v2));
+            }
+            finally
+            {
+                MathUtils.Epsilon = defaultEpsilon;
+            }
+        }
 
         [Test]
         public void ParseAdditionalContent()

--- a/Src/Newtonsoft.Json/Utilities/MathUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/MathUtils.cs
@@ -169,16 +169,16 @@ namespace Newtonsoft.Json.Utilities
             return Math.Max(val1.GetValueOrDefault(), val2.GetValueOrDefault());
         }
 
+        public static double Epsilon { get; set; } = 2.2204460492503131E-16;
+
         public static bool ApproxEquals(double d1, double d2)
         {
-            const double epsilon = 2.2204460492503131E-16;
-
             if (d1 == d2)
             {
                 return true;
             }
 
-            double tolerance = ((Math.Abs(d1) + Math.Abs(d2)) + 10.0) * epsilon;
+            double tolerance = ((Math.Abs(d1) + Math.Abs(d2)) + 10.0) * Epsilon;
             double difference = d1 - d2;
 
             return (-tolerance < difference && tolerance > difference);


### PR DESCRIPTION
This commit allows the epsilon value for double comparison to be set.
The previously hard coded value is too tight for many of our use cases.