### PR TITLE
Fix quadratic JObject duplicate property handling

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectAsyncTests.cs
@@ -25,6 +25,7 @@
 
 #if !(NET20 || NET35 || NET40 || PORTABLE40)
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Tests.TestObjects;
 #if DNXCORE50
@@ -36,6 +37,7 @@ using NUnit.Framework;
 #endif
 using Newtonsoft.Json.Linq;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Newtonsoft.Json.Tests.Linq
@@ -194,6 +196,57 @@ namespace Newtonsoft.Json.Tests.Linq
             string value = (string)o["Name"];
 
             Assert.AreEqual("Name1", value);
+        }
+
+        [Test]
+        public async Task ParseMultipleProperties_ReplaceInterleavedAndNestedAsync()
+        {
+            string json = @"{
+        ""a"": 1,
+                ""b"": 2,
+                ""c"": 3,
+                ""b"": 4,
+        ""nested"": {
+          ""x"": 1,
+                    ""y"": 2,
+                    ""z"": 3,
+          ""y"": 4
+        },
+                ""c"": 5
+      }";
+
+            JsonTextReader reader = new JsonTextReader(new StringReader(json));
+            JObject o = (JObject)await JToken.ReadFromAsync(reader);
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c", "nested" }, o.Properties().Select(p => p.Name));
+            Assert.AreEqual(4, (int)o["b"]);
+            Assert.AreEqual(5, (int)o["c"]);
+            Assert.AreEqual(4, (int)o["nested"]["y"]);
+        }
+
+        [Test]
+        public async Task ParseMultipleProperties_DoesNotSearchForPropertyIndexAsync()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{
+        ""a"": 1,
+        ""b"": 2,
+        ""c"": 3,
+        ""b"": 4
+      }"));
+            Assert.IsTrue(await reader.ReadAsync());
+
+            NoPropertyIndexSearchJObject o = new NoPropertyIndexSearchJObject();
+            await o.ReadTokenFromAsync(reader, null);
+
+            Assert.AreEqual(4, (int)o["b"]);
+        }
+
+        private sealed class NoPropertyIndexSearchJObject : JObject
+        {
+            internal override int IndexOfItem(JToken item)
+            {
+                throw new InvalidOperationException("Property replacement must not search for its index.");
+            }
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JObjectTests.cs
@@ -1658,6 +1658,62 @@ Parameter name: arrayIndex",
             Assert.AreEqual("Name2", value);
         }
 
+        [Test]
+        public void ParseMultipleProperties_ReplaceInterleavedAndNested()
+        {
+            string json = @"{
+        ""a"": 1,
+        ""b"": 2,
+        ""c"": 3,
+        ""b"": 4,
+        ""nested"": {
+          ""x"": 1,
+          ""y"": 2,
+          ""z"": 3,
+          ""y"": 4
+        },
+        ""c"": 5
+      }";
+
+            JObject o = JObject.Parse(json);
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c", "nested" }, o.Properties().Select(p => p.Name));
+            Assert.AreEqual(4, (int)o["b"]);
+            Assert.AreEqual(5, (int)o["c"]);
+            Assert.AreEqual(4, (int)o["nested"]["y"]);
+        }
+
+        [Test]
+        public void ParseMultipleProperties_DoesNotSearchForPropertyIndex()
+        {
+            JsonTextReader reader = new JsonTextReader(new StringReader(@"{
+        ""a"": 1,
+        ""b"": 2,
+        ""c"": 3,
+        ""b"": 4
+      }"));
+            Assert.IsTrue(reader.Read());
+
+            NoPropertyIndexSearchJObject o = new NoPropertyIndexSearchJObject();
+            o.ReadTokenFrom(reader, null);
+
+            Assert.AreEqual(4, (int)o["b"]);
+        }
+
+        [Test]
+        public void DeserializeMultipleProperties_ReplacesInOriginalPosition()
+        {
+            JObject o = JsonConvert.DeserializeObject<JObject>(@"{
+        ""a"": 1,
+        ""b"": 2,
+        ""c"": 3,
+        ""b"": 4
+      }");
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c" }, o.Properties().Select(p => p.Name));
+            Assert.AreEqual(4, (int)o["b"]);
+        }
+
 #if !(PORTABLE || DNXCORE50 || PORTABLE40) || NETSTANDARD2_0 || NET6_0_OR_GREATER
         [Test]
         public void WriteObjectNullDBNullValue()
@@ -2139,6 +2195,14 @@ Parameter name: arrayIndex",
             Assert.AreEqual("name", a.Property("name", StringComparison.OrdinalIgnoreCase).Name);
             // Return exact match without ignoring case
             Assert.AreEqual("name", a.Property("name", StringComparison.Ordinal).Name);
+        }
+
+        private sealed class NoPropertyIndexSearchJObject : JObject
+        {
+            internal override int IndexOfItem(JToken item)
+            {
+                throw new InvalidOperationException("Property replacement must not search for its index.");
+            }
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterAsyncTests.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterAsyncTests.cs
@@ -26,6 +26,7 @@
 #if !(NET20 || NET35 || NET40 || PORTABLE40)
 
 using System;
+using System.Collections.Generic;
 #if !PORTABLE || NETSTANDARD1_3 || NETSTANDARD2_0 || NET6_0_OR_GREATER
 using System.Numerics;
 #endif
@@ -371,6 +372,32 @@ namespace Newtonsoft.Json.Tests.Linq
         }
 
         [Test]
+        public async Task WriteDuplicatePropertyNameDoesNotSearchForPropertyIndexAsync()
+        {
+            NoPropertyIndexSearchJObject o = new NoPropertyIndexSearchJObject();
+            JTokenWriter writer = new JTokenWriter(o);
+
+            await writer.WritePropertyNameAsync("a");
+            await writer.WriteValueAsync(1);
+            await writer.WritePropertyNameAsync("b");
+            await writer.WriteValueAsync(2);
+            await writer.WritePropertyNameAsync("c");
+            await writer.WriteValueAsync(3);
+            await writer.WritePropertyNameAsync("b");
+            await writer.WriteValueAsync(4);
+            o.AddFirst(new JProperty("external", 0));
+            await writer.WritePropertyNameAsync("b");
+            await writer.WriteValueAsync(5);
+            ((IList<JToken>)o).RemoveAt(0);
+            await writer.WritePropertyNameAsync("c");
+            await writer.WriteValueAsync(6);
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c" }, o.Properties().Select(p => p.Name));
+            Assert.AreEqual(5, (int)o["b"]);
+            Assert.AreEqual(6, (int)o["c"]);
+        }
+
+        [Test]
         public async Task DateTimeZoneHandlingAsync()
         {
             JTokenWriter writer = new JTokenWriter
@@ -384,6 +411,14 @@ namespace Newtonsoft.Json.Tests.Linq
             DateTime dt = (DateTime)value.Value;
 
             Assert.AreEqual(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeKind.Utc), dt);
+        }
+
+        private sealed class NoPropertyIndexSearchJObject : JObject
+        {
+            internal override int IndexOfItem(JToken item)
+            {
+                throw new InvalidOperationException("Property replacement must not search for its index.");
+            }
         }
     }
 }

--- a/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterTest.cs
+++ b/Src/Newtonsoft.Json.Tests/Linq/JTokenWriterTest.cs
@@ -378,6 +378,32 @@ namespace Newtonsoft.Json.Tests.Linq
         }
 
         [Test]
+        public void WriteDuplicatePropertyNameDoesNotSearchForPropertyIndex()
+        {
+            NoPropertyIndexSearchJObject o = new NoPropertyIndexSearchJObject();
+            JTokenWriter writer = new JTokenWriter(o);
+
+            writer.WritePropertyName("a");
+            writer.WriteValue(1);
+            writer.WritePropertyName("b");
+            writer.WriteValue(2);
+            writer.WritePropertyName("c");
+            writer.WriteValue(3);
+            writer.WritePropertyName("b");
+            writer.WriteValue(4);
+            o.AddFirst(new JProperty("external", 0));
+            writer.WritePropertyName("b");
+            writer.WriteValue(5);
+            ((IList<JToken>)o).RemoveAt(0);
+            writer.WritePropertyName("c");
+            writer.WriteValue(6);
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c" }, o.Properties().Select(p => p.Name));
+            Assert.AreEqual(5, (int)o["b"]);
+            Assert.AreEqual(6, (int)o["c"]);
+        }
+
+        [Test]
         public void DateTimeZoneHandling()
         {
             JTokenWriter writer = new JTokenWriter
@@ -414,6 +440,14 @@ namespace Newtonsoft.Json.Tests.Linq
             }
 
             Assert.AreEqual(@"[1,{""integer"":2147483647,""null-string"":null}]", token.ToString(Formatting.None));
+        }
+
+        private sealed class NoPropertyIndexSearchJObject : JObject
+        {
+            internal override int IndexOfItem(JToken item)
+            {
+                throw new InvalidOperationException("Property replacement must not search for its index.");
+            }
         }
     }
 }

--- a/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.Async.cs
@@ -26,6 +26,7 @@
 #if HAVE_ASYNC
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
@@ -57,6 +58,8 @@ namespace Newtonsoft.Json.Linq
         private async Task ReadContentFromAsync(JsonReader reader, JsonLoadSettings? settings, CancellationToken cancellationToken = default)
         {
             IJsonLineInfo? lineInfo = reader as IJsonLineInfo;
+            // Loading is iterative, so keep separate duplicate indexes for JObjects at different depths.
+            Dictionary<JObject, Dictionary<string, int>>? duplicatePropertyIndexes = null;
 
             JContainer? parent = this;
 
@@ -101,6 +104,11 @@ namespace Newtonsoft.Json.Linq
                         parent = o;
                         break;
                     case JsonToken.EndObject:
+                        // The index is only needed while its JObject is being loaded.
+                        if (parent is JObject parentObject)
+                        {
+                            duplicatePropertyIndexes?.Remove(parentObject);
+                        }
                         if (parent == this)
                         {
                             return;
@@ -151,7 +159,7 @@ namespace Newtonsoft.Json.Linq
                         parent.Add(v);
                         break;
                     case JsonToken.PropertyName:
-                        JProperty? property = ReadProperty(reader, settings, lineInfo, parent);
+                        JProperty? property = ReadProperty(reader, settings, lineInfo, parent, ref duplicatePropertyIndexes);
                         if (property != null)
                         {
                             parent = property;

--- a/Src/Newtonsoft.Json/Linq/JContainer.cs
+++ b/Src/Newtonsoft.Json/Linq/JContainer.cs
@@ -797,6 +797,8 @@ namespace Newtonsoft.Json.Linq
         {
             ValidationUtils.ArgumentNotNull(r, nameof(r));
             IJsonLineInfo? lineInfo = r as IJsonLineInfo;
+            // Loading is iterative, so keep separate duplicate indexes for JObjects at different depths.
+            Dictionary<JObject, Dictionary<string, int>>? duplicatePropertyIndexes = null;
 
             JContainer? parent = this;
 
@@ -841,6 +843,11 @@ namespace Newtonsoft.Json.Linq
                         parent = o;
                         break;
                     case JsonToken.EndObject:
+                        // The index is only needed while its JObject is being loaded.
+                        if (parent is JObject parentObject)
+                        {
+                            duplicatePropertyIndexes?.Remove(parentObject);
+                        }
                         if (parent == this)
                         {
                             return;
@@ -891,7 +898,7 @@ namespace Newtonsoft.Json.Linq
                         parent.Add(v);
                         break;
                     case JsonToken.PropertyName:
-                        JProperty? property = ReadProperty(r, settings, lineInfo, parent);
+                        JProperty? property = ReadProperty(r, settings, lineInfo, parent, ref duplicatePropertyIndexes);
                         if (property != null)
                         {
                             parent = property;
@@ -907,7 +914,7 @@ namespace Newtonsoft.Json.Linq
             } while (r.Read());
         }
 
-        private static JProperty? ReadProperty(JsonReader r, JsonLoadSettings? settings, IJsonLineInfo? lineInfo, JContainer parent)
+        private static JProperty? ReadProperty(JsonReader r, JsonLoadSettings? settings, IJsonLineInfo? lineInfo, JContainer parent, ref Dictionary<JObject, Dictionary<string, int>>? duplicatePropertyIndexes)
         {
             DuplicatePropertyNameHandling duplicatePropertyNameHandling = settings?.DuplicatePropertyNameHandling ?? DuplicatePropertyNameHandling.Replace;
 
@@ -931,11 +938,32 @@ namespace Newtonsoft.Json.Linq
             // handle multiple properties with the same name in JSON
             if (existingPropertyWithName == null)
             {
+                // Keep an existing index current when a unique property is appended.
+                if (duplicatePropertyIndexes != null && duplicatePropertyIndexes.TryGetValue(parentObject, out Dictionary<string, int>? propertyIndexes))
+                {
+                    propertyIndexes[propertyName] = parentObject.Count;
+                }
+
                 parent.Add(property);
             }
             else
             {
-                existingPropertyWithName.Replace(property);
+                // Most objects don't contain duplicate names, so only create an index when one is encountered.
+                duplicatePropertyIndexes ??= new Dictionary<JObject, Dictionary<string, int>>();
+
+                if (!duplicatePropertyIndexes.TryGetValue(parentObject, out Dictionary<string, int>? propertyIndexes))
+                {
+                    propertyIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+                    int index = 0;
+                    foreach (JProperty existingProperty in parentObject.Properties())
+                    {
+                        propertyIndexes.Add(existingProperty.Name, index++);
+                    }
+                    duplicatePropertyIndexes.Add(parentObject, propertyIndexes);
+                }
+
+                // Replace by known position to avoid JProperty.Replace searching the property list.
+                parentObject.SetItem(propertyIndexes[propertyName], property);
             }
 
             return property;

--- a/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
+++ b/Src/Newtonsoft.Json/Linq/JTokenWriter.cs
@@ -24,6 +24,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 #if HAVE_BIG_INTEGER
@@ -43,6 +44,8 @@ namespace Newtonsoft.Json.Linq
         // used when writer is writing single value and the value has no containing parent
         private JValue? _value;
         private JToken? _current;
+        // Content is written iteratively, so writing switches between JObjects at different depths.
+        private Dictionary<JObject, Dictionary<string, int>>? _duplicatePropertyIndexes;
 
         /// <summary>
         /// Gets the <see cref="JToken"/> at the writer's current position.
@@ -102,6 +105,7 @@ namespace Newtonsoft.Json.Linq
         public override void Close()
         {
             base.Close();
+            _duplicatePropertyIndexes = null;
         }
 
         /// <summary>
@@ -167,6 +171,11 @@ namespace Newtonsoft.Json.Linq
         /// <param name="token">The token.</param>
         protected override void WriteEnd(JsonToken token)
         {
+            if (token == JsonToken.EndObject && _parent is JObject parentObject)
+            {
+                _duplicatePropertyIndexes?.Remove(parentObject);
+            }
+
             RemoveParent();
         }
 
@@ -176,11 +185,53 @@ namespace Newtonsoft.Json.Linq
         /// <param name="name">The name of the property.</param>
         public override void WritePropertyName(string name)
         {
-            // avoid duplicate property name exception
-            // last property name wins
-            (_parent as JObject)?.Remove(name);
+            JProperty property = new JProperty(name);
+            if (_parent is JObject parentObject)
+            {
+                JProperty? existingProperty = parentObject.Property(name, StringComparison.Ordinal);
+                if (existingProperty != null)
+                {
+                    // Most objects don't contain duplicate names, so only create an index when one is encountered.
+                    _duplicatePropertyIndexes ??= new Dictionary<JObject, Dictionary<string, int>>();
+                    if (!_duplicatePropertyIndexes.TryGetValue(parentObject, out Dictionary<string, int>? propertyIndexes))
+                    {
+                        propertyIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+                        _duplicatePropertyIndexes.Add(parentObject, propertyIndexes);
+                    }
 
-            AddParent(new JProperty(name));
+                    // A container supplied to the writer can be modified between writes, invalidating cached indexes.
+                    if (!propertyIndexes.TryGetValue(name, out int propertyIndex)
+                        || propertyIndex >= parentObject.Count
+                        || !ReferenceEquals(parentObject.GetItem(propertyIndex), existingProperty))
+                    {
+                        propertyIndexes.Clear();
+                        int index = 0;
+                        foreach (JProperty childProperty in parentObject.Properties())
+                        {
+                            propertyIndexes.Add(childProperty.Name, index++);
+                        }
+                        propertyIndex = propertyIndexes[name];
+                    }
+
+                    parentObject.SetItem(propertyIndex, property);
+                    _parent = property;
+                    _current = property;
+                }
+                else
+                {
+                    // Keep an existing index current when a unique property is appended.
+                    if (_duplicatePropertyIndexes != null && _duplicatePropertyIndexes.TryGetValue(parentObject, out Dictionary<string, int>? propertyIndexes))
+                    {
+                        propertyIndexes[name] = parentObject.Count;
+                    }
+
+                    AddParent(property);
+                }
+            }
+            else
+            {
+                AddParent(property);
+            }
 
             // don't set state until after in case of an error
             // incorrect state will cause issues if writer is disposed when closing open properties


### PR DESCRIPTION
## Summary

- use lazy, operation-scoped property indexes when replacing duplicate properties during `JObject` loading
- apply the same indexed replacement to `JTokenWriter`, including nested-object cleanup and stale-index recovery for externally mutated target containers
- add deterministic sync and async regressions that fail if duplicate replacement searches the property list, plus nested, ordering, and serializer coverage

Duplicate-heavy input previously performed a linear property-list search for each replacement. The new path builds an index only after the first duplicate and replaces subsequent properties by their known position, preserving last-value-wins behavior and the original property position.

## Validation

- `dotnet test .\Src\Newtonsoft.Json.Tests\Newtonsoft.Json.Tests.csproj -f net8.0 --no-build --no-restore`
  - 3,524 passed, 0 failed
- focused duplicate loading tests: 10 passed
- focused duplicate writer tests: 4 passed
- `git diff --check`

Freshly loaded rebuilt DLL, duplicate attack versus same-token-count unique control:

| Path | 15K attack | 15K control | 30K attack | 30K control |
|---|---:|---:|---:|---:|
| `JObject.Parse` | 28-31 ms | 26 ms | 72-79 ms | 62-65 ms |
| `JsonConvert.DeserializeObject<JObject>` | 30 ms | 27-32 ms | 60-62 ms | 56-61 ms |

The attack cases also verified final values of `14999` and `29999`, confirming last-value-wins semantics.