### PR TITLE
Make JPath public to allow more basic operations on JSONPath expressi…

### DIFF
--- a/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/JPath.cs
@@ -31,7 +31,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal class JPath
+    public class JPath
     {
         private static readonly char[] FloatCharacters = new[] {'.', 'E', 'e'};
 

--- a/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
+++ b/Src/Newtonsoft.Json/Linq/JsonPath/PathFilter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Utilities;
 
 namespace Newtonsoft.Json.Linq.JsonPath
 {
-    internal abstract class PathFilter
+    public abstract class PathFilter
     {
         public abstract IEnumerable<JToken> ExecuteFilter(JToken root, IEnumerable<JToken> current, JsonSelectSettings? settings);
 


### PR DESCRIPTION
Making JPath public has a lot of benefits. Users of the Newtonsoft JSON library can then parse JSON expressions and validate them, without having to actually supply a data object (which sometimes is not available at validation or preparation).

This functionality is currently missing except using SelectTokens, which is a very high level approach.