### PR TITLE
[FixBug] Error converting value "" to Int64

### DIFF
--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -473,6 +473,15 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
+        /// Reads the next JSON token from the underlying <see cref="TextReader"/> as a <see cref="Nullable{T}"/> of <see cref="Int64"/>.
+        /// </summary>
+        /// <returns>A <see cref="Nullable{T}"/> of <see cref="Int64"/>. This method will return <c>null</c> at the end of an array.</returns>
+        public override long? ReadAsInt64()
+        {
+            return (long?)ReadNumberValue(ReadType.ReadAsInt64);
+        }
+
+        /// <summary>
         /// Reads the next JSON token from the underlying <see cref="TextReader"/> as a <see cref="Nullable{T}"/> of <see cref="DateTime"/>.
         /// </summary>
         /// <returns>A <see cref="Nullable{T}"/> of <see cref="DateTime"/>. This method will return <c>null</c> at the end of an array.</returns>
@@ -1022,6 +1031,8 @@ namespace Newtonsoft.Json
             {
                 case ReadType.ReadAsInt32:
                     return ReadInt32String(_stringReference.ToString());
+                case ReadType.ReadAsInt64:
+                    return ReadInt64String(_stringReference.ToString());
                 case ReadType.ReadAsDecimal:
                     return ReadDecimalString(_stringReference.ToString());
                 case ReadType.ReadAsDouble:


### PR DESCRIPTION
# Solve the following problems
When property type is int32, The following code OK
```c#
    public class Program
    {
        public class TestModel
        {
            public int from { get; set; }
        }

        public static void Main(string[] args)
        {
            var json = "{ \"from\": \"\"}";
            var ss = JsonConvert.DeserializeObject<TestModel>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
            Console.WriteLine(ss);
        }
    }
```

When property type is int64, The following code throw exception
```c#
    public class Program
    {
        public class TestModel
        {
            public long from { get; set; }
        }

        public static void Main(string[] args)
        {
            var json = "{ \"from\": \"\"}";
            var ss = JsonConvert.DeserializeObject<TestModel>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
            Console.WriteLine(ss);
        }
    }
```

set `NullValueHandling = NullValueHandling.Ignore` they not have the same effect