### PR TITLE
Add ShallowCopy method for settings

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -8081,7 +8081,7 @@ This is just junk, though.";
         {
             var settings = new JsonSerializerSettings();
 
-            var clone = settings.ShallowCopy();
+            var clone = new JsonSerializerSettings(settings);
 
             Assert.AreEqual(false, settings._dateFormatStringSet);
             Assert.AreEqual(false, clone._dateFormatStringSet);

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -8079,12 +8079,109 @@ This is just junk, though.";
         [Test]
         public void ShallowCopy_DoesntSetDateFormatStringSet()
         {
+            var propertyNames = typeof(JsonSerializerSettings).GetProperties().Select(property => property.Name).ToList();
+
             var settings = new JsonSerializerSettings();
 
             var clone = new JsonSerializerSettings(settings);
 
-            Assert.AreEqual(false, settings._dateFormatStringSet);
-            Assert.AreEqual(false, clone._dateFormatStringSet);
+            Assert.AreEqual(settings.DateFormatString, clone.DateFormatString);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.DateFormatString)));
+
+            Assert.AreEqual(settings.DateFormatHandling, clone.DateFormatHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.DateFormatHandling)));
+
+            Assert.AreEqual(settings.ReferenceLoopHandling, clone.ReferenceLoopHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ReferenceLoopHandling)));
+
+            Assert.AreEqual(settings.MissingMemberHandling, clone.MissingMemberHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.MissingMemberHandling)));
+
+            Assert.AreEqual(settings.ObjectCreationHandling, clone.ObjectCreationHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ObjectCreationHandling)));
+
+            Assert.AreEqual(settings.NullValueHandling, clone.NullValueHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.NullValueHandling)));
+
+            Assert.AreEqual(settings.DefaultValueHandling, clone.DefaultValueHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.DefaultValueHandling)));
+
+            Assert.AreEqual(settings.Converters, clone.Converters);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Converters)));
+
+            Assert.AreEqual(settings.PreserveReferencesHandling, clone.PreserveReferencesHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.PreserveReferencesHandling)));
+
+            Assert.AreEqual(settings.TypeNameHandling, clone.TypeNameHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.TypeNameHandling)));
+
+            Assert.AreEqual(settings.MetadataPropertyHandling, clone.MetadataPropertyHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.MetadataPropertyHandling)));
+
+            Assert.AreEqual(settings.TypeNameAssemblyFormat, clone.TypeNameAssemblyFormat);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.TypeNameAssemblyFormat)));
+
+            Assert.AreEqual(settings.TypeNameAssemblyFormatHandling, clone.TypeNameAssemblyFormatHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.TypeNameAssemblyFormatHandling)));
+
+            Assert.AreEqual(settings.ConstructorHandling, clone.ConstructorHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ConstructorHandling)));
+
+            Assert.AreEqual(settings.ContractResolver, clone.ContractResolver);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ContractResolver)));
+
+            Assert.AreEqual(settings.EqualityComparer, clone.EqualityComparer);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.EqualityComparer)));
+
+            Assert.AreEqual(settings.ReferenceResolver, clone.ReferenceResolver);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ReferenceResolver)));
+
+            Assert.AreEqual(settings.ReferenceResolverProvider, clone.ReferenceResolverProvider);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.ReferenceResolverProvider)));
+
+            Assert.AreEqual(settings.TraceWriter, clone.TraceWriter);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.TraceWriter)));
+
+            Assert.AreEqual(settings.Binder, clone.Binder);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Binder)));
+
+            Assert.AreEqual(settings.SerializationBinder, clone.SerializationBinder);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.SerializationBinder)));
+
+            Assert.AreEqual(settings.Error, clone.Error);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Error)));
+
+            Assert.AreEqual(settings.Context, clone.Context);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Context)));
+
+            Assert.AreEqual(settings.MaxDepth, clone.MaxDepth);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.MaxDepth)));
+
+            Assert.AreEqual(settings.Formatting, clone.Formatting);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Formatting)));
+
+            Assert.AreEqual(settings.DateTimeZoneHandling, clone.DateTimeZoneHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.DateTimeZoneHandling)));
+
+            Assert.AreEqual(settings.DateParseHandling, clone.DateParseHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.DateParseHandling)));
+
+            Assert.AreEqual(settings.FloatFormatHandling, clone.FloatFormatHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.FloatFormatHandling)));
+
+            Assert.AreEqual(settings.FloatParseHandling, clone.FloatParseHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.FloatParseHandling)));
+
+            Assert.AreEqual(settings.StringEscapeHandling, clone.StringEscapeHandling);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.StringEscapeHandling)));
+
+            Assert.AreEqual(settings.Culture, clone.Culture);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.Culture)));
+
+            Assert.AreEqual(settings.CheckAdditionalContent, clone.CheckAdditionalContent);
+            Assert.IsTrue(propertyNames.Remove(nameof(JsonSerializerSettings.CheckAdditionalContent)));
+
+            Assert.AreEqual(0, propertyNames.Count);
         }
 
         private static int GetDepth(JToken o)

--- a/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/JsonSerializerTest.cs
@@ -8076,6 +8076,17 @@ This is just junk, though.";
             Assert.AreEqual(150, depth);
         }
 
+        [Test]
+        public void ShallowCopy_DoesntSetDateFormatStringSet()
+        {
+            var settings = new JsonSerializerSettings();
+
+            var clone = settings.ShallowCopy();
+
+            Assert.AreEqual(false, settings._dateFormatStringSet);
+            Assert.AreEqual(false, clone._dateFormatStringSet);
+        }
+
         private static int GetDepth(JToken o)
         {
             int depth = 1;

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -31,6 +31,7 @@ using System.Runtime.Serialization.Formatters;
 using Newtonsoft.Json.Serialization;
 using System.Runtime.Serialization;
 using System.Diagnostics;
+using System.Runtime;
 
 namespace Newtonsoft.Json
 {
@@ -451,6 +452,49 @@ namespace Newtonsoft.Json
         public JsonSerializerSettings()
         {
             Converters = new List<JsonConverter>();
+        }
+
+        /// <summary>
+        /// Create a copy of the current <see cref="JsonSerializer"/>.
+        /// </summary>
+        public JsonSerializerSettings ShallowCopy()
+        {
+            var copiedSettings = new JsonSerializerSettings
+            {
+                _floatParseHandling = _floatParseHandling,
+                _floatFormatHandling = _floatFormatHandling,
+                _dateParseHandling = _dateParseHandling,
+                _dateTimeZoneHandling = _dateTimeZoneHandling,
+                _dateFormatHandling = _dateFormatHandling,
+                _formatting = _formatting,
+                _maxDepth = _maxDepth,
+                _maxDepthSet = _maxDepthSet,
+                _dateFormatString = _dateFormatString,
+                _dateFormatStringSet = _dateFormatStringSet,
+                _context = _context,
+                Error = Error,
+                SerializationBinder = SerializationBinder,
+                TraceWriter = TraceWriter,
+                _culture = _culture,
+                ReferenceResolverProvider = ReferenceResolverProvider,
+                EqualityComparer = EqualityComparer,
+                ContractResolver = ContractResolver,
+                _constructorHandling = _constructorHandling,
+                _typeNameAssemblyFormatHandling = _typeNameAssemblyFormatHandling,
+                _metadataPropertyHandling = _metadataPropertyHandling,
+                _typeNameHandling = _typeNameHandling,
+                _preserveReferencesHandling = _preserveReferencesHandling,
+                Converters = Converters,
+                _defaultValueHandling = _defaultValueHandling,
+                _nullValueHandling = _nullValueHandling,
+                _objectCreationHandling = _objectCreationHandling,
+                _missingMemberHandling = _missingMemberHandling,
+                _referenceLoopHandling = _referenceLoopHandling,
+                _checkAdditionalContent = _checkAdditionalContent,
+                _stringEscapeHandling = _stringEscapeHandling,
+            };
+
+            return copiedSettings;
         }
     }
 }

--- a/Src/Newtonsoft.Json/JsonSerializerSettings.cs
+++ b/Src/Newtonsoft.Json/JsonSerializerSettings.cs
@@ -455,46 +455,41 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
-        /// Create a copy of the current <see cref="JsonSerializer"/>.
+        /// Create a copy of the passed in <see cref="JsonSerializer"/>.
         /// </summary>
-        public JsonSerializerSettings ShallowCopy()
+        public JsonSerializerSettings(JsonSerializerSettings original)
         {
-            var copiedSettings = new JsonSerializerSettings
-            {
-                _floatParseHandling = _floatParseHandling,
-                _floatFormatHandling = _floatFormatHandling,
-                _dateParseHandling = _dateParseHandling,
-                _dateTimeZoneHandling = _dateTimeZoneHandling,
-                _dateFormatHandling = _dateFormatHandling,
-                _formatting = _formatting,
-                _maxDepth = _maxDepth,
-                _maxDepthSet = _maxDepthSet,
-                _dateFormatString = _dateFormatString,
-                _dateFormatStringSet = _dateFormatStringSet,
-                _context = _context,
-                Error = Error,
-                SerializationBinder = SerializationBinder,
-                TraceWriter = TraceWriter,
-                _culture = _culture,
-                ReferenceResolverProvider = ReferenceResolverProvider,
-                EqualityComparer = EqualityComparer,
-                ContractResolver = ContractResolver,
-                _constructorHandling = _constructorHandling,
-                _typeNameAssemblyFormatHandling = _typeNameAssemblyFormatHandling,
-                _metadataPropertyHandling = _metadataPropertyHandling,
-                _typeNameHandling = _typeNameHandling,
-                _preserveReferencesHandling = _preserveReferencesHandling,
-                Converters = Converters,
-                _defaultValueHandling = _defaultValueHandling,
-                _nullValueHandling = _nullValueHandling,
-                _objectCreationHandling = _objectCreationHandling,
-                _missingMemberHandling = _missingMemberHandling,
-                _referenceLoopHandling = _referenceLoopHandling,
-                _checkAdditionalContent = _checkAdditionalContent,
-                _stringEscapeHandling = _stringEscapeHandling,
-            };
-
-            return copiedSettings;
+            _floatParseHandling = original._floatParseHandling;
+            _floatFormatHandling = original._floatFormatHandling;
+            _dateParseHandling = original._dateParseHandling;
+            _dateTimeZoneHandling = original._dateTimeZoneHandling;
+            _dateFormatHandling = original._dateFormatHandling;
+            _formatting = original._formatting;
+            _maxDepth = original._maxDepth;
+            _maxDepthSet = original._maxDepthSet;
+            _dateFormatString = original._dateFormatString;
+            _dateFormatStringSet = original._dateFormatStringSet;
+            _context = original._context;
+            Error = original.Error;
+            SerializationBinder = original.SerializationBinder;
+            TraceWriter = original.TraceWriter;
+            _culture = original._culture;
+            ReferenceResolverProvider = original.ReferenceResolverProvider;
+            EqualityComparer = original.EqualityComparer;
+            ContractResolver = original.ContractResolver;
+            _constructorHandling = original._constructorHandling;
+            _typeNameAssemblyFormatHandling = original._typeNameAssemblyFormatHandling;
+            _metadataPropertyHandling = original._metadataPropertyHandling;
+            _typeNameHandling = original._typeNameHandling;
+            _preserveReferencesHandling = original._preserveReferencesHandling;
+            Converters = original.Converters;
+            _defaultValueHandling = original._defaultValueHandling;
+            _nullValueHandling = original._nullValueHandling;
+            _objectCreationHandling = original._objectCreationHandling;
+            _missingMemberHandling = original._missingMemberHandling;
+            _referenceLoopHandling = original._referenceLoopHandling;
+            _checkAdditionalContent = original._checkAdditionalContent;
+            _stringEscapeHandling = original._stringEscapeHandling;
         }
     }
 }


### PR DESCRIPTION
Start of the fix for https://github.com/dotnet/aspnetcore/issues/29532

There are some hidden side effects for 2 of the properties (MaxDepth and DateFormatString). If you were to create a new JsonSerializerSettings object and copy all of the properties across the behaviour would be different (MaxDepth would be null on your source but as the "set" bool is false you'd have a value of 64. If you set your destination's property to be null then the value will be unlimited

This ShallowCopy method will create a copy of the object but at a field level (where possible) to avoid these side effects