### PR TITLE
Fix comment on JsonConvert.SerializeObject

### DIFF
--- a/Src/Newtonsoft.Json/JsonConvert.cs
+++ b/Src/Newtonsoft.Json/JsonConvert.cs
@@ -593,7 +593,7 @@ namespace Newtonsoft.Json
         }
 
         /// <summary>
-        /// Serializes the specified object to a JSON string using a type, formatting and <see cref="JsonSerializerSettings"/>.
+        /// Serializes the specified object to a JSON string using a type and <see cref="JsonSerializerSettings"/>.
         /// </summary>
         /// <param name="value">The object to serialize.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> used to serialize the object.


### PR DESCRIPTION
Fixes a small mistake in a function comment for JsonConvert.SerializeObject.
I suspect the comment incorrectly copied from an alternative version of the function and not updated to reflect the new parameters.