### PR TITLE
Correction for arrays of more than 2 dimensions

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ReflectionUtils.cs
@@ -187,19 +187,30 @@ namespace Newtonsoft.Json.Utilities
             // loop through the type name and filter out qualified assembly details from nested type names
             bool writingAssemblyName = false;
             bool skippingAssemblyDetails = false;
+            bool DimensionArrayMaybe = false;
             for (int i = 0; i < fullyQualifiedTypeName.Length; i++)
             {
                 char current = fullyQualifiedTypeName[i];
                 switch (current)
                 {
                     case '[':
+                        writingAssemblyName = false;
+                        skippingAssemblyDetails = false;
+                        DimensionArrayMaybe = true;
+                        builder.Append(current);
+                        break;
                     case ']':
                         writingAssemblyName = false;
                         skippingAssemblyDetails = false;
+                        DimensionArrayMaybe = false;
                         builder.Append(current);
                         break;
                     case ',':
-                        if (!writingAssemblyName)
+                        if (DimensionArrayMaybe)
+                        {
+                            builder.Append(current);
+                        }
+                        else if (!writingAssemblyName)
                         {
                             writingAssemblyName = true;
                             builder.Append(current);
@@ -210,6 +221,7 @@ namespace Newtonsoft.Json.Utilities
                         }
                         break;
                     default:
+                        DimensionArrayMaybe = false;
                         if (!skippingAssemblyDetails)
                         {
                             builder.Append(current);


### PR DESCRIPTION
When using the type interpretation for arrays of more than 2 dimensions, on deserialization, an error is encountered.
There is a problem in the switch case that does not allow adding more than one comma between the brackets of System.xxxx [].
View issue #2591