### PR TITLE
Use a safer method for detecting negative zero

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/BoxedPrimitives.cs
+++ b/Src/Newtonsoft.Json/Utilities/BoxedPrimitives.cs
@@ -99,7 +99,7 @@ namespace Newtonsoft.Json.Utilities
 #if NET6_0_OR_GREATER
             // Number of bits scale is shifted by.
             const int ScaleShift = 16;
-        
+
             if (value == decimal.Zero)
             {
                 Span<int> bits = stackalloc int[4];
@@ -126,13 +126,18 @@ namespace Newtonsoft.Json.Utilities
         private static readonly object DecimalZero = decimal.Zero;
         private static readonly object DecimalZeroWithTrailingZero = 0.0m;
 #endif
+        private static readonly long NegativeZeroBits = BitConverter.DoubleToInt64Bits(-0.0d);
+        private static bool IsNegativeZero(double value)
+        {
+            return BitConverter.DoubleToInt64Bits(value) == NegativeZeroBits;
+        }
 
         internal static object Get(double value)
         {
             if (value == 0.0d)
             {
-                // Double supports -0.0. Detection logic from https://stackoverflow.com/a/4739883/11829.
-                return double.IsNegativeInfinity(1.0 / value) ? DoubleNegativeZero : DoubleZero;
+                // Double supports -0.0. Detection logic from https://stackoverflow.com/q/4739795/8525132.
+                return IsNegativeZero(value) ? DoubleNegativeZero : DoubleZero;
             }
             if (double.IsInfinity(value))
             {


### PR DESCRIPTION
Fixes https://github.com/JamesNK/Newtonsoft.Json/issues/2869.

The prior method would throw a DivideByZeroException on systems where the `_EM_ZERODIVIDE` floating point exception was enabled.

The changes in this PR are just a safer implementation of the changes in https://github.com/JamesNK/Newtonsoft.Json/pull/2777 and are covered by those same tests.

Note: I tried to add a test for https://github.com/JamesNK/Newtonsoft.Json/issues/2869, but changing the `_EM_ZERODIVIDE` flag with [_controlfp](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/control87-controlfp-control87-2?view=msvc-170) was affecting other tests due to the changing of global state and the parallel execution of the tests.  I tried several different test methods before giving up on using [_controlfp](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/control87-controlfp-control87-2?view=msvc-170).  I also didn't see any other use of interop (P/Invoke) in the tests, so I wasn't sure you'd accept that anyway.

Even without the additional test, I think these changes are very straightforward and would resolve the above issue, preserving all existing functionality.