### PR TITLE
Deserializing with NullValueHandling.Ignore ignore null values

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -975,6 +975,11 @@ namespace Newtonsoft.Json.Serialization
                     return null;
                 }
 
+                if (value == null && Serializer.NullValueHandling == NullValueHandling.Ignore)
+                {
+                    return Activator.CreateInstance(targetType);
+                }
+
                 try
                 {
                     if (contract.IsConvertable)


### PR DESCRIPTION
When NullValueHandling is set for NullValueHandling.Ignore, it should initialize primitive type with its default value, as seen in #2954 