### PR TITLE
Update DataSetConverter.cs

### DIFF
--- a/Src/Newtonsoft.Json/Converters/DataSetConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/DataSetConverter.cs
@@ -85,7 +85,8 @@ namespace Newtonsoft.Json.Converters
             DataSet ds = (objectType == typeof(DataSet))
                 ? new DataSet()
                 : (DataSet)Activator.CreateInstance(objectType)!;
-
+            ds.EnforceConstraints = false; // necessary in case the typed dataset contains foreign key constraints and the tables were serialized out of order
+            
             DataTableConverter converter = new DataTableConverter();
 
             reader.ReadAndAssert();
@@ -105,6 +106,9 @@ namespace Newtonsoft.Json.Converters
                 reader.ReadAndAssert();
             }
 
+             // once all tables are populated there should be no foreign key constraint violations so reset EnforceConstraints
+            ds.EnforceConstraints = true;
+            
             return ds;
         }
 


### PR DESCRIPTION
Typed datasets are serialized in whatever order tables were added (usually via the designer).  If there is a foreign key constraint and the child table happened to be added by the developer prior to the parent table, deserialization could fail with an InvalidConstraintException.  To avoid that, set EnforceConstraints to false prior to deserializing the dataset and then set it back to true when deserialization is complete.