### PR TITLE
Add nullable annotation to `JToken.ToObject(Type, JsonSerializer)`

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JToken.cs
+++ b/Src/Newtonsoft.Json/Linq/JToken.cs
@@ -2074,7 +2074,7 @@ namespace Newtonsoft.Json.Linq
         /// <param name="objectType">The object type that the token will be deserialized to.</param>
         /// <param name="jsonSerializer">The <see cref="JsonSerializer"/> that will be used when creating the object.</param>
         /// <returns>The new object created from the JSON value.</returns>
-        public object? ToObject(Type objectType, JsonSerializer jsonSerializer)
+        public object? ToObject(Type? objectType, JsonSerializer jsonSerializer)
         {
             ValidationUtils.ArgumentNotNull(jsonSerializer, nameof(jsonSerializer));
 


### PR DESCRIPTION
This method accepts a null `Type` value in its `objectType` parameter, and the nullable annotation should reflect that.