### PR TITLE
issue #2887 set release number in assembly version AssemblyVersion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ steps:
     write-host "Build number $buildNumber" -fore white
     $nugetPrerelease = if ($Env:SourceBranch.StartsWith("refs/heads/release/")) { $version.Prerelease } else { "build$($buildNumber.ToString("D6"))" }
     write-host "Prerelease $nugetPrerelease" -fore white
-    $assemblyVersion = if ($version.Assembly) { $version.Assembly } else { "$($version.Major).0.0.0" }
+    $assemblyVersion = if ($version.Assembly) { $version.Assembly } else { "$($version.Major).0.$($version.Release).0" }
     write-host "Assembly $assemblyVersion" -fore white
     .\Build\runbuild.ps1 -properties @{"majorVersion"="$($version.Major).0"; "majorWithReleaseVersion"="$($version.Major).0.$($version.Release)"; "nugetPrerelease"=$nugetPrerelease; "assemblyVersion"=$assemblyVersion; "zipFileName"="Json$($version.Major)0r$($version.Release).zip"; "signAssemblies"=$sign; "signKeyPath"=$keyPath; "treatWarningsAsErrors"=$true; "buildNuGet"=$true; "ensureNetCliSdk"=$false}
   env:


### PR DESCRIPTION
AssemblyVersion should always be unique specified for each release.
This is necessary to avoid version mismatch with dlls in GAC
See [AssemblyVersion only contains Major version causes DLL conflicts #2887](https://github.com/JamesNK/Newtonsoft.Json/issues/2887)