### PR TITLE
Microoptimizations on DateTimeParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ BenchmarkDotNet.Artifacts/
 _ReSharper.*
 *.ReSharper.user
 *.resharper.user
+*/.idea/*
 .vs/
 .vscode/
 *.lock.json

--- a/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
@@ -27,13 +27,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 using BenchmarkDotNet.Attributes;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Tests.TestObjects;
 
 namespace Newtonsoft.Json.Tests.Benchmarks
@@ -42,11 +39,11 @@ namespace Newtonsoft.Json.Tests.Benchmarks
     {
         private static readonly string LargeJsonText;
         private static readonly string FloatArrayJson;
-        private static readonly string LargeJsonFilePath = TestFixtureBase.ResolvePath("large.json");
+        private static readonly JsonSerializer Serializer = new();
 
         static DeserializeBenchmarks()
         {
-            LargeJsonText = System.IO.File.ReadAllText(LargeJsonFilePath);
+            LargeJsonText = System.IO.File.ReadAllText(TestFixtureBase.ResolvePath("large.json"));
 
             FloatArrayJson = new JArray(Enumerable.Range(0, 5000).Select(i => i * 1.1m)).ToString(Formatting.None);
         }
@@ -60,11 +57,10 @@ namespace Newtonsoft.Json.Tests.Benchmarks
         [Benchmark]
         public IList<RootObject> DeserializeLargeJsonFile()
         {
-            using (var jsonFile = System.IO.File.OpenText(LargeJsonFilePath))
+            using StringReader jsonFile = new(LargeJsonText);
             using (JsonTextReader jsonTextReader = new JsonTextReader(jsonFile))
             {
-                JsonSerializer serializer = new JsonSerializer();
-                return serializer.Deserialize<IList<RootObject>>(jsonTextReader);
+                return Serializer.Deserialize<IList<RootObject>>(jsonTextReader);
             }
         }
 

--- a/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
@@ -39,6 +39,7 @@ namespace Newtonsoft.Json.Tests.Benchmarks
     {
         private static readonly string LargeJsonText;
         private static readonly string FloatArrayJson;
+        private static readonly string DateArrayJson;
         private static readonly JsonSerializer Serializer = new();
 
         static DeserializeBenchmarks()
@@ -46,6 +47,8 @@ namespace Newtonsoft.Json.Tests.Benchmarks
             LargeJsonText = System.IO.File.ReadAllText(TestFixtureBase.ResolvePath("large.json"));
 
             FloatArrayJson = new JArray(Enumerable.Range(0, 5000).Select(i => i * 1.1m)).ToString(Formatting.None);
+            DateTime time = new(1969, 7, 20, 2, 56, 15, DateTimeKind.Utc);
+            DateArrayJson = new JArray(Enumerable.Range(0, 5000).Select(i => time.AddDays(i))).ToString(Formatting.None);
         }
 
         [Benchmark]
@@ -74,6 +77,11 @@ namespace Newtonsoft.Json.Tests.Benchmarks
         public IList<decimal> DeserializeDecimalList()
         {
             return JsonConvert.DeserializeObject<IList<decimal>>(FloatArrayJson);
+        }
+        [Benchmark]
+        public IList<DateTime> DeserializeDateTimeList()
+        {
+            return JsonConvert.DeserializeObject<IList<DateTime>>(DateArrayJson);
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/DeserializeBenchmarks.cs
@@ -42,10 +42,11 @@ namespace Newtonsoft.Json.Tests.Benchmarks
     {
         private static readonly string LargeJsonText;
         private static readonly string FloatArrayJson;
+        private static readonly string LargeJsonFilePath = TestFixtureBase.ResolvePath("large.json");
 
         static DeserializeBenchmarks()
         {
-            LargeJsonText = System.IO.File.ReadAllText(TestFixtureBase.ResolvePath("large.json"));
+            LargeJsonText = System.IO.File.ReadAllText(LargeJsonFilePath);
 
             FloatArrayJson = new JArray(Enumerable.Range(0, 5000).Select(i => i * 1.1m)).ToString(Formatting.None);
         }
@@ -59,7 +60,7 @@ namespace Newtonsoft.Json.Tests.Benchmarks
         [Benchmark]
         public IList<RootObject> DeserializeLargeJsonFile()
         {
-            using (var jsonFile = System.IO.File.OpenText(TestFixtureBase.ResolvePath("large.json")))
+            using (var jsonFile = System.IO.File.OpenText(LargeJsonFilePath))
             using (JsonTextReader jsonTextReader = new JsonTextReader(jsonFile))
             {
                 JsonSerializer serializer = new JsonSerializer();

--- a/Src/Newtonsoft.Json.Tests/Benchmarks/SerializeBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/SerializeBenchmarks.cs
@@ -42,6 +42,7 @@ namespace Newtonsoft.Json.Tests.Benchmarks
     public class SerializeBenchmarks
     {
         private static readonly IList<RootObject> LargeCollection;
+        private static readonly string LargeWriteJsonPath = TestFixtureBase.ResolvePath("largewrite.json");
 
         static SerializeBenchmarks()
         {
@@ -53,7 +54,7 @@ namespace Newtonsoft.Json.Tests.Benchmarks
         [Benchmark]
         public void SerializeLargeJsonFile()
         {
-            using (StreamWriter file = System.IO.File.CreateText(TestFixtureBase.ResolvePath("largewrite.json")))
+            using (StreamWriter file = System.IO.File.CreateText(LargeWriteJsonPath))
             {
                 JsonSerializer serializer = new JsonSerializer();
                 serializer.Formatting = Formatting.Indented;

--- a/Src/Newtonsoft.Json.Tests/Benchmarks/SerializeBenchmarks.cs
+++ b/Src/Newtonsoft.Json.Tests/Benchmarks/SerializeBenchmarks.cs
@@ -25,16 +25,9 @@
 
 #if HAVE_BENCHMARKS
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 using BenchmarkDotNet.Attributes;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Tests.TestObjects;
 
 namespace Newtonsoft.Json.Tests.Benchmarks
@@ -42,7 +35,9 @@ namespace Newtonsoft.Json.Tests.Benchmarks
     public class SerializeBenchmarks
     {
         private static readonly IList<RootObject> LargeCollection;
-        private static readonly string LargeWriteJsonPath = TestFixtureBase.ResolvePath("largewrite.json");
+        private static readonly MemoryStream ReusedMemoryStream = new();
+        private static readonly StreamWriter JsonFile = new(ReusedMemoryStream);
+        private static readonly JsonSerializer Serializer = new() { Formatting = Formatting.Indented };
 
         static SerializeBenchmarks()
         {
@@ -54,12 +49,8 @@ namespace Newtonsoft.Json.Tests.Benchmarks
         [Benchmark]
         public void SerializeLargeJsonFile()
         {
-            using (StreamWriter file = System.IO.File.CreateText(LargeWriteJsonPath))
-            {
-                JsonSerializer serializer = new JsonSerializer();
-                serializer.Formatting = Formatting.Indented;
-                serializer.Serialize(file, LargeCollection);
-            }
+            ReusedMemoryStream.Seek(0, SeekOrigin.Begin);
+            Serializer.Serialize(JsonFile, LargeCollection);
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Issues/Issue2768.cs
+++ b/Src/Newtonsoft.Json.Tests/Issues/Issue2768.cs
@@ -71,7 +71,7 @@ namespace Newtonsoft.Json.Tests.Issues
         {
             decimal d = JsonConvert.DeserializeObject<decimal>("0.0");
 
-            Assert.AreEqual("0.0", d.ToString());
+            Assert.AreEqual("0.0", d.ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace Newtonsoft.Json.Tests.Issues
         {
             decimal d = JsonConvert.DeserializeObject<decimal>("-0.0");
 
-            Assert.AreEqual("0.0", d.ToString());
+            Assert.AreEqual("0.0", d.ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace Newtonsoft.Json.Tests.Issues
         {
             decimal d = JsonConvert.DeserializeObject<decimal>("0.00");
 
-            Assert.AreEqual("0.00", d.ToString());
+            Assert.AreEqual("0.00", d.ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace Newtonsoft.Json.Tests.Issues
                 }
             }
 
-            Assert.AreEqual("0.0", parsedValue.ToString());
+            Assert.AreEqual("0.0", parsedValue?.ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]

--- a/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
+++ b/Src/Newtonsoft.Json.Tests/JsonConvertTest.cs
@@ -778,7 +778,7 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(@"\/Date(253402300799999)\/", result.MsDateUtc);
 
             DateTime year2000local = new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Local);
-            string localToUtcDate = year2000local.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK");
+            string localToUtcDate = year2000local.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
 
             result = TestDateTime("DateTime Local", year2000local);
             Assert.AreEqual("2000-01-01T01:01:01" + GetOffset(year2000local, DateFormatHandling.IsoDateFormat), result.IsoDateRoundtrip);
@@ -791,7 +791,7 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(@"\/Date(" + DateTimeUtils.ConvertDateTimeToJavaScriptTicks(year2000local) + @")\/", result.MsDateUtc);
 
             DateTime millisecondsLocal = new DateTime(2000, 1, 1, 1, 1, 1, 999, DateTimeKind.Local);
-            localToUtcDate = millisecondsLocal.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK");
+            localToUtcDate = millisecondsLocal.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
 
             result = TestDateTime("DateTime Local with milliseconds", millisecondsLocal);
             Assert.AreEqual("2000-01-01T01:01:01.999" + GetOffset(millisecondsLocal, DateFormatHandling.IsoDateFormat), result.IsoDateRoundtrip);
@@ -804,7 +804,7 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(@"\/Date(" + DateTimeUtils.ConvertDateTimeToJavaScriptTicks(millisecondsLocal) + @")\/", result.MsDateUtc);
 
             DateTime ticksLocal = new DateTime(636556897826822481, DateTimeKind.Local);
-            localToUtcDate = ticksLocal.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK");
+            localToUtcDate = ticksLocal.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture);
 
             result = TestDateTime("DateTime Local with ticks", ticksLocal);
             Assert.AreEqual("2018-03-03T16:03:02.6822481" + GetOffset(ticksLocal, DateFormatHandling.IsoDateFormat), result.IsoDateRoundtrip);
@@ -829,7 +829,7 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(@"\/Date(" + DateTimeUtils.ConvertDateTimeToJavaScriptTicks(year2000Unspecified.ToLocalTime()) + @")\/", result.MsDateUtc);
 
             DateTime year2000Utc = new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc);
-            string utcTolocalDate = year2000Utc.ToLocalTime().ToString("yyyy-MM-ddTHH:mm:ss");
+            string utcTolocalDate = year2000Utc.ToLocalTime().ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 
             result = TestDateTime("DateTime Utc", year2000Utc);
             Assert.AreEqual("2000-01-01T01:01:01Z", result.IsoDateRoundtrip);
@@ -842,7 +842,7 @@ namespace Newtonsoft.Json.Tests
             Assert.AreEqual(@"\/Date(946688461000)\/", result.MsDateUtc);
 
             DateTime unixEpoc = new DateTime(621355968000000000, DateTimeKind.Utc);
-            utcTolocalDate = unixEpoc.ToLocalTime().ToString("yyyy-MM-ddTHH:mm:ss");
+            utcTolocalDate = unixEpoc.ToLocalTime().ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
 
             result = TestDateTime("DateTime Unix Epoc", unixEpoc);
             Assert.AreEqual("1970-01-01T00:00:00Z", result.IsoDateRoundtrip);

--- a/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
@@ -132,7 +132,7 @@ namespace Newtonsoft.Json.Utilities
                   && ParseChar(start + LzHH_mm, ':')
                   && Parse2Digit(start + LzHH_mm_, out Second)
                   && Second < 60
-                  && (Hour != 24 || (Minute == 0 && Second == 0)))) // hour can be 24 if minute/second is zero)
+                  && ((Minute == 0 && Second == 0) || Hour != 24))) // hour can be 24 if minute/second is zero)
             {
                 return false;
             }

--- a/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
@@ -24,10 +24,11 @@
 #endregion
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Newtonsoft.Json.Utilities
 {
-    internal enum ParserTimeZone
+    internal enum ParserTimeZone : byte
     {
         Unspecified = 0,
         Utc = 1,
@@ -35,6 +36,7 @@ namespace Newtonsoft.Json.Utilities
         LocalEastOfUtc = 3
     }
 
+    [StructLayout(LayoutKind.Auto)]
     internal struct DateTimeParser
     {
         static DateTimeParser()
@@ -56,15 +58,15 @@ namespace Newtonsoft.Json.Utilities
             Lz_zz = "-zz".Length;
         }
 
-        public int Year;
-        public int Month;
-        public int Day;
-        public int Hour;
-        public int Minute;
-        public int Second;
+        public ushort Year;
+        public byte Month;
+        public byte Day;
+        public byte Hour;
+        public byte Minute;
+        public byte Second;
         public int Fraction;
-        public int ZoneHour;
-        public int ZoneMinute;
+        public byte ZoneHour;
+        public byte ZoneMinute;
         public ParserTimeZone Zone;
 
         private char[] _text;
@@ -231,7 +233,7 @@ namespace Newtonsoft.Json.Utilities
             return (start == _end);
         }
 
-        private bool Parse4Digit(int start, out int num)
+        private bool Parse4Digit(int start, out ushort num)
         {
             if (start + 3 < _end)
             {
@@ -244,7 +246,7 @@ namespace Newtonsoft.Json.Utilities
                     && 0 <= digit3 && digit3 < 10
                     && 0 <= digit4 && digit4 < 10)
                 {
-                    num = (((((digit1 * 10) + digit2) * 10) + digit3) * 10) + digit4;
+                    num = (ushort)((((((digit1 * 10) + digit2) * 10) + digit3) * 10) + digit4);
                     return true;
                 }
             }
@@ -252,7 +254,7 @@ namespace Newtonsoft.Json.Utilities
             return false;
         }
 
-        private bool Parse2Digit(int start, out int num)
+        private bool Parse2Digit(int start, out byte num)
         {
             if (start + 1 < _end)
             {
@@ -261,7 +263,7 @@ namespace Newtonsoft.Json.Utilities
                 if (0 <= digit1 && digit1 < 10
                     && 0 <= digit2 && digit2 < 10)
                 {
-                    num = (digit1 * 10) + digit2;
+                    num = (byte)((digit1 * 10) + digit2);
                     return true;
                 }
             }

--- a/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
+++ b/Src/Newtonsoft.Json/Utilities/DateTimeParser.cs
@@ -256,10 +256,11 @@ namespace Newtonsoft.Json.Utilities
 
         private bool Parse2Digit(int start, out byte num)
         {
-            if (start + 1 < _end)
+            int end = start + 1;
+            if (end < _end)
             {
                 int digit1 = _text[start] - '0';
-                int digit2 = _text[start + 1] - '0';
+                int digit2 = _text[end] - '0';
                 if (0 <= digit1 && digit1 < 10
                     && 0 <= digit2 && digit2 < 10)
                 {


### PR DESCRIPTION
I have reduced the size of the `DateTimeParser` `struct` that is being copied when calling `CreateDateTime`

The reduced size of the JIT assembly can be seen [here](https://sharplab.io/#v2:C4LghgzgtgPgAgJgIwFgBQcAMACOSB0ASgK4B2wAllAKb4CS51ATgPYAOAyswG4UDG1CAG506OAGZcCbAGFsAb3TZl2CoyakwAG2zVSxKNgAKYJhGYAVKtQBaLUtWwhsAIwCewakpWK0K/9gAqqQQbNR8FABmFNQAJtgAvNiYADTeAUHAfInYSGl+GdgAMix82gDqgsAA8pGBWTkI+YXFpdoAopA1dQ1J4unYAL4D/gDaHMBMxHzARWBuLMTAABRzC0sA0mqx+ACCSywAlAC6A2qeGtrYEJPTwNgAImCeVjQmZswDvi0jKhLYxAgAAsWEx7gBNaimEQFDL/dyebAAWXswCBMJa8I8jiebgxhSxiIAEosmPi4ZIEY4kWoltRyQFCY4uHx7LEGf5/udsAAxJhgGYUewcv6U7HYOwOEnEMm/ZRMiX2ag0/SeEXyyTvcxMV62JWKhwM4aw3CSJ4vayybRaNQAc3KFDREymM2WhwUcsez2ouq1zGwsW9vtM2pyDgA7l6LW8Q8w3TDzT7LfEkjImFDPIndSi+ABrZaB6PUP1MQ7q3AAdgDRoGbCYFG43twSAAbFGkzRZOnvVnrDn872Yx8mAGg9YS4dvoVB44U9gI+3dQWx0PtfhIaYUqOiyX8CjyECt4WO8XY0x8LijyvT8P8NKmFed2e97TPI+T7uWWyy57/HOdrssSxFYeYQMuT63nyAqUPYP4mpyVbsgMxqDEAA===)
(Remove `: byte` on the `enum` & change `byte`/`ushort` fields to `int`)
Works for both Framework and .NET 8

Optimized the time verification, hour is very likely to be different than 24, minute & seconds are less likely to be 0, so we can exit earlier out of the checks.

Reusing the `start + 1` calculation in `Parse2Digit` saves _one_ line of JIT assembly 😅

Optimized some benchmarks so they mainly test (de)serialization & added one for deserialization of dates.
Fixed some unit tests for da-DK culture.
Gitignore Rider files.

DateTimeParser haven't changed in 9 years, so these changes can be backported to the [many versions used](https://www.nuget.org/stats/packageversions)
