### PR TITLE
Fix ContractResolver to also consider non-public ShouldSerialize methods

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1635,7 +1635,7 @@ namespace Newtonsoft.Json.Serialization
 
         private Predicate<object>? CreateShouldSerializeTest(MemberInfo member)
         {
-            MethodInfo shouldSerializeMethod = member.DeclaringType.GetMethod(JsonTypeReflector.ShouldSerializePrefix + member.Name, ReflectionUtils.EmptyTypes);
+            MethodInfo shouldSerializeMethod = member.DeclaringType.GetMethod(JsonTypeReflector.ShouldSerializePrefix + member.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, binder: null, ReflectionUtils.EmptyTypes, modifiers: null);
 
             if (shouldSerializeMethod == null || shouldSerializeMethod.ReturnType != typeof(bool))
             {


### PR DESCRIPTION
The [documentation](https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm) doesn't say whether this works with public or non-public methods, but it does claim that it works _similar_ to [XmlSerializer](http://msdn.microsoft.com/en-us/library/53b8022e.aspx), which in fact accepts private methods.

I think this would be good to allow not spoiling the public API of the types.