### PR TITLE
Attempt to deserialise as DateOnly if DateTime fails

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/DateOnlyTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/DateOnlyTests.cs
@@ -198,6 +198,15 @@ namespace Newtonsoft.Json.Tests.Serialization
             Assert.AreEqual(new DateOnly(2000, 12, 29), l[0]);
             Assert.AreEqual(null, l[1]);
         }
+
+        [Test]
+        public void DeserializeArray_Objects()
+        {
+            var l = JsonConvert.DeserializeObject<object[]>(@"[
+  ""9999-12-31""
+]");
+            Assert.AreEqual(DateOnly.MaxValue, l[0]);
+        }
     }
 }
 #endif

--- a/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
+++ b/Src/Newtonsoft.Json/Converters/XmlNodeConverter.cs
@@ -1781,6 +1781,13 @@ namespace Newtonsoft.Json.Converters
                     }
 
 #endif
+#if HAVE_DATE_ONLY
+                    if (reader.Value is DateOnly date)
+                    {
+                        return reader.Value?.ToString();
+                    }
+
+#endif
                     DateTime d = Convert.ToDateTime(reader.Value, CultureInfo.InvariantCulture);
 #if !PORTABLE || NETSTANDARD1_3
                     return XmlConvert.ToString(d, DateTimeUtils.ToSerializationMode(d.Kind));

--- a/Src/Newtonsoft.Json/JsonTextReader.cs
+++ b/Src/Newtonsoft.Json/JsonTextReader.cs
@@ -224,6 +224,13 @@ namespace Newtonsoft.Json
                                 SetToken(JsonToken.Date, dt, false);
                                 return;
                             }
+#if HAVE_DATE_ONLY
+                            if (DateTimeUtils.TryParseDateOnly(_stringReference, DateTimeZoneHandling, DateFormatString, Culture, out DateOnly date))
+                            {
+                                SetToken(JsonToken.Date, date, false);
+                                return;
+                            }
+#endif
                         }
 #if HAVE_DATE_TIME_OFFSET
                         else

--- a/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
@@ -100,6 +100,20 @@ namespace Newtonsoft.Json.Utilities
 
             return false;
         }
+#if HAVE_DATE_ONLY
+        public bool ParseDateOnly(char[] text, int startIndex, int length)
+        {
+            _text = text;
+            _end = startIndex + length;
+
+            if (ParseDate(startIndex))
+            {
+                return true;
+            }
+
+            return false;
+        }
+#endif
 
         private bool ParseDate(int start)
         {

--- a/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
@@ -341,6 +341,12 @@ namespace Newtonsoft.Json.Utilities
             return d;
         }
 
+#if HAVE_DATE_ONLY
+        private static DateOnly CreateDateOnly(DateTimeParser dateTimeParser)
+        {
+            return new DateOnly(dateTimeParser.Year, dateTimeParser.Month, dateTimeParser.Day);
+        }
+#endif
         internal static bool TryParseDateTime(StringReference s, DateTimeZoneHandling dateTimeZoneHandling, string? dateFormatString, CultureInfo culture, out DateTime dt)
         {
             if (s.Length > 0)
@@ -376,6 +382,31 @@ namespace Newtonsoft.Json.Utilities
             dt = default;
             return false;
         }
+
+#if HAVE_DATE_ONLY
+        internal static bool TryParseDateOnly(StringReference s, DateTimeZoneHandling dateTimeZoneHandling, string? dateFormatString, CultureInfo culture, out DateOnly date)
+        {
+            if (s.Length > 0)
+            {
+                int i = s.StartIndex;
+                if (s.Length == 10 && char.IsDigit(s[i]))
+                {
+                    DateTimeParser dateTimeParser = new DateTimeParser();
+                    if (!dateTimeParser.ParseDateOnly(s.Chars, s.StartIndex, s.Length))
+                    {
+                        date = default;
+                        return false;
+                    }
+
+                    date = CreateDateOnly(dateTimeParser);
+                    return true;
+                }
+            }
+
+            date = default;
+            return false;
+        }
+#endif
 
         internal static bool TryParseDateTime(string s, DateTimeZoneHandling dateTimeZoneHandling, string? dateFormatString, CultureInfo culture, out DateTime dt)
         {


### PR DESCRIPTION
Close #2831 

The xml node changes was because 2 tests were failing due to DateOnly not implementing IConvertible and the existing implementation made it parse as a string regardless. There are no XmlConvert for DateOnly.