### PR TITLE
Fix failing tests on net7.0

### DIFF
--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterAsyncTests.cs
@@ -1095,7 +1095,13 @@ namespace Newtonsoft.Json.Tests
             {
                 await jsonWriter.WriteTokenAsync(JsonToken.StartArray);
 
-                await ExceptionAssert.ThrowsAsync<FormatException>(async () => { await jsonWriter.WriteTokenAsync(JsonToken.Integer, "three"); }, "Input string was not in a correct format.");
+#if NET7_0_OR_GREATER
+                // .NET 7.0 prints actual input in the message:
+                string expectedMessage = "The input string 'three' was not in a correct format.";
+#else
+                string expectedMessage = "Input string was not in a correct format.";
+#endif
+                await ExceptionAssert.ThrowsAsync<FormatException>(async () => { await jsonWriter.WriteTokenAsync(JsonToken.Integer, "three"); }, expectedMessage);
 
                 await ExceptionAssert.ThrowsAsync<ArgumentNullException>(async () => { await jsonWriter.WriteTokenAsync(JsonToken.Integer); }, @"Value cannot be null.
 Parameter name: value", "Value cannot be null. (Parameter 'value')");

--- a/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonTextWriterTest.cs
@@ -966,7 +966,13 @@ namespace Newtonsoft.Json.Tests
             {
                 jsonWriter.WriteToken(JsonToken.StartArray);
 
-                ExceptionAssert.Throws<FormatException>(() => { jsonWriter.WriteToken(JsonToken.Integer, "three"); }, "Input string was not in a correct format.");
+#if NET7_0_OR_GREATER
+                // .NET 7.0 prints actual input in the message:
+                string expectedMessage = "The input string 'three' was not in a correct format.";
+#else
+                string expectedMessage = "Input string was not in a correct format.";
+#endif
+                ExceptionAssert.Throws<FormatException>(() => { jsonWriter.WriteToken(JsonToken.Integer, "three"); }, expectedMessage);
 
                 ExceptionAssert.Throws<ArgumentNullException>(() => { jsonWriter.WriteToken(JsonToken.Integer); }, @"Value cannot be null.
 Parameter name: value", "Value cannot be null. (Parameter 'value')");


### PR DESCRIPTION
.NET 7.0 includes actual input into FormatException so these tests fail if I bump this project to .NET7.0 by hands (I was testing various stress modes for .NET7.0 + OSS projects)