### PR TITLE
Fix TimeOnly format error deserializing `HH:mm`

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/TimeOnlyTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TimeOnlyTests.cs
@@ -145,6 +145,22 @@ namespace Newtonsoft.Json.Tests.Serialization
         }
 
         [Test]
+        public void Deserialize_Milliseconds()
+        {
+            TimeOnly t = JsonConvert.DeserializeObject<TimeOnly>(@"""23:59:59.999""");
+
+            Assert.AreEqual(new TimeOnly(23, 59, 59, 999), t);
+        }
+
+        [Test]
+        public void Deserialize_WithoutSeconds()
+        {
+            TimeOnly t = JsonConvert.DeserializeObject<TimeOnly>(@"""23:59""");
+
+            Assert.AreEqual(new TimeOnly(23, 59, 00), t);
+        }
+
+        [Test]
         public void DeserializeDefault()
         {
             TimeOnly t = JsonConvert.DeserializeObject<TimeOnly>(@"""00:00:00""");

--- a/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/ConvertUtils.cs
@@ -511,7 +511,7 @@ namespace Newtonsoft.Json.Utilities
                 }
                 if (targetType == typeof(TimeOnly))
                 {
-                    value = TimeOnly.ParseExact(s, "HH':'mm':'ss.FFFFFFF", CultureInfo.InvariantCulture);
+                    value = TimeOnly.Parse(s, CultureInfo.InvariantCulture);
                     return ConvertResult.Success;
                 }
 #endif


### PR DESCRIPTION
This commit also adds a missing Deserialize_Milliseconds test for TimeOnly