### PR TITLE
Converter can be null

### DIFF
--- a/Src/Newtonsoft.Json/JsonSerializer.cs
+++ b/Src/Newtonsoft.Json/JsonSerializer.cs
@@ -1207,7 +1207,7 @@ namespace Newtonsoft.Json
                 for (int i = 0; i < converters.Count; i++)
                 {
                     JsonConverter converter = converters[i];
-
+                    if(converter == null) continue;
                     if (converter.CanConvert(objectType))
                     {
                         return converter;


### PR DESCRIPTION
In my case, the converters list had a null value, which caused the application not to continue.
![image](https://github.com/JamesNK/Newtonsoft.Json/assets/153179772/8ee0ed7b-8dd1-4bde-b805-1ea2be4822e8)
