### PR TITLE
Fix: Null String being reported as String rather than JTokenType.Null

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Issues/Issue2775.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue2775.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Newtonsoft.Json.Linq;
+#if DNXCORE50
+using Xunit;
+using Test = Xunit.FactAttribute;
+using Assert = Newtonsoft.Json.Tests.XUnitAssert;
+using TestCase = Xunit.InlineDataAttribute;
+#else
+using NUnit.Framework;
+#endif
+
+namespace Newtonsoft.Json.Tests.Issues
+{
+    public class Issue2775
+    {
+        [Test]
+        //https://github.com/JamesNK/Newtonsoft.Json/issues/2775
+        public void TokenType()
+        {
+            var jObject = new JObject { { "NullProperty", false ? "0" : null } };
+
+            var jToken = JToken.FromObject(jObject);
+            
+            Assert.AreEqual(JTokenType.Null, jToken.Children().Children().Single().Type);
+
+            jObject = new JObject { { "NullProperty", (string)null } };
+
+            jToken = JToken.FromObject(jObject);
+            Assert.AreEqual(JTokenType.Null, jToken.Children().Children().Single().Type);
+        }
+    }
+}

--- a/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -281,6 +281,12 @@ namespace Newtonsoft.Json.Linq
         /// <param name="value">The <see cref="String"/> value to write.</param>
         public override void WriteValue(string? value)
         {
+            if (value == null)
+            {
+                WriteNull();
+                return;
+            }
+            
             base.WriteValue(value);
             AddJValue(new JValue(value), JsonToken.String);
         }


### PR DESCRIPTION
Fixes #2775 

I tried reverting #2639 on a hunch and it fixed this issue so that led me here.