### PR TITLE
Validate BSON binary data lengths before allocation

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Bson/BsonReaderTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Bson/BsonReaderTests.cs
@@ -528,6 +528,28 @@ namespace Newtonsoft.Json.Tests.Bson
         }
 
         [Test]
+        public void ReadBinaryWithNegativeLength()
+        {
+            byte[] data = HexToBytes("0C-00-00-00-05-00-FF-FF-FF-FF-00-00");
+            BsonReader reader = new BsonReader(new MemoryStream(data));
+
+            Assert.IsTrue(reader.Read());
+            Assert.IsTrue(reader.Read());
+            ExceptionAssert.Throws<JsonReaderException>(() => reader.Read(), "Unexpected length for BSON binary data: -1. Path ''.");
+        }
+
+        [Test]
+        public void ReadBinaryWithLengthLargerThanContainer()
+        {
+            byte[] data = HexToBytes("0C-00-00-00-05-00-FF-FF-FF-7F-00-00");
+            BsonReader reader = new BsonReader(new MemoryStream(data));
+
+            Assert.IsTrue(reader.Read());
+            Assert.IsTrue(reader.Read());
+            ExceptionAssert.Throws<JsonReaderException>(() => reader.Read(), "Unexpected length for BSON binary data: 2147483647. Path ''.");
+        }
+
+        [Test]
         public void ReadOid()
         {
             byte[] data = HexToBytes("29000000075F6964004ABBED9D1D8B0F02180000010274657374000900000031323334C2A335360000");

--- a/Src/Newtonsoft.Json/Bson/BsonReader.cs
+++ b/Src/Newtonsoft.Json/Bson/BsonReader.cs
@@ -583,6 +583,12 @@ namespace Newtonsoft.Json.Bson
             }
 #pragma warning restore 612,618
 
+            long remainingLength = (long)_currentContext.Length - _currentContext.Position - 1;
+            if (dataLength < 0 || dataLength > remainingLength)
+            {
+                throw JsonReaderException.Create(this, "Unexpected length for BSON binary data: {0}.".FormatWith(CultureInfo.InvariantCulture, dataLength));
+            }
+
             return ReadBytes(dataLength);
         }
 


### PR DESCRIPTION
## Summary

- validate BSON binary lengths before passing them to `BinaryReader.ReadBytes`
- reject negative lengths and lengths larger than the enclosing container with `JsonReaderException`
- add regression coverage for negative and `int.MaxValue` wire lengths

## Testing

- `dotnet test .\Src\Newtonsoft.Json.Tests\Newtonsoft.Json.Tests.csproj -f net8.0 --no-build --filter "FullyQualifiedName~BsonReaderTests.ReadBinaryWith"` (2 passed)
- `dotnet test .\Src\Newtonsoft.Json.Tests\Newtonsoft.Json.Tests.csproj -f net8.0 --no-build --filter "FullyQualifiedName~Newtonsoft.Json.Tests.Bson.BsonReaderTests"` (62 passed)
- `git diff --check`