### PR TITLE
Ensure CamelCasePropertyNamesContractResolver considers NamingStrategy in the cache

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/CamelCasePropertyNamesContractResolverTests.cs
@@ -240,5 +240,36 @@ namespace Newtonsoft.Json.Tests.Serialization
   ""second"": ""Value2!""
 }", json);
         }
+
+        [Test]
+        public void EnsureNamingStrategyIsConsideredInCache()
+        {
+            Dictionary<string, string> values = new Dictionary<string, string> { { "Key", "Value" } };
+
+            string jsonWithProcessDictionaryKeys = JsonConvert.SerializeObject(values,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    {
+                        NamingStrategy = new CamelCaseNamingStrategy { ProcessDictionaryKeys = true }
+                    }
+                });
+
+            StringAssert.AreEqual(@"{""key"":""Value""}", jsonWithProcessDictionaryKeys);
+
+
+            string jsonWithoutProcessDictionaryKeys = JsonConvert.SerializeObject(values,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    {
+                        NamingStrategy = new CamelCaseNamingStrategy { ProcessDictionaryKeys = false }
+                    }
+                });
+
+            StringAssert.AreEqual(@"{""Key"":""Value""}", jsonWithoutProcessDictionaryKeys);
+        }
+
+
     }
 }

--- a/Src/Newtonsoft.Json/Serialization/CamelCasePropertyNamesContractResolver.cs
+++ b/Src/Newtonsoft.Json/Serialization/CamelCasePropertyNamesContractResolver.cs
@@ -37,7 +37,7 @@ namespace Newtonsoft.Json.Serialization
     {
         private static readonly object TypeContractCacheLock = new object();
         private static readonly DefaultJsonNameTable NameTable = new DefaultJsonNameTable();
-        private static Dictionary<StructMultiKey<Type, Type>, JsonContract>? _contractCache;
+        private static Dictionary<StructMultiKey<Type, Type, NamingStrategy?>, JsonContract>? _contractCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CamelCasePropertyNamesContractResolver"/> class.
@@ -64,8 +64,8 @@ namespace Newtonsoft.Json.Serialization
             }
 
             // for backwards compadibility the CamelCasePropertyNamesContractResolver shares contracts between instances
-            StructMultiKey<Type, Type> key = new StructMultiKey<Type, Type>(GetType(), type);
-            Dictionary<StructMultiKey<Type, Type>, JsonContract>? cache = _contractCache;
+            StructMultiKey<Type, Type, NamingStrategy?> key = new StructMultiKey<Type, Type, NamingStrategy?>(GetType(), type, NamingStrategy);
+            Dictionary<StructMultiKey<Type, Type, NamingStrategy?>, JsonContract>? cache = _contractCache;
             if (cache == null || !cache.TryGetValue(key, out JsonContract? contract))
             {
                 contract = CreateContract(type);
@@ -74,9 +74,9 @@ namespace Newtonsoft.Json.Serialization
                 lock (TypeContractCacheLock)
                 {
                     cache = _contractCache;
-                    Dictionary<StructMultiKey<Type, Type>, JsonContract> updatedCache = (cache != null)
-                        ? new Dictionary<StructMultiKey<Type, Type>, JsonContract>(cache)
-                        : new Dictionary<StructMultiKey<Type, Type>, JsonContract>();
+                    Dictionary<StructMultiKey<Type, Type, NamingStrategy?>, JsonContract> updatedCache = (cache != null)
+                        ? new Dictionary<StructMultiKey<Type, Type, NamingStrategy?>, JsonContract>(cache)
+                        : new Dictionary<StructMultiKey<Type, Type, NamingStrategy?>, JsonContract>();
                     updatedCache[key] = contract;
 
                     _contractCache = updatedCache;

--- a/Src/Newtonsoft.Json/Utilities/StructMultiKey.cs
+++ b/Src/Newtonsoft.Json/Utilities/StructMultiKey.cs
@@ -58,4 +58,38 @@ namespace Newtonsoft.Json.Utilities
             return (Equals(Value1, other.Value1) && Equals(Value2, other.Value2));
         }
     }
+
+    internal readonly struct StructMultiKey<T1, T2, T3> : IEquatable<StructMultiKey<T1, T2, T3>>
+    {
+        public readonly T1 Value1;
+        public readonly T2 Value2;
+        public readonly T3 Value3;
+
+        public StructMultiKey(T1 v1, T2 v2, T3 v3)
+        {
+            Value1 = v1;
+            Value2 = v2;
+            Value3 = v3;
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value1?.GetHashCode() ?? 0) ^ (Value2?.GetHashCode() ?? 0) ^ (Value3?.GetHashCode() ?? 0);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is StructMultiKey<T1, T2, T3> key))
+            {
+                return false;
+            }
+
+            return Equals(key);
+        }
+
+        public bool Equals(StructMultiKey<T1, T2, T3> other)
+        {
+            return (Equals(Value1, other.Value1) && Equals(Value2, other.Value2) && Equals(Value3, other.Value3));
+        }
+    }
 }


### PR DESCRIPTION
`CamelCasePropertyNamesContractResolver` uses a shared contract cache across all instances but it doesn't consider the fact that sometimes different instances use different naming strategies. https://github.com/JamesNK/Newtonsoft.Json/issues/2927

In our case, we were using `CamelCasePropertyNamesContractResolver` in our ASP.NET app and then added [Elsa Workflow](https://github.com/elsa-workflows/elsa-core) which was using the same resolver with another naming strategy and broke our existing code. It is now fixed in Elsa Workflow (with this PR https://github.com/elsa-workflows/elsa-core/pull/4521) but it took us a long time to understand what was wrong.
