### PR TITLE
Check conversion operators to determine if `objectType` is assignable from `byte[]`

### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -327,7 +327,15 @@ namespace Newtonsoft.Json.Serialization
                         string s = (string)reader.Value!;
 
                         // string that needs to be returned as a byte array should be base 64 decoded
-                        if (objectType == typeof(byte[]))
+                        if (
+                            objectType == typeof(byte[]) ||
+                            contract != null &&
+                            contract.NonNullableUnderlyingType
+                                .GetMethods()
+                                .Where(a => a.GetParameters().Length == 1 && (a.Name == "op_Explicit" || a.Name == "op_Implicit"))
+                                .Select(a => a.GetParameters().Single())
+                                .Any(a => a.ParameterType == typeof(byte[]))
+                        )
                         {
                             return Convert.FromBase64String(s);
                         }

--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -337,7 +337,7 @@ namespace Newtonsoft.Json.Serialization
                                 .Any(a => a.ParameterType == typeof(byte[]))
                         )
                         {
-                            return Convert.FromBase64String(s);
+                            return EnsureType(reader, Convert.FromBase64String(s), CultureInfo.InvariantCulture, contract, objectType);
                         }
 
                         // convert empty string to null automatically for nullable types


### PR DESCRIPTION
https://learn.microsoft.com/dotnet/csharp/language-reference/operators/user-defined-conversion-operators

For when `objectType` is `Memory<byte>` for example.