### PR TITLE
Change exception message used when MissingMemberHandling.Error is active

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Documentation/Samples/Serializer/DeserializeMissingMemberHandling.cs
+++ b/Src/Newtonsoft.Json.Tests/Documentation/Samples/Serializer/DeserializeMissingMemberHandling.cs
@@ -68,7 +68,7 @@ namespace Newtonsoft.Json.Tests.Documentation.Samples.Serializer
             catch (JsonSerializationException ex)
             {
                 Console.WriteLine(ex.Message);
-                // Could not find member 'DeletedDate' on object of type 'Account'. Path 'DeletedDate', line 4, position 23.
+                // The JSON property 'DeletedDate' does not exist on object of type 'Account'. Path 'DeletedDate', line 4, position 23.
             }
             #endregion
         }

--- a/Src/Newtonsoft.Json.Tests/Documentation/Samples/Serializer/TraceWriter.cs
+++ b/Src/Newtonsoft.Json.Tests/Documentation/Samples/Serializer/TraceWriter.cs
@@ -73,9 +73,9 @@ namespace Newtonsoft.Json.Tests.Documentation.Samples.Serializer
 
             Console.WriteLine(traceWriter.ToString());
             // 2013-01-21T01:36:24.422 Info Started deserializing Newtonsoft.Json.Tests.Documentation.Examples.TraceWriter+Account. Path 'FullName', line 2, position 20.
-            // 2013-01-21T01:36:24.442 Verbose Could not find member 'DeletedDate' on Newtonsoft.Json.Tests.Documentation.Examples.TraceWriter+Account. Path 'DeletedDate', line 4, position 23.
+            // 2013-01-21T01:36:24.442 Verbose The JSON property 'DeletedDate' does not exist on Newtonsoft.Json.Tests.Documentation.Examples.TraceWriter+Account. Path 'DeletedDate', line 4, position 23.
             // 2013-01-21T01:36:24.447 Info Finished deserializing Newtonsoft.Json.Tests.Documentation.Examples.TraceWriter+Account. Path '', line 5, position 8.
-            // 2013-01-21T01:36:24.450 Verbose Deserialized JSON: 
+            // 2013-01-21T01:36:24.450 Verbose Deserialized JSON:
             // {
             //   "FullName": "Dan Deleted",
             //   "Deleted": true,

--- a/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/MissingMemberHandlingTests.cs
@@ -68,7 +68,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             ExceptionAssert.Throws<JsonSerializationException>(() =>
             {
                 ProductShort deserializedProductShort = (ProductShort)JsonConvert.DeserializeObject(output, typeof(ProductShort), new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
-            }, @"Could not find member 'Price' on object of type 'ProductShort'. Path 'Price', line 4, position 10.");
+            }, @"The JSON property 'Price' does not exist on object of type 'ProductShort'. Path 'Price', line 4, position 10.");
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace Newtonsoft.Json.Tests.Serialization
         {
             string json = @"{""Missing"":1}";
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<DoubleClass>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error }); }, "Could not find member 'Missing' on object of type 'DoubleClass'. Path 'Missing', line 1, position 11.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<DoubleClass>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error }); }, "The JSON property 'Missing' does not exist on object of type 'DoubleClass'. Path 'Missing', line 1, position 11.");
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace Newtonsoft.Json.Tests.Serialization
         {
             string json = @"{""Missing"":1}";
 
-            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<NameWithMissingError>(json); }, "Could not find member 'Missing' on object of type 'NameWithMissingError'. Path 'Missing', line 1, position 11.");
+            ExceptionAssert.Throws<JsonSerializationException>(() => { JsonConvert.DeserializeObject<NameWithMissingError>(json); }, "The JSON property 'Missing' does not exist on object of type 'NameWithMissingError'. Path 'Missing', line 1, position 11.");
         }
 
         [JsonObject(MissingMemberHandling = MissingMemberHandling.Error)]
@@ -202,7 +202,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             JsonConvert.PopulateObject(@"{nameERROR:{""first"":""hi""}}", p, settings);
 
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("Could not find member 'nameERROR' on object of type 'Person'. Path 'nameERROR', line 1, position 11.", errors[0]);
+            Assert.AreEqual("The JSON property 'nameERROR' does not exist on object of type 'Person'. Path 'nameERROR', line 1, position 11.", errors[0]);
         }
 
         [Test]
@@ -228,7 +228,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             JsonConvert.PopulateObject(@"{name:{""firstERROR"":""hi""}}", p, settings);
 
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("Could not find member 'firstERROR' on object of type 'Name'. Path 'name.firstERROR', line 1, position 20.", errors[0]);
+            Assert.AreEqual("The JSON property 'firstERROR' does not exist on object of type 'Name'. Path 'name.firstERROR', line 1, position 20.", errors[0]);
         }
 
         [JsonObject(MissingMemberHandling = MissingMemberHandling.Ignore)]
@@ -269,7 +269,7 @@ namespace Newtonsoft.Json.Tests.Serialization
             ExceptionAssert.Throws<JsonSerializationException>(() =>
             {
                 JsonConvert.DeserializeObject<ObjectWithExtendableChild>(json, new JsonSerializerSettings { MissingMemberHandling = MissingMemberHandling.Error });
-            }, "Could not find member 'InvalidData' on object of type 'ObjectWithExtendableChild'. Path 'InvalidData', line 1, position 15.");
+            }, "The JSON property 'InvalidData' does not exist on object of type 'ObjectWithExtendableChild'. Path 'InvalidData', line 1, position 15.");
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Serialization/TraceWriterTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Serialization/TraceWriterTests.cs
@@ -33,7 +33,7 @@ using System.Threading.Tasks;
 #endif
 
 namespace Newtonsoft.Json.Tests.Serialization
-{ 
+{
     public class Staff
     {
         public string Name { get; set; }
@@ -356,7 +356,7 @@ Newtonsoft.Json Error: 0 : Error!
             // 2012-11-11T12:08:42.797 Info Started serializing System.Collections.Generic.List`1[System.String]. Path 'Roles'.
             // 2012-11-11T12:08:42.798 Info Finished serializing System.Collections.Generic.List`1[System.String]. Path 'Roles'.
             // 2012-11-11T12:08:42.799 Info Finished serializing Newtonsoft.Json.Tests.Serialization.Staff. Path ''.
-            // 2013-05-19T00:07:24.360 Verbose Deserialized JSON: 
+            // 2013-05-19T00:07:24.360 Verbose Deserialized JSON:
             // {
             //   "Name": "Arnie Admin",
             //   "StartDate": new Date(
@@ -917,7 +917,7 @@ Newtonsoft.Json Error: 0 : Error!
                 });
 
             Assert.AreEqual("Started deserializing Newtonsoft.Json.Tests.TestObjects.Organization.Person. Path 'MissingMemberProperty', line 1, position 25.", traceWriter.TraceRecords[0].Message);
-            Assert.AreEqual("Could not find member 'MissingMemberProperty' on Newtonsoft.Json.Tests.TestObjects.Organization.Person. Path 'MissingMemberProperty', line 1, position 25.", traceWriter.TraceRecords[1].Message);
+            Assert.AreEqual("The JSON property 'MissingMemberProperty' does not exist on Newtonsoft.Json.Tests.TestObjects.Organization.Person. Path 'MissingMemberProperty', line 1, position 25.", traceWriter.TraceRecords[1].Message);
             Assert.IsTrue(traceWriter.TraceRecords[2].Message.StartsWith("Finished deserializing Newtonsoft.Json.Tests.TestObjects.Organization.Person. Path ''"));
         }
 
@@ -945,7 +945,7 @@ Newtonsoft.Json Error: 0 : Error!
             });
 
             Assert.AreEqual("Deserializing Newtonsoft.Json.Tests.TestObjects.VersionOld using creator with parameters: Major, Minor, Build, Revision. Path 'Major', line 2, position 10.", traceWriter.TraceRecords[0].Message);
-            Assert.AreEqual("Could not find member 'MissingMemberProperty' on Newtonsoft.Json.Tests.TestObjects.VersionOld. Path 'MissingMemberProperty', line 8, position 31.", traceWriter.TraceRecords[1].Message);
+            Assert.AreEqual("The JSON property 'MissingMemberProperty' does not exist on Newtonsoft.Json.Tests.TestObjects.VersionOld. Path 'MissingMemberProperty', line 8, position 31.", traceWriter.TraceRecords[1].Message);
             Assert.IsTrue(traceWriter.TraceRecords[2].Message.StartsWith("Started deserializing Newtonsoft.Json.Tests.TestObjects.VersionOld. Path ''"));
             Assert.IsTrue(traceWriter.TraceRecords[3].Message.StartsWith("Finished deserializing Newtonsoft.Json.Tests.TestObjects.VersionOld. Path ''"));
         }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -2282,7 +2282,7 @@ namespace Newtonsoft.Json.Serialization
                                 {
                                     creatorPropertyContext.Value = CreateValueInternal(reader, property.PropertyType, property.PropertyContract, property, contract, containerProperty, null);
                                 }
-                                
+
                                 continue;
                             }
                             else
@@ -2302,12 +2302,12 @@ namespace Newtonsoft.Json.Serialization
 
                             if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                             {
-                                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}.".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
+                                TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "The JSON property '{0}' does not exist on {1}.".FormatWith(CultureInfo.InvariantCulture, memberName, contract.UnderlyingType)), null);
                             }
 
                             if ((contract.MissingMemberHandling ?? Serializer._missingMemberHandling) == MissingMemberHandling.Error)
                             {
-                                throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
+                                throw JsonSerializationException.Create(reader, "The JSON property '{0}' does not exist on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, memberName, objectType.Name));
                             }
                         }
 
@@ -2425,12 +2425,12 @@ namespace Newtonsoft.Json.Serialization
                             {
                                 if (TraceWriter != null && TraceWriter.LevelFilter >= TraceLevel.Verbose)
                                 {
-                                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "Could not find member '{0}' on {1}".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType)), null);
+                                    TraceWriter.Trace(TraceLevel.Verbose, JsonPosition.FormatMessage(reader as IJsonLineInfo, reader.Path, "The JSON property '{0}' does not exist on {1}".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType)), null);
                                 }
 
                                 if ((contract.MissingMemberHandling ?? Serializer._missingMemberHandling) == MissingMemberHandling.Error)
                                 {
-                                    throw JsonSerializationException.Create(reader, "Could not find member '{0}' on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType.Name));
+                                    throw JsonSerializationException.Create(reader, "The JSON property '{0}' does not exist on object of type '{1}'".FormatWith(CultureInfo.InvariantCulture, propertyName, contract.UnderlyingType.Name));
                                 }
 
                                 if (!reader.Read())


### PR DESCRIPTION
Changes the exception message `Could not find member '{0}' on object of type '{1}'` to `The JSON property '{0}' does not exist on object of type '{1}'`

The existing message is not very clear about if the problem is a missing property in the JSON string or if it is missing in the .NET object.

The new message is more clear that a JSON property exists and it does not correspond to a member on the .NET object.

While this is not too difficult to figure out for a developer well versed in the library, in my use case I show these messages to administrators who are likely thinking that "Could not find" means they have to add that thing to the json string they entered.

I as not able to get the unit tests running on my system right now as it doesn't seem to be able to find the 2.1 and 3.1 runtimes even though I have them installed. Do I have to do something special to get that working?

Also, my editor removed some trailing spaces as you can see in the diffs. Let me know if you want me to undo those whitespace changes.