### PR TITLE
Avoid LINQ expression trees on .NET 6+.

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1412,7 +1412,7 @@ namespace Newtonsoft.Json.Serialization
             // warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
             IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET6_0_OR_GREATER)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);


### PR DESCRIPTION
The condition was changed in https://github.com/JamesNK/Newtonsoft.Json/pull/2678 and it looks like an accidental search and replace rather than intentional change. [Other similar code path](https://github.com/JamesNK/Newtonsoft.Json/blob/0a2e291c0d9c0c7675d445703e51750363a549ef/Src/Newtonsoft.Json/Serialization/JsonTypeReflector.cs#L517-L531) uses the reflection on .NET 6 builds.

Notably, the LINQ expression trees are broken for many scenarios on iOS for .NET 6 and 7. This was tracked by https://github.com/dotnet/runtime/issues/69410 and fixed in .NET 8 with refactoring of several switches in the LINQ expression implementation but the changes were not back-ported to older .NET releases. The suggested workaround (using Mono interpreter) unfortunately hits a different unrelated issue (https://github.com/dotnet/runtime/issues/89359) which was also fixed in .NET 8 only.

All the unit tests still pass locally for me with this change. I have also confirmed that it resolves the following crash on our iOS application:
```
System.ExecutionEngineException: Attempting to JIT compile method '(wrapper delegate-invoke) System.Collections.Generic.IList`1<Google.Apis.Gmail.v1.Data.Label> <Module>:invoke_callvirt_IList`1<Label>_ListLabelsResponse (Google.Apis.Gmail.v1.Data.ListLabelsResponse)' while running in aot-only mode. See https://docs.microsoft.com/xamarin/ios/internals/limitations for more information.

   at System.Linq.Expressions.Interpreter.FuncCallInstruction`2[[Google.Apis.Gmail.v1.Data.ListLabelsResponse, Google.Apis.Gmail.v1, Version=1.62.0.3105, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab],[System.Collections.Generic.IList`1[[Google.Apis.Gmail.v1.Data.Label, Google.Apis.Gmail.v1, Version=1.62.0.3105, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Run(InterpretedFrame )
   at System.Linq.Expressions.Interpreter.Interpreter.Run(InterpretedFrame )
   at System.Linq.Expressions.Interpreter.LightLambda.Run(Object[] )
   at System.Dynamic.Utils.DelegateHelpers.FuncThunk1[Object,Object](Func`2 handler, Object t1)
   at Newtonsoft.Json.Serialization.ExpressionValueProvider.GetValue(Object target)
``` 