### PR TITLE
Add support to pre-epoch Unix time

### DIFF
--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -39,6 +39,20 @@ namespace Newtonsoft.Json.Converters
         private bool _allowPreEpoch;
 
         /// <summary>
+        /// Gets or sets the default value of the <see cref="AllowPreEpoch"/>
+        /// property for new instances of the <see cref="UnixDateTimeConverter"/>
+        /// class.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to allow converting dates before Unix epoch to and from
+        /// JSON;
+        /// <c>false</c> to throw an exception when a date being converted to or
+        /// from JSON occurred before Unix epoch.
+        /// The default is <c>false</c>.
+        /// </value>
+        public static bool DefaultAllowPreEpoch { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the dates before Unix epoch
         /// should converted to and from JSON.
         /// </summary>
@@ -59,7 +73,7 @@ namespace Newtonsoft.Json.Converters
         /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/> class.
         /// </summary>
         public UnixDateTimeConverter()
-            : this(false)
+            : this(DefaultAllowPreEpoch)
         {
 
         }

--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -36,8 +36,6 @@ namespace Newtonsoft.Json.Converters
     {
         internal static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        private bool _allowPreEpoch;
-
         /// <summary>
         /// Gets or sets a value indicating whether the dates before Unix epoch
         /// should converted to and from JSON.
@@ -49,35 +47,26 @@ namespace Newtonsoft.Json.Converters
         /// from JSON occurred before Unix epoch.
         /// The default is <c>false</c>.
         /// </value>
-        public bool AllowPreEpoch
+        public bool AllowPreEpoch { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/> class.
+        /// </summary>
+        public UnixDateTimeConverter() : this(false)
         {
-            get => _allowPreEpoch;
-            set => _allowPreEpoch = value;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/> class.
         /// </summary>
-        public UnixDateTimeConverter()
-            : this(false)
-        {
-
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/>
-        /// class.
-        /// </summary>
         /// <param name="allowPreEpoch">
-        /// <c>true</c> to allow converting dates before Unix epoch to and from
-        /// JSON;
-        /// <c>false</c> to throw an exception when a date being converted to
-        /// or from JSON occurred before Unix epoch.
-        /// The default is <c>false</c>.
+        /// <c>true</c> to allow converting dates before Unix epoch to and from JSON;
+        /// <c>false</c> to throw an exception when a date being converted to or from JSON
+        /// occurred before Unix epoch. The default value is <c>false</c>.
         /// </param>
         public UnixDateTimeConverter(bool allowPreEpoch)
         {
-            _allowPreEpoch = allowPreEpoch;
+            AllowPreEpoch = allowPreEpoch;
         }
 
         /// <summary>
@@ -105,7 +94,7 @@ namespace Newtonsoft.Json.Converters
                 throw new JsonSerializationException("Expected date object value.");
             }
 
-            if (!_allowPreEpoch && seconds < 0)
+            if (!AllowPreEpoch && seconds < 0)
             {
                 throw new JsonSerializationException("Cannot convert date value that is before Unix epoch of 00:00:00 UTC on 1 January 1970.");
             }
@@ -152,7 +141,7 @@ namespace Newtonsoft.Json.Converters
                 throw JsonSerializationException.Create(reader, "Unexpected token parsing date. Expected Integer or String, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
             }
 
-            if (_allowPreEpoch || seconds >= 0)
+            if (AllowPreEpoch || seconds >= 0)
             {
                 DateTime d = UnixEpoch.AddSeconds(seconds);
 

--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -73,7 +73,7 @@ namespace Newtonsoft.Json.Converters
         /// JSON;
         /// <c>false</c> to throw an exception when a date being converted to
         /// or from JSON occurred before Unix epoch.
-        /// The default is <see cref="DefaultAllowPreEpoch"/>.
+        /// The default is <c>false</c>.
         /// </param>
         public UnixDateTimeConverter(bool allowPreEpoch)
         {

--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -36,6 +36,50 @@ namespace Newtonsoft.Json.Converters
     {
         internal static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        private bool _allowPreEpoch;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the dates before Unix epoch
+        /// should converted to and from JSON.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> to allow converting dates before Unix epoch to and from
+        /// JSON;
+        /// <c>false</c> to throw an exception when a date being converted to or
+        /// from JSON occurred before Unix epoch.
+        /// The default is <c>false</c>.
+        /// </value>
+        public bool AllowPreEpoch
+        {
+            get => _allowPreEpoch;
+            set => _allowPreEpoch = value;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/> class.
+        /// </summary>
+        public UnixDateTimeConverter()
+            : this(false)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/>
+        /// class.
+        /// </summary>
+        /// <param name="allowPreEpoch">
+        /// <c>true</c> to allow converting dates before Unix epoch to and from
+        /// JSON;
+        /// <c>false</c> to throw an exception when a date being converted to
+        /// or from JSON occurred before Unix epoch.
+        /// The default is <see cref="DefaultAllowPreEpoch"/>.
+        /// </param>
+        public UnixDateTimeConverter(bool allowPreEpoch)
+        {
+            _allowPreEpoch = allowPreEpoch;
+        }
+
         /// <summary>
         /// Writes the JSON representation of the object.
         /// </summary>
@@ -61,7 +105,7 @@ namespace Newtonsoft.Json.Converters
                 throw new JsonSerializationException("Expected date object value.");
             }
 
-            if (seconds < 0)
+            if (!_allowPreEpoch && seconds < 0)
             {
                 throw new JsonSerializationException("Cannot convert date value that is before Unix epoch of 00:00:00 UTC on 1 January 1970.");
             }
@@ -108,7 +152,7 @@ namespace Newtonsoft.Json.Converters
                 throw JsonSerializationException.Create(reader, "Unexpected token parsing date. Expected Integer or String, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
             }
 
-            if (seconds >= 0)
+            if (_allowPreEpoch || seconds >= 0)
             {
                 DateTime d = UnixEpoch.AddSeconds(seconds);
 

--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -41,11 +41,9 @@ namespace Newtonsoft.Json.Converters
         /// should converted to and from JSON.
         /// </summary>
         /// <value>
-        /// <c>true</c> to allow converting dates before Unix epoch to and from
-        /// JSON;
-        /// <c>false</c> to throw an exception when a date being converted to or
-        /// from JSON occurred before Unix epoch.
-        /// The default is <c>false</c>.
+        /// <c>true</c> to allow converting dates before Unix epoch to and from JSON;
+        /// <c>false</c> to throw an exception when a date being converted to or from JSON
+        /// occurred before Unix epoch. The default value is <c>false</c>.
         /// </value>
         public bool AllowPreEpoch { get; set; }
 

--- a/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/UnixDateTimeConverter.cs
@@ -39,20 +39,6 @@ namespace Newtonsoft.Json.Converters
         private bool _allowPreEpoch;
 
         /// <summary>
-        /// Gets or sets the default value of the <see cref="AllowPreEpoch"/>
-        /// property for new instances of the <see cref="UnixDateTimeConverter"/>
-        /// class.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> to allow converting dates before Unix epoch to and from
-        /// JSON;
-        /// <c>false</c> to throw an exception when a date being converted to or
-        /// from JSON occurred before Unix epoch.
-        /// The default is <c>false</c>.
-        /// </value>
-        public static bool DefaultAllowPreEpoch { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets a value indicating whether the dates before Unix epoch
         /// should converted to and from JSON.
         /// </summary>
@@ -73,7 +59,7 @@ namespace Newtonsoft.Json.Converters
         /// Initializes a new instance of the <see cref="UnixDateTimeConverter"/> class.
         /// </summary>
         public UnixDateTimeConverter()
-            : this(DefaultAllowPreEpoch)
+            : this(false)
         {
 
         }


### PR DESCRIPTION
Fixes #2292

The existing implementation contains code specifically to disallow dates before Unix epoch. It can be assumed that some users of the library depend on the converter throwing an exception if such date is serialized or deserialized. To maintain backwards compatibility, a constructor parameter and a property are introduced to explicitly enable the new behavior. A static default setting for allowing pre-epoch dates was also introduced to help library users to switch to the new behavior with minimal changes of the client code.

### Rationale

Many implementations of Unix time use signed integer values with negative values representing dates before Unix epoch. Examples of such implementations are some C standard libraries and DateTimeOffset.ToUnixTimeSeconds and DateTimeOffset.FromUnixTimeSeconds methods in .NET basic class library. JavaScript built-in Date.prototype.getTime() method type uses milliseconds instead of seconds but it still handles pre-epoch dates with negative numbers. In fact the only implementation disallowing pre-epoch dates I could find was MySQL. Hence negative timestamps are likely to appear in JSON documents in any problem domain that handles dates before 1970-01-01 (e.g. people birthdays).